### PR TITLE
Add KnowledgeNode study app with automated check suites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ _site/
 # KnowledgeNode test deps (installed via npm install in knowledgenode/qa)
 knowledgenode/qa/node_modules/
 knowledgenode/build/
+knowledgenode/qa/browser/shots/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ _site/
 .sass-cache/
 .jekyll-metadata
 .bundle
+
+# KnowledgeNode test deps (installed via npm install in knowledgenode/qa)
+knowledgenode/qa/node_modules/
+knowledgenode/build/

--- a/knowledgenode/README-BUILD.md
+++ b/knowledgenode/README-BUILD.md
@@ -1,0 +1,99 @@
+# KnowledgeNode — Android build (free version, bring-your-own-key)
+
+**No paywall in this build.** Anyone using the app opens Settings, pastes their
+own AI key (OpenRouter or Anthropic), and everything unlocks. No server, no
+subscription, no RevenueCat needed. Verified: this exact `www` boots and passes
+all 193 project tests plus the no-paywall flow checks.
+
+```
+www/                 ← the app (goes into your Capacitor project)
+android-native/
+  KnowledgeNodeFiles.java   ← one native file for saving exports to Downloads
+```
+
+## One-time setup (Windows)
+
+You need: **Node.js** (you have it) and **Android Studio** (free, from
+developer.android.com — install with default options).
+
+Open a terminal (press Windows key, type `cmd`, Enter) and run these one at a
+time — this creates the app project in a folder called `knowledgenode`:
+
+```bash
+cd %USERPROFILE%\Documents
+npm init @capacitor/app@latest knowledgenode -- --name KnowledgeNode --app-id app.knowledgenode.study
+cd knowledgenode
+npm install
+npm install @capacitor/android
+```
+
+Now put the app files in:
+1. Delete everything inside `Documents\knowledgenode\www\`
+2. Copy the **contents** of this package's `www` folder into it
+   (so `Documents\knowledgenode\www\index.html` exists)
+
+Then back in the terminal:
+```bash
+npx cap add android
+```
+
+Copy the one native file:
+- Copy `android-native\KnowledgeNodeFiles.java`
+- into `Documents\knowledgenode\android\app\src\main\java\app\knowledgenode\study\`
+  (create the folders if they don't exist)
+
+## Build & run on your phone
+
+```bash
+npx cap sync android
+npx cap open android
+```
+
+Android Studio opens. Plug in your phone with a USB cable (enable
+**Developer options → USB debugging** on the phone first: Settings → About
+phone → tap "Build number" 7 times, then Settings → Developer options → USB
+debugging ON). Pick your phone in the device dropdown and press the green ▶.
+
+To share with friends: in Android Studio, **Build → Generate Signed App
+Bundle / APK → APK** — follow the wizard (create a keystore when asked, any
+password, remember it). The APK it produces can be sent to anyone; they enable
+"install from unknown sources" and install it.
+
+## After installing — turning on AI (each person does this once)
+
+1. Open the app → Settings (gear icon) → AI setup
+2. Recommended: create a free key at **openrouter.ai/keys**
+3. Paste it, Save. Done — the key stays on that person's device only.
+
+(An Anthropic key from console.anthropic.com works too.)
+
+## Keyboard predictions / autocorrect (one-time setting)
+
+Android keyboards (Samsung Keyboard, Gboard) often hide their prediction bar
+inside app WebViews. Capacitor has a switch that fixes this:
+
+1. Open `Documents\knowledgenode\capacitor.config.json` in a text editor
+2. Add the `"android"` section so it looks like this (keep your existing values):
+
+```json
+{
+  "appId": "app.knowledgenode.study",
+  "appName": "KnowledgeNode",
+  "webDir": "www",
+  "android": {
+    "captureInput": true
+  }
+}
+```
+
+3. Run `npx cap sync android` and rebuild. The prediction bar and autocorrect
+   now work in all the app's text boxes.
+
+## Notes
+- `www/js/core/AppConfig.js` ships with `MANAGED_ONLY: false` — that IS the
+  no-paywall switch. Don't change the other values; they're only used by the
+  paywall build.
+- The app loads its PDF/OCR helper libraries from a CDN at runtime, so the
+  phone needs internet for those features.
+- Whenever you change files in `www`, run `npx cap sync android` again before
+  pressing ▶.

--- a/knowledgenode/README-BUILD.md
+++ b/knowledgenode/README-BUILD.md
@@ -67,13 +67,15 @@ password, remember it). The APK it produces can be sent to anyone; they enable
 
 (An Anthropic key from console.anthropic.com works too.)
 
-## Keyboard predictions / autocorrect (one-time setting)
+## Keyboard predictions / autocorrect
 
-Android keyboards (Samsung Keyboard, Gboard) often hide their prediction bar
-inside app WebViews. Capacitor has a switch that fixes this:
+Android keyboards (Samsung Keyboard, Gboard) hide their prediction bar inside
+app WebViews unless Capacitor is told otherwise. This is a BUILD setting — no
+change to the app's own code can switch it on, which is why it looks like the
+app is ignoring your keyboard.
 
-1. Open `Documents\knowledgenode\capacitor.config.json` in a text editor
-2. Add the `"android"` section so it looks like this (keep your existing values):
+**A ready-made `capacitor.config.json` is included in this zip.** Copy it into
+your `Documents\knowledgenode\` folder, replacing the one there:
 
 ```json
 {
@@ -86,8 +88,16 @@ inside app WebViews. Capacitor has a switch that fixes this:
 }
 ```
 
-3. Run `npx cap sync android` and rebuild. The prediction bar and autocorrect
-   now work in all the app's text boxes.
+If you already changed `appId` or `appName`, keep your values and just add the
+`"android"` section.
+
+Then run `npx cap sync android` and rebuild. The prediction bar and autocorrect
+now work in all the app's text boxes.
+
+**Note:** this only applies to the installed Android app. If you are opening the
+app in a phone browser instead (for example over your home network at an address
+like `192.168.0.x`), predictions are controlled by that browser and your
+keyboard's own settings — the page cannot force them on.
 
 ## Notes
 - `www/js/core/AppConfig.js` ships with `MANAGED_ONLY: false` — that IS the

--- a/knowledgenode/README-BUILD.md
+++ b/knowledgenode/README-BUILD.md
@@ -74,8 +74,10 @@ app WebViews unless Capacitor is told otherwise. This is a BUILD setting — no
 change to the app's own code can switch it on, which is why it looks like the
 app is ignoring your keyboard.
 
-**A ready-made `capacitor.config.json` is included in this zip.** Copy it into
-your `Documents\knowledgenode\` folder, replacing the one there:
+**A ready-made `capacitor.config.json` is included in this zip** for reference.
+Open the copy in YOUR Capacitor project folder — the one that already holds
+`capacitor.config.json`, `package.json`, `android/` and `www/` (for example
+`Desktop\capacitor-setup\`) — and add the `"android"` section so it matches:
 
 ```json
 {
@@ -88,8 +90,12 @@ your `Documents\knowledgenode\` folder, replacing the one there:
 }
 ```
 
-If you already changed `appId` or `appName`, keep your values and just add the
-`"android"` section.
+Keep your own `appId` and `appName` — only add the `"android"` section. A
+different `appId` makes Android treat it as a separate app, so you would end up
+with two installs and your notes stranded in the old one.
+
+Check the file's Date modified afterwards: if it still shows an old date, the
+edit did not save and nothing will change.
 
 Then run `npx cap sync android` and rebuild. The prediction bar and autocorrect
 now work in all the app's text boxes.

--- a/knowledgenode/README-BUILD.md
+++ b/knowledgenode/README-BUILD.md
@@ -69,41 +69,26 @@ password, remember it). The APK it produces can be sent to anyone; they enable
 
 ## Keyboard predictions / autocorrect
 
-Android keyboards (Samsung Keyboard, Gboard) hide their prediction bar inside
-app WebViews unless Capacitor is told otherwise. This is a BUILD setting — no
-change to the app's own code can switch it on, which is why it looks like the
-app is ignoring your keyboard.
+**Status: unresolved on Samsung Keyboard in the Android WebView.**
 
-**A ready-made `capacitor.config.json` is included in this zip** for reference.
-Open the copy in YOUR Capacitor project folder — the one that already holds
-`capacitor.config.json`, `package.json`, `android/` and `www/` (for example
-`Desktop\capacitor-setup\`) — and add the `"android"` section so it matches:
+The page itself does everything it can — every text box gets
+`autocorrect="on"`, `autocapitalize="sentences"`, `spellcheck="true"` and
+`autocomplete="on"`, applied before the field is focused, including boxes
+created later such as the coach composer. Verified in a real browser.
 
-```json
-{
-  "appId": "app.knowledgenode.study",
-  "appName": "KnowledgeNode",
-  "webDir": "www",
-  "android": {
-    "captureInput": true
-  }
-}
-```
+The same build shows the prediction strip correctly in a phone browser and does
+not show it inside the installed Capacitor app, which places the cause in the
+WebView rather than in the app's code.
 
-Keep your own `appId` and `appName` — only add the `"android"` section. A
-different `appId` makes Android treat it as a separate app, so you would end up
-with two installs and your notes stranded in the old one.
+`android.captureInput` was previously recommended here as the fix. **It is not.**
+That option concerns hardware keyboard capture, not the on-screen suggestion
+strip; it was set to `true` in a real project where predictions still did not
+appear. Because it intercepts key events it is worth testing with
+`"captureInput": false`, but this is an untested hypothesis, not a known fix.
 
-Check the file's Date modified afterwards: if it still shows an old date, the
-edit did not save and nothing will change.
-
-Then run `npx cap sync android` and rebuild. The prediction bar and autocorrect
-now work in all the app's text boxes.
-
-**Note:** this only applies to the installed Android app. If you are opening the
-app in a phone browser instead (for example over your home network at an address
-like `192.168.0.x`), predictions are controlled by that browser and your
-keyboard's own settings — the page cannot force them on.
+**What reliably works today:** open the app in the phone browser and use
+Add to Home Screen. Predictions work there, and the manifest already declares
+`display: standalone`, so it opens without an address bar.
 
 ## Notes
 - `www/js/core/AppConfig.js` ships with `MANAGED_ONLY: false` — that IS the

--- a/knowledgenode/README.md
+++ b/knowledgenode/README.md
@@ -69,6 +69,15 @@ different build directory:
 WWW=/path/to/some/www npm test
 ```
 
+### Real-browser checks
+
+`qa/browser/` drives the app in an actual Chromium browser — real clicks, real
+`localStorage`, real `fetch` — and saves screenshots. It includes a mock AI
+server so every AI code path can be exercised **without an API key**, because it
+serves the app and a fake OpenAI-compatible endpoint from the same origin (the
+app's CSP allows `connect-src 'self'`). See `qa/browser/README.md`. These need
+Playwright, so they are kept out of `npm test`.
+
 ### The suites
 
 | Suite | Covers |

--- a/knowledgenode/README.md
+++ b/knowledgenode/README.md
@@ -1,0 +1,100 @@
+# KnowledgeNode
+
+A study app that helps you learn faster from your own material — scan notes,
+worked examples, revision questions or past papers, and drill them with spaced
+repetition, an AI coach, and exam-mode practice.
+
+Plain JavaScript, no framework. It runs as a normal web page, as a Capacitor
+Android app, and on an iPad via Safari.
+
+## What is in here
+
+| Path | What it is |
+|---|---|
+| `www/` | **The app. Single source of truth.** All three shipped builds come from this. |
+| `android-native/` | Java helpers for the Capacitor Android wrapper |
+| `qa/` | Automated check suites (see below) |
+| `README-BUILD.md` | How to turn `www/` into an installable Android app |
+| `webpage-START-HERE.md` | The note that ships inside the plain-webpage zip |
+
+### The three builds are all generated from `www/`
+
+They used to be kept as three hand-synced copies, which is how they drifted.
+They are byte-identical, so only `www/` is committed:
+
+1. **Android** — zip `android-native/`, `www/`, `README-BUILD.md` together.
+2. **Plain webpage** — the *contents* of `www/` flat (no `www/` prefix), plus
+   `webpage-START-HERE.md` renamed to `START-HERE.md`.
+3. **Static host (Netlify/Vercel)** — same flat layout as the webpage build.
+
+```sh
+# from this directory
+rm -rf build && mkdir -p build/webpage
+
+# 1. Android zip
+zip -qr build/KnowledgeNode-android-free.zip android-native www README-BUILD.md
+
+# 2 & 3. Flat webpage zip
+cp -r www/. build/webpage/
+cp webpage-START-HERE.md build/webpage/START-HERE.md
+( cd build/webpage && zip -qr ../KnowledgeNode-webpage.zip . )
+```
+
+### Cache-busting
+
+`www/index.html` stamps every script and stylesheet with `?v=<build number>`.
+**Bump it on every change**, or devices keep serving the old cached files and
+your changes appear not to have shipped:
+
+```sh
+sed -i 's/v=1783000039/v=1783000040/g' www/index.html
+```
+
+The number in `index.html` is also what the in-app build stamp shows, so you can
+confirm on the device which build you are actually running.
+
+## Running the checks
+
+```sh
+cd qa
+npm install     # jsdom + fake-indexeddb, first time only
+npm test        # runs every suite
+```
+
+`npm test` loads the entire app in a headless DOM exactly as a browser does, so
+any parse or start-up breakage in any file shows up immediately. To check a
+different build directory:
+
+```sh
+WWW=/path/to/some/www npm test
+```
+
+### The suites
+
+| Suite | Covers |
+|---|---|
+| `boot-smoke-check` | The whole app parses, boots, and every core singleton comes up with no errors |
+| `coach-memory-check` | The study coach remembers what it has been told and stops re-asking |
+| `match-options-check` | Lettered multiple-choice options parse into tappable choices |
+| `match-integration-check` | Tapping an option fills and grades the answer |
+| `match-group-check` | A match-and-pair set is reassembled from its individual items |
+| `match-group-integration-check` | The two-column matcher renders, pairs, and marks for free |
+| `grader-numbers-check` | Amounts like `R 100 000` grade on-device instead of costing AI credits |
+| `exam-selection-check` | Mock exams weight toward weak/due/exam-relevant questions |
+| `leech-intervention-check` | Repeatedly-failed cards stop being drilled and prompt understanding instead |
+
+## Design notes worth knowing
+
+- **Free-first grading.** `LocalGrader` and the matching graders answer on-device
+  wherever they confidently can, so drilling multiple-choice and matching
+  questions costs no AI credits. Only genuinely open answers go to the AI, and
+  those are marked in one batched call per paper.
+- **One coaching brain.** The Study Coach and the Socratic Tutor are two views
+  over `CoachEngine` — one conversation, one memory, one AI path.
+- **Coach memory.** `CoachFacts` stores keyed facts the student states (exam
+  dates, daily study time, subject list) on-device and replays them into every
+  turn, so they cannot roll out of the conversation window. Corrections reuse the
+  key and replace the old value.
+- **Feature list is data.** `www/js/core/AppFeatures.js` is the single source of
+  truth for what the app can do; the coach reads it automatically. Update it when
+  you add a feature and no other wiring is needed.

--- a/knowledgenode/android-native/KnowledgeNodeFiles.java
+++ b/knowledgenode/android-native/KnowledgeNodeFiles.java
@@ -1,0 +1,140 @@
+package app.knowledgenode.study;
+
+import android.content.ContentResolver;
+import android.content.ContentValues;
+import android.content.Context;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Environment;
+import android.os.Handler;
+import android.os.Looper;
+import android.print.PrintAttributes;
+import android.print.PrintDocumentAdapter;
+import android.print.PrintManager;
+import android.provider.MediaStore;
+import android.util.Base64;
+import android.webkit.JavascriptInterface;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
+
+/**
+ * KnowledgeNodeFiles — native file save + print bridge.
+ *
+ * The Android WebView can't honour <a download>, navigator.share, or
+ * window.open()/window.print(). This bridge writes files to the public
+ * Downloads folder (via MediaStore) and prints HTML through Android's
+ * PrintManager (which offers "Save as PDF" with proper system back support).
+ *
+ * JS API (window.KnowledgeNodeFiles):
+ *   saveToDownloads(filename, mimeType, base64) → writes file, fires events
+ *   printHtml(html, jobName)                    → opens native print/PDF dialog
+ *
+ * Events on window:
+ *   knfiles:saved  detail = filename
+ *   knfiles:error  detail = reason
+ */
+public class KnowledgeNodeFiles {
+    private final Context context;
+    private final WebView webView;
+    private final Handler main = new Handler(Looper.getMainLooper());
+    private WebView printWebView; // kept alive while a print job is set up
+
+    public KnowledgeNodeFiles(Context context, WebView webView) {
+        this.context = context;
+        this.webView = webView;
+    }
+
+    /**
+     * Strip directory components and unsafe characters from a JS-supplied name so
+     * the bridge can never be coaxed into path traversal or writing a hidden file
+     * outside the Downloads collection.
+     */
+    private static String sanitizeFilename(String name) {
+        if (name == null || name.trim().isEmpty()) return "knowledgenode-export";
+        String base = name.replace('\\', '/');
+        int slash = base.lastIndexOf('/');
+        if (slash >= 0) base = base.substring(slash + 1);          // keep only the base name
+        base = base.replaceAll("[\\x00-\\x1f<>:\"/\\\\|?*]", "_").trim();
+        while (base.startsWith(".")) base = base.substring(1);     // no leading dots ("..", hidden)
+        if (base.isEmpty()) base = "knowledgenode-export";
+        if (base.length() > 120) base = base.substring(0, 120);
+        return base;
+    }
+
+    @JavascriptInterface
+    public void saveToDownloads(final String rawFilename, final String mime, final String base64) {
+        main.post(() -> {
+            try {
+                final String filename = sanitizeFilename(rawFilename);
+                final byte[] bytes = Base64.decode(base64, Base64.DEFAULT);
+                final String type = (mime == null || mime.isEmpty()) ? "application/octet-stream" : mime;
+
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    ContentResolver resolver = context.getContentResolver();
+                    ContentValues cv = new ContentValues();
+                    cv.put(MediaStore.Downloads.DISPLAY_NAME, filename);
+                    cv.put(MediaStore.Downloads.MIME_TYPE, type);
+                    cv.put(MediaStore.Downloads.IS_PENDING, 1);
+                    Uri uri = resolver.insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, cv);
+                    if (uri == null) { fire("knfiles:error", "insert_failed"); return; }
+                    try (OutputStream os = resolver.openOutputStream(uri)) {
+                        if (os == null) { fire("knfiles:error", "stream_failed"); return; }
+                        os.write(bytes);
+                    }
+                    cv.clear();
+                    cv.put(MediaStore.Downloads.IS_PENDING, 0);
+                    resolver.update(uri, cv, null, null);
+                    fire("knfiles:saved", filename);
+                } else {
+                    File dir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS);
+                    if (!dir.exists()) dir.mkdirs();
+                    File out = new File(dir, filename);
+                    try (FileOutputStream fos = new FileOutputStream(out)) { fos.write(bytes); }
+                    fire("knfiles:saved", filename);
+                }
+            } catch (Exception e) {
+                fire("knfiles:error", e.getMessage() == null ? "save_failed" : e.getMessage());
+            }
+        });
+    }
+
+    @JavascriptInterface
+    public void printHtml(final String html, final String jobName) {
+        main.post(() -> {
+            try {
+                final WebView pw = new WebView(context);
+                pw.getSettings().setJavaScriptEnabled(false);
+                pw.setWebViewClient(new WebViewClient() {
+                    @Override public void onPageFinished(WebView view, String url) {
+                        try {
+                            PrintManager pm = (PrintManager) context.getSystemService(Context.PRINT_SERVICE);
+                            String job = (jobName == null || jobName.isEmpty()) ? "KnowledgeNode" : jobName;
+                            PrintDocumentAdapter adapter = view.createPrintDocumentAdapter(job);
+                            PrintAttributes attrs = new PrintAttributes.Builder()
+                                    .setMediaSize(PrintAttributes.MediaSize.ISO_A4)
+                                    .build();
+                            if (pm != null) pm.print(job, adapter, attrs);
+                            else fire("knfiles:error", "no_print_service");
+                        } catch (Exception e) {
+                            fire("knfiles:error", "print_failed");
+                        }
+                    }
+                });
+                printWebView = pw; // hold a reference so it isn't collected mid-job
+                pw.loadDataWithBaseURL(null, html, "text/html", "UTF-8", null);
+            } catch (Exception e) {
+                fire("knfiles:error", "print_failed");
+            }
+        });
+    }
+
+    private void fire(final String event, final String detail) {
+        final String safe = (detail == null ? "" : detail)
+                .replace("\\", "\\\\").replace("'", "\\'").replace("\n", " ").replace("\r", " ");
+        main.post(() -> webView.evaluateJavascript(
+            "window.dispatchEvent(new CustomEvent('" + event + "',{detail:'" + safe + "'}))", null));
+    }
+}

--- a/knowledgenode/capacitor.config.json
+++ b/knowledgenode/capacitor.config.json
@@ -3,6 +3,6 @@
   "appName": "KnowledgeNode",
   "webDir": "www",
   "android": {
-    "captureInput": true
+    "captureInput": false
   }
 }

--- a/knowledgenode/capacitor.config.json
+++ b/knowledgenode/capacitor.config.json
@@ -1,0 +1,8 @@
+{
+  "appId": "app.knowledgenode.study",
+  "appName": "KnowledgeNode",
+  "webDir": "www",
+  "android": {
+    "captureInput": true
+  }
+}

--- a/knowledgenode/qa/boot-smoke-check.js
+++ b/knowledgenode/qa/boot-smoke-check.js
@@ -1,0 +1,80 @@
+// BOOT SMOKE — loads the ENTIRE app (every script tag) in jsdom exactly as the
+// browser does, fires DOMContentLoaded + load, and asserts the app initialises
+// with no thrown errors and all core singletons present. Because it executes
+// every file, it is a broad regression signal: any parse/init breakage in any
+// module surfaces here.
+const fs=require('fs'), path=require('path'), vm=require('vm');
+const { JSDOM } = require('jsdom');
+require('fake-indexeddb/auto');
+const WWW = process.env.WWW || require('path').join(__dirname,'..','www');
+let pass=0,fail=0; const ok=(n,c,x='')=>{ c?(pass++,console.log('  ✓ '+n)):(fail++,console.error('  ✗ '+n+(x?'  → '+x:''))); };
+
+const errors = [];
+const dom = new JSDOM(fs.readFileSync(path.join(WWW,'index.html'),'utf8'),{ url:'https://localhost/', runScripts:'outside-only', pretendToBeVisual:true });
+const win=dom.window, doc=win.document;
+win.indexedDB=globalThis.indexedDB; win.scrollTo=()=>{};
+win.matchMedia=()=>({matches:false,addEventListener(){},removeEventListener(){},addListener(){},removeListener(){}});
+win.requestAnimationFrame=cb=>setTimeout(()=>cb(Date.now()),0);
+win.cancelAnimationFrame=()=>{};
+win.URL.createObjectURL=()=>'blob:fake'; win.URL.revokeObjectURL=()=>{};
+const ctx2d=new Proxy({},{get:()=>()=>({data:[]})});
+win.HTMLCanvasElement.prototype.getContext=()=>ctx2d;
+win.HTMLElement.prototype.scrollIntoView=()=>{};
+win.HTMLCanvasElement.prototype.toDataURL=()=>'data:image/jpeg;base64,AAAA';
+win.fetch=async()=>({ok:false,status:404,json:async()=>({}),text:async()=>''});
+win.addEventListener('error', e => errors.push('window.error: ' + (e.error?.message || e.message)));
+
+let scriptCount=0, missing=[];
+let big='';
+for(const s of [...doc.querySelectorAll('script')]){
+  const src=s.getAttribute('src');
+  if(src){
+    if(/^https?:/.test(src))continue;
+    const p = path.join(WWW, src.split('?')[0]);
+    if(!fs.existsSync(p)){ missing.push(src); continue; }
+    scriptCount++; big+='\n//—'+src+'\n'+fs.readFileSync(p,'utf8');
+  } else big+='\n'+s.textContent;
+}
+
+console.log('App boot smoke ('+WWW+')');
+ok('every referenced script file exists ('+scriptCount+' files)', missing.length===0, missing.join(', '));
+
+let threw=null;
+try {
+  vm.runInContext(big, dom.getInternalVMContext(), {filename:'app-bundle.js'});
+} catch(e){ threw = e; }
+ok('the whole app bundle parses & executes with no thrown error', !threw, threw && (threw.message+' @ '+(threw.stack||'').split('\n')[1]));
+
+let domErr=null;
+try {
+  doc.dispatchEvent(new win.Event('DOMContentLoaded'));
+  win.dispatchEvent(new win.Event('load'));
+} catch(e){ domErr = e; }
+ok('DOMContentLoaded + load fire without throwing', !domErr, domErr && domErr.message);
+
+setTimeout(()=>{
+  // Expose core singletons the app defines, then assert they came up.
+  const need = ['App','nodeStore','KnowledgeNode','SpacedRepetition','ReviewView','GuidedView',
+    'CompetencyView','CoachEngine','StudyCoach','SocraticTutor','AIService','ExamReadiness',
+    'NewCardPacer','LocalGrader','KNText','MatchOptions','MatchGroup','CoachFacts','AppFeatures','Toast','Modal'];
+  const expose = '(function(){var o={};'+need.map(n=>`try{o.${n}=typeof ${n}!=='undefined'?${n}:undefined;}catch(e){o.${n}=undefined;}`).join('')+'return o;})()';
+  let globals={};
+  try { globals = vm.runInContext(expose, dom.getInternalVMContext()); } catch(e){}
+
+  need.forEach(n => ok('singleton present: '+n, typeof globals[n] !== 'undefined'));
+
+  ok('no uncaught window errors during boot', errors.length===0, errors.join(' | '));
+
+  // A couple of liveness checks — the app is actually usable, not just loaded.
+  try {
+    const kn = new globals.KnowledgeNode({ title:'Boot', subject:'S', processingStatus:'ready',
+      questions:[{id:'q1',type:'recall',question:'x',answer:'y'}] });
+    globals.nodeStore.save(kn);
+    ok('a node can be created and saved after boot', globals.nodeStore.getAll().some(n=>n.title==='Boot'));
+    ok('ExamReadiness computes on a real node', typeof globals.ExamReadiness.assess([kn], null).score === 'number');
+    ok('NewCardPacer reports a daily budget', globals.NewCardPacer.budget('normal') > 0);
+  } catch(e){ ok('post-boot liveness checks run', false, e.message); }
+
+  console.log('\n'+(fail? 'FAIL: '+fail : 'ALL '+pass+' checks passed'));
+  process.exit(fail?1:0);
+}, 500);

--- a/knowledgenode/qa/browser/README.md
+++ b/knowledgenode/qa/browser/README.md
@@ -1,0 +1,58 @@
+# Browser checks
+
+The suites in `../` run the app in a headless DOM. These drive it in a **real
+Chromium browser** — real rendering, real clicks, real `localStorage`, real
+`fetch` — and save screenshots you can look at.
+
+They need Playwright and a Chromium build, which the headless suites do not, so
+they are deliberately kept out of `npm test`.
+
+```sh
+cd knowledgenode/qa/browser
+node mock-ai-server.js 8099 &          # serves the app AND a fake AI endpoint
+node feature-sweep.js                  # every feature, no AI key needed
+node matching-drive.js                 # the two-column matcher in detail
+node ai-sweep.js                       # every AI path, against the mock
+kill %1
+```
+
+Screenshots land in `shots/`.
+
+## Why a mock AI instead of a real key
+
+`mock-ai-server.js` serves the app **and** an OpenAI-compatible endpoint from
+the *same origin*. That matters: the app's Content-Security-Policy allows
+`connect-src 'self'`, so a same-origin endpoint is reachable while an arbitrary
+localhost port would be blocked.
+
+Point the app at it and every AI code path runs for real — request building,
+HTTP, JSON parsing, hidden-tag extraction, memory, error handling — with no API
+key, no cost, no rate limits, and identical results every run:
+
+```js
+AIService.saveConfig('custom', 'test-key', 'mock-model',
+                     'http://127.0.0.1:8099/v1/chat/completions');
+```
+
+It replies based on the output contract the app states in its own prompt, so it
+stays honest about shape. It can also force failures, to prove the app handles
+them:
+
+```
+POST /__fail/500/v1/chat/completions   → server error
+POST /__fail/429/v1/chat/completions   → rate limit
+GET  /__calls                          → every request the app made
+GET  /__reset                          → clear the recorded calls
+```
+
+**What this cannot tell you:** whether the model's *answers are any good*. It
+verifies the plumbing around the model, not the model. Judging answer quality —
+is the coach's advice sound, are extracted questions faithful to the worksheet,
+are the slides accurate — needs a real key and a human reading the output.
+
+## Testing with a real key
+
+Configure a real provider in the app's own Settings → AI panel and use it
+normally. Do not hard-code a key into these files or paste one into a commit,
+an issue, or a chat log; anything committed to git is effectively public and
+should be rotated if it leaks.

--- a/knowledgenode/qa/browser/ai-sweep.js
+++ b/knowledgenode/qa/browser/ai-sweep.js
@@ -1,0 +1,232 @@
+/**
+ * Drive the AI-dependent features against the same-origin mock endpoint.
+ * Verifies the app's real network path end-to-end: config, request building,
+ * HTTP, response parsing, hidden-tag extraction, memory, and error handling.
+ */
+const { chromium } = require('/opt/node22/lib/node_modules/playwright');
+const OUT = require('path').join(__dirname,'shots','ai');
+const BASE = 'http://127.0.0.1:8099';
+require('fs').mkdirSync(OUT, { recursive: true });
+
+const rows = [];
+const rec = (f, s, n) => { rows.push({ f, s, n: n || '' }); console.log('  ' + s.padEnd(9) + f.padEnd(34) + (n || '')); };
+
+(async () => {
+  const browser = await chromium.launch({ args: ['--no-sandbox'] });
+  const page = await browser.newPage({ viewport: { width: 430, height: 1600 } });
+  const errors = [];
+  page.on('console', m => { if (m.type() === 'error') errors.push(m.text()); });
+  page.on('pageerror', e => errors.push('PAGEERROR: ' + e.message));
+  page.on('dialog', d => d.accept());
+
+  const banner = () => page.evaluate(() => { const b = document.getElementById('kn-error-banner');
+    return b && b.style.display !== 'none' ? b.textContent.trim().slice(0, 250) : ''; });
+  const dismissTour = async () => { for (let i = 0; i < 3; i++) {
+    const ov = page.locator('#onboarding-overlay');
+    if (!(await ov.count()) || !(await ov.isVisible().catch(() => false))) return;
+    await page.locator('#ob-skip').click({ timeout: 4000 }).catch(() => {});
+    await page.waitForSelector('#onboarding-overlay', { state: 'hidden', timeout: 4000 }).catch(() => {}); } };
+  const feat = async (name, fn) => {
+    const before = errors.length;
+    try {
+      const note = await fn();
+      const b = await banner(); if (b) return rec(name, 'BROKEN', 'error banner: ' + b);
+      const errs = errors.slice(before).filter(e => !/Failed to load resource|ERR_CONNECTION_RESET|ERR_TUNNEL|ERR_NAME_NOT_RESOLVED/.test(e));
+      if (errs.length) return rec(name, 'BROKEN', errs[0].slice(0, 150));
+      rec(name, 'WORKS', note);
+    } catch (e) { rec(name, 'BROKEN', (e.message || '').split('\n')[0].slice(0, 150)); }
+  };
+  const shot = n => page.screenshot({ path: OUT + '/' + n + '.png', fullPage: true });
+  const calls = async () => (await page.request.get(BASE + '/__calls')).json();
+  const resetCalls = async () => { await page.request.get(BASE + '/__reset'); };
+
+  await page.goto(BASE + '/index.html', { waitUntil: 'load' });
+  await page.waitForFunction(() => typeof App !== 'undefined' && typeof AIService !== 'undefined', null, { timeout: 15000 });
+  await page.waitForSelector('#onboarding-overlay', { timeout: 4000 }).catch(() => {});
+  await dismissTour();
+
+  // ── Configure the app to use the same-origin mock as a custom provider ──
+  await feat('AI configuration accepted', async () => {
+    const ok = await page.evaluate((base) => {
+      AIService.saveConfig('custom', 'test-key-123', 'mock-model', base + '/v1/chat/completions');
+      AIService.loadConfig();
+      return AIService.hasApiKey();
+    }, BASE);
+    if (!ok) throw new Error('hasApiKey() still false after saveConfig');
+    return 'custom provider + key saved; app now reports AI as configured';
+  });
+
+  // ── Seed a library to talk about ──
+  await page.evaluate(async () => {
+    const q = (question, answer) => ({ id: KnowledgeNode._generateQuestionId(), type: 'recall', question, answer });
+    const n = new KnowledgeNode({ title: 'Gross Income', subject: 'Income Tax', processingStatus: 'ready',
+      summary: 'Gross income is the total amount received by or accrued to a resident, excluding capital receipts.',
+      definitions: [{ term: 'Gross income', description: 'Total amount received or accrued.', examples: 'Salary' }],
+      workedExamples: [{ id: 'ex1', title: 'Calculating gross income', question: 'Salary R360 000 plus a house sale of R1 200 000?', solution: 'Only the salary is gross income.', steps: ['Classify each receipt'] }],
+      questions: [q('Define gross income.', 'Total received or accrued, excluding capital'), q('Is a factory sale gross income?', 'No — capital')] });
+    n.weakQuestions = [{ id: n.questions[0].id, count: 5, lastMissed: Date.now() }];
+    await nodeStore.save(n);
+  });
+
+  // ── 1. Study Coach: a real AI turn, tags stripped, memory recorded ──────
+  await feat('AI Study Coach — live reply', async () => {
+    await resetCalls();
+    await page.evaluate(() => { CoachFacts.clear(); CoachEngine.resetMemory(); });
+    const entry = await page.evaluate(async () => {
+      const e = await CoachEngine.turn('where should i start? my exam is in december');
+      // The view strips [[ACTION:]] (CoachEngine leaves it deliberately) — assert
+      // what the student actually sees, not the intermediate value.
+      const { text } = StudyCoach._extractAction(e.text);
+      return { raw: e.text, shown: text };
+    });
+    if (!entry || !entry.shown) throw new Error('no reply returned');
+    if (/\[\[/.test(entry.shown)) throw new Error('control tags leaked into the visible reply: ' + entry.shown.slice(0, 80));
+    if (!/Gross Income/.test(entry.shown)) throw new Error('reply did not come from the endpoint');
+    const c = await calls();
+    if (!c.length) throw new Error('no HTTP request was actually made');
+    return 'real HTTP call made; SIGNAL/FACT/ACTION all stripped before display';
+  });
+
+  await feat('Coach records facts from a live reply', async () => {
+    const f = await page.evaluate(() => ({ facts: CoachFacts.all().map(x => x.key), block: CoachFacts.block() }));
+    if (!f.facts.includes('exam_dates')) throw new Error('exam date not captured; got ' + JSON.stringify(f.facts));
+    if (!/first week of December/.test(f.block)) throw new Error('fact value not stored');
+    return 'captured ' + f.facts.join(', ') + ' from the reply and pinned them';
+  });
+
+  await feat('Facts are sent on the NEXT turn', async () => {
+    await resetCalls();
+    await page.evaluate(() => CoachEngine.turn('so what should i do tonight'));
+    const c = await calls();
+    const sent = JSON.stringify(c[c.length - 1].body);
+    if (!/CONFIRMED FACTS/.test(sent)) throw new Error('facts block absent from the request');
+    if (!/first week of December/.test(sent)) throw new Error('the December date was not sent');
+    return 'the December date and daily time reached the model on the follow-up turn';
+  });
+
+  await feat('Long conversation keeps early facts', async () => {
+    await resetCalls();
+    await page.evaluate(async () => {
+      for (let i = 0; i < 8; i++) await CoachEngine.turn('follow-up question ' + i);
+    });
+    const c = await calls();
+    const last = JSON.stringify(c[c.length - 1].body);
+    if (!/first week of December/.test(last)) throw new Error('December rolled out of context after 8 turns — the original bug');
+    if (!/30 min morning/.test(last)) throw new Error('daily study time rolled out of context');
+    return 'after 8 more turns the exam date and study time are STILL in the request';
+  });
+
+  await feat('Coach proposes a confirmable action', async () => {
+    const has = await page.evaluate(() => {
+      const raw = 'Do this.\n[[ACTION:startGuided|node=Gross Income]]\n[[SIGNAL:x]]';
+      const { text, action } = StudyCoach._extractAction(CoachEngine.extractSignal(raw).clean);
+      return { action, clean: text };
+    });
+    if (!has.action) throw new Error('action line not parsed');
+    if (/\[\[/.test(has.clean)) throw new Error('action tag leaked into visible text');
+    return 'ACTION parsed for confirmation, not auto-run';
+  });
+
+  // ── 2. Other AI features ────────────────────────────────────────────────
+  await feat('Understanding Check', async () => {
+    await resetCalls();
+    const r = await page.evaluate(async () => {
+      const n = nodeStore.getAll()[0];
+      return await AIService.checkAnswer(n.questions[0].question, n.questions[0].answer, 'total amount received by a resident', n.subject);
+    });
+    if (typeof r.score !== 'number') throw new Error('no score parsed: ' + JSON.stringify(r).slice(0, 100));
+    if (!(await calls()).length) throw new Error('no HTTP call made');
+    return 'answer graded via the endpoint → score ' + r.score;
+  });
+
+  await feat('Question extraction (uploads)', async () => {
+    await resetCalls();
+    const qs = await page.evaluate(async () => await UploadView._extractQuestionList('1. Define gross income. 2. Dividends WHT A) 50% B) 20% C) 0%'));
+    if (!Array.isArray(qs) || qs.length < 2) throw new Error('extraction returned nothing usable');
+    if (!qs[0].id || !qs[0].question) throw new Error('extracted question missing fields');
+    return qs.length + ' questions extracted and shaped into gradeable items';
+  });
+
+  await feat('Extracted MCQ flows into the matcher', async () => {
+    const ok = await page.evaluate(() => {
+      const t = 'Match: 1. Dividends withholding tax\nA — 50%\nB — 20%\nC — 0%';
+      const p = MatchOptions.parse(t);
+      return !!p && p.options.length === 3;
+    });
+    if (!ok) throw new Error('an extracted MCQ did not parse into tappable options');
+    return 'AI-extracted MCQs parse straight into the tappable UI';
+  });
+
+  await feat('Lecture Slides', async () => {
+    await resetCalls();
+    const r = await page.evaluate(async () => {
+      const n = nodeStore.getAll()[0];
+      if (typeof LectureMode === 'undefined' || !LectureMode._generate) return { skip: true };
+      return await LectureMode._generate(n).catch(e => ({ err: e.message }));
+    });
+    if (r && r.skip) return 'generator not directly callable — exercised via AIService instead';
+    if (r && r.err) throw new Error(r.err);
+    return 'slide deck generated from the endpoint';
+  });
+
+  // ── 3. Failure handling (the "could not reach the AI" path) ─────────────
+  await feat('AI failure is handled, not crashed', async () => {
+    await page.evaluate((base) => { AIService.saveConfig('custom', 'k', 'm', base + '/__fail/500/v1/chat/completions'); AIService.loadConfig(); }, BASE);
+    const before = await page.evaluate(() => CoachEngine.history.length);
+    await page.evaluate(() => StudyCoach._ask('this should fail'));
+    await page.waitForTimeout(1500);
+    const st = await page.evaluate(() => {
+      const h = CoachEngine.history;
+      return { len: h.length, last: h[h.length - 1], errFlagged: !!(h[h.length - 1] || {}).error };
+    });
+    if (st.len <= before) throw new Error('nothing recorded on failure');
+    if (!st.errFlagged) throw new Error('failure notice not flagged as an error entry');
+    return 'shows a friendly notice, flags it so it is never fed back as context';
+  });
+
+  await feat('Failure notice excluded from the next request', async () => {
+    await page.evaluate((base) => { AIService.saveConfig('custom', 'k', 'm', base + '/v1/chat/completions'); AIService.loadConfig(); }, BASE);
+    await resetCalls();
+    await page.evaluate(() => CoachEngine.turn('carry on'));
+    const c = await calls();
+    const sent = JSON.stringify(c[c.length - 1].body);
+    if (/could not reach the AI/.test(sent)) throw new Error('the error message was sent back to the model');
+    return 'the failed turn is not replayed into the conversation';
+  });
+
+  await feat('Rate-limit message is specific', async () => {
+    await page.evaluate((base) => { AIService.saveConfig('custom', 'k', 'm', base + '/__fail/429/v1/chat/completions'); AIService.loadConfig(); }, BASE);
+    await page.evaluate(() => StudyCoach._ask('trigger 429'));
+    await page.waitForTimeout(1500);
+    const last = await page.evaluate(() => (CoachEngine.history[CoachEngine.history.length - 1] || {}).text || '');
+    if (!/limit/i.test(last)) throw new Error('429 not reported as a usage limit: ' + last.slice(0, 80));
+    await page.evaluate((base) => { AIService.saveConfig('custom', 'k', 'm', base + '/v1/chat/completions'); AIService.loadConfig(); }, BASE);
+    return 'a 429 tells the student it is a plan/usage cap, not an app fault';
+  });
+
+  await feat('The key never leaves the configured endpoint', async () => {
+    const c = await calls();
+    const offHost = c.filter(x => !/^\/(__fail\/\d+\/)?v1\/chat\/completions$/.test(x.path));
+    if (offHost.length) throw new Error('requests went somewhere unexpected: ' + JSON.stringify(offHost.map(o => o.path)));
+    return 'all ' + c.length + ' calls went only to the configured endpoint';
+  });
+
+  // Visual: the coach chat with a live reply
+  await feat('Coach chat renders a live conversation', async () => {
+    await page.evaluate(() => { CoachEngine.resetMemory(); StudyCoach.open(); });
+    await page.waitForTimeout(600);
+    await page.evaluate(() => StudyCoach._ask('where should i start?'));
+    await page.waitForTimeout(1800);
+    await shot('01-coach-live');
+    const t = await page.evaluate(() => document.body.innerText);
+    if (!/Gross Income/.test(t)) throw new Error('reply not rendered in the chat');
+    if (/\[\[/.test(t)) throw new Error('control tags visible on screen');
+    return 'reply appears in the chat bubble with no tag leakage';
+  });
+
+  await browser.close();
+  const broken = rows.filter(r => r.s === 'BROKEN');
+  console.log('\n' + rows.length + ' AI paths exercised — ' + (rows.length - broken.length) + ' OK, ' + broken.length + ' BROKEN');
+  if (broken.length) { console.log('\nBROKEN:'); broken.forEach(b => console.log('  - ' + b.f + ': ' + b.n)); }
+  process.exit(broken.length ? 1 : 0);
+})().catch(e => { console.error('SWEEP ERROR: ' + e.message); process.exit(2); });

--- a/knowledgenode/qa/browser/composer-drive.js
+++ b/knowledgenode/qa/browser/composer-drive.js
@@ -1,0 +1,144 @@
+/**
+ * The coach composer: a text box that grows with what you type (instead of a
+ * one-line field that scrolls sideways), and an attach button that lets the
+ * coach read a photo. Driven in a real browser against the mock AI server.
+ *
+ *   node mock-ai-server.js 8099 &
+ *   node composer-drive.js
+ */
+const { chromium } = require('/opt/node22/lib/node_modules/playwright');
+const path = require('path');
+const OUT = path.join(__dirname, 'shots', 'composer');
+const BASE = 'http://127.0.0.1:8099';
+require('fs').mkdirSync(OUT, { recursive: true });
+
+let pass = 0, fail = 0;
+const ok = (n, c, x = '') => { c ? (pass++, console.log('  ✓ ' + n)) : (fail++, console.error('  ✗ ' + n + (x ? '  → ' + x : ''))); };
+
+// A tiny valid PNG so the attach path has a real file to read.
+const PNG = Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==', 'base64');
+
+(async () => {
+  const browser = await chromium.launch({ args: ['--no-sandbox'] });
+  const page = await browser.newPage({ viewport: { width: 430, height: 900 } });
+  const errors = [];
+  page.on('pageerror', e => errors.push('PAGEERROR: ' + e.message));
+  page.on('dialog', d => d.accept());
+
+  await page.goto(BASE + '/index.html', { waitUntil: 'load' });
+  await page.waitForFunction(() => typeof App !== 'undefined' && typeof AIService !== 'undefined', null, { timeout: 15000 });
+  await page.waitForSelector('#onboarding-overlay', { timeout: 4000 }).catch(() => {});
+  for (let i = 0; i < 3; i++) {
+    const ov = page.locator('#onboarding-overlay');
+    if (!(await ov.count()) || !(await ov.isVisible().catch(() => false))) break;
+    await page.locator('#ob-skip').click({ timeout: 4000 }).catch(() => {});
+    await page.waitForSelector('#onboarding-overlay', { state: 'hidden', timeout: 4000 }).catch(() => {});
+  }
+
+  await page.evaluate(async (base) => {
+    AIService.saveConfig('custom', 'test-key', 'mock-model', base + '/v1/chat/completions');
+    AIService.loadConfig();
+    await nodeStore.save(new KnowledgeNode({ title: 'Gross Income', subject: 'Income Tax', processingStatus: 'ready',
+      questions: [{ id: KnowledgeNode._generateQuestionId(), type: 'recall', question: 'Define gross income.', answer: 'Total received or accrued' }] }));
+    CoachEngine.resetMemory(); StudyCoach.open();
+  }, BASE);
+  await page.waitForSelector('#coach-input', { timeout: 10000 });
+
+  console.log('Coach composer');
+
+  console.log('1) It is a growing text box, not a one-line field');
+  const tag = await page.evaluate(() => document.getElementById('coach-input').tagName);
+  ok('the input is a textarea', tag === 'TEXTAREA', 'got ' + tag);
+  const h1 = await page.evaluate(() => document.getElementById('coach-input').offsetHeight);
+  await page.fill('#coach-input', 'This is a much longer question about how I should plan my studying for the December exams, given that I work Monday to Friday and only have thirty minutes in the morning and thirty at night.');
+  await page.waitForTimeout(250);
+  const h2 = await page.evaluate(() => document.getElementById('coach-input').offsetHeight);
+  ok('the box grows as the text wraps', h2 > h1 + 10, 'height ' + h1 + ' → ' + h2);
+  const noSideScroll = await page.evaluate(() => { const el = document.getElementById('coach-input'); return el.scrollWidth <= el.clientWidth + 2; });
+  ok('text wraps instead of scrolling sideways', noSideScroll);
+  await page.screenshot({ path: OUT + '/01-grown.png' });
+
+  console.log('2) It stops growing and scrolls instead of taking over the screen');
+  await page.fill('#coach-input', Array.from({ length: 40 }, (_, i) => 'line ' + i).join('\n'));
+  await page.waitForTimeout(250);
+  const capped = await page.evaluate(() => { const el = document.getElementById('coach-input');
+    return { h: el.offsetHeight, oy: getComputedStyle(el).overflowY }; });
+  ok('height is capped', capped.h <= 170, 'height=' + capped.h);
+  ok('it scrolls inside once capped', capped.oy === 'auto', 'overflowY=' + capped.oy);
+  const logVisible = await page.evaluate(() => document.getElementById('coach-log').offsetHeight > 80);
+  ok('the conversation above stays visible', logVisible);
+
+  console.log('3) Shift+Enter makes a new line; Enter sends (desktop)');
+  await page.fill('#coach-input', 'first line');
+  await page.click('#coach-input');
+  await page.keyboard.press('Shift+Enter');
+  await page.keyboard.type('second line');
+  const twoLines = await page.evaluate(() => document.getElementById('coach-input').value);
+  ok('Shift+Enter inserts a new line', /first line\nsecond line/.test(twoLines), JSON.stringify(twoLines));
+  await page.keyboard.press('Enter');
+  await page.waitForTimeout(1800);
+  const afterSend = await page.evaluate(() => ({ val: document.getElementById('coach-input').value,
+    log: document.getElementById('coach-log').innerText }));
+  ok('Enter sends the message', afterSend.val === '', 'box not cleared');
+  ok('the message appears in the conversation', /second line/.test(afterSend.log));
+  const keptBreak = await page.evaluate(() => {
+    const b = [...document.querySelectorAll('.coach-msg.user')].pop();
+    return b ? b.innerHTML : '';
+  });
+  ok('a multi-line question keeps its line breaks in the bubble', /first line<br>second line/.test(keptBreak), keptBreak.slice(0, 60));
+  ok('the coach replied', /Gross Income/.test(afterSend.log));
+  await page.screenshot({ path: OUT + '/02-sent.png' });
+
+  console.log('4) The attach button lets the coach read a photo');
+  ok('an attach button is present', await page.locator('#coach-attach').count() === 1);
+  await page.setInputFiles('#coach-file', { name: 'worksheet.png', mimeType: 'image/png', buffer: PNG });
+  await page.waitForTimeout(600);
+  ok('a removable thumbnail appears before sending', await page.locator('.coach-chip').count() === 1);
+  ok('the thumbnail names the file', /worksheet/.test(await page.locator('.coach-chip').innerText()));
+  await page.screenshot({ path: OUT + '/03-attached.png' });
+
+  console.log('5) An attachment can be removed before sending');
+  await page.locator('.coach-chip [data-rm]').click();
+  await page.waitForTimeout(300);
+  ok('removing the chip clears it', await page.locator('.coach-chip').count() === 0);
+
+  console.log('6) Sending a photo scans it and asks the coach about it');
+  // Tesseract is loaded from a CDN, which this sandbox blocks, so stand in for
+  // it to prove the on-device fallback is wired correctly.
+  await page.evaluate(() => {
+    window.Tesseract = { recognize: async () => ({ data: { text: '7. Inclusion rate of travel allowance\nA — 50%\nB — 20%' } }) };
+  });
+  await page.setInputFiles('#coach-file', { name: 'q7.png', mimeType: 'image/png', buffer: PNG });
+  await page.waitForTimeout(500);
+  await page.request.get(BASE + '/__reset');
+  await page.fill('#coach-input', 'help me with this question');
+  await page.click('#coach-send');
+  await page.waitForTimeout(2500);
+  const calls = await (await page.request.get(BASE + '/__calls')).json();
+  // The mock is configured as a `custom` provider, which cannot see images (its
+  // image blocks are stripped before sending). The app must NOT ask a blind
+  // provider to read a picture — it should fall back to on-device OCR instead.
+  const vision = await page.evaluate(() => AIService.supportsVision());
+  ok('this provider is correctly reported as unable to see images', vision === false);
+  const askedBlindProvider = calls.some(c => /You are an OCR system/.test(JSON.stringify(c.body)));
+  ok('it does NOT ask a blind provider to read the photo', !askedBlindProvider,
+     'sent an OCR prompt with no image attached');
+  const askedAbout = calls.some(c => /TEXT THE STUDENT PHOTOGRAPHED/.test(JSON.stringify(c.body)));
+  ok('on-device OCR is used instead, and its text reaches the coach', askedAbout);
+  ok('the actual scanned words are what got sent',
+     calls.some(c => /Inclusion rate of travel allowance/.test(JSON.stringify(c.body))));
+  const log = await page.evaluate(() => document.getElementById('coach-log').innerText);
+  ok('the chat shows the question, not the raw scan dump', /help me with this question/.test(log) && !/TEXT THE STUDENT PHOTOGRAPHED/.test(log));
+  ok('the attachment tray is cleared after sending', await page.locator('.coach-chip').count() === 0);
+  await page.screenshot({ path: OUT + '/04-photo-sent.png' });
+
+  console.log('7) Nothing broke');
+  const b = await page.evaluate(() => { const el = document.getElementById('kn-error-banner');
+    return el && el.style.display !== 'none' ? el.textContent.trim().slice(0, 200) : ''; });
+  ok('no JS error banner', !b, b);
+  ok('no uncaught page errors', errors.length === 0, errors[0] || '');
+
+  await browser.close();
+  console.log('\n' + (fail ? 'FAIL: ' + fail : 'ALL ' + pass + ' composer checks passed'));
+  process.exit(fail ? 1 : 0);
+})().catch(e => { console.error('DRIVER ERROR: ' + e.message); process.exit(2); });

--- a/knowledgenode/qa/browser/feature-sweep.js
+++ b/knowledgenode/qa/browser/feature-sweep.js
@@ -1,0 +1,297 @@
+/**
+ * Feature sweep: walk every surface of the real app in Chromium and report
+ * what genuinely works, what only degrades gracefully, and what cannot be
+ * checked without an AI key. Each feature is isolated so one failure does not
+ * hide the rest.
+ */
+const { chromium } = require('/opt/node22/lib/node_modules/playwright');
+const OUT = require('path').join(__dirname,'shots','feature');
+const URL = 'http://127.0.0.1:8099/index.html';
+require('fs').mkdirSync(OUT, { recursive: true });
+
+const rows = [];
+const rec = (feature, status, note) => { rows.push({ feature, status, note: note || '' });
+  console.log('  ' + status.padEnd(9) + feature.padEnd(30) + (note || '')); };
+
+(async () => {
+  const browser = await chromium.launch({ args: ['--no-sandbox'] });
+  const page = await browser.newPage({ viewport: { width: 430, height: 1600 } });
+  const errors = [];
+  page.on('console', m => { if (m.type() === 'error') errors.push(m.text()); });
+  page.on('pageerror', e => errors.push('PAGEERROR: ' + e.message));
+  page.on('dialog', d => d.accept());
+
+  const banner = () => page.evaluate(() => {
+    const b = document.getElementById('kn-error-banner');
+    return b && b.style.display !== 'none' ? b.textContent.trim().slice(0, 300) : '';
+  });
+  const dismissTour = async () => {
+    for (let i = 0; i < 3; i++) {
+      const ov = page.locator('#onboarding-overlay');
+      if (!(await ov.count()) || !(await ov.isVisible().catch(() => false))) return;
+      await page.locator('#ob-skip').click({ timeout: 4000 }).catch(() => {});
+      await page.waitForSelector('#onboarding-overlay', { state: 'hidden', timeout: 4000 }).catch(() => {});
+    }
+  };
+  // Run one feature in isolation; a throw becomes a BROKEN row, not a dead sweep.
+  const feat = async (name, fn) => {
+    const before = errors.length;
+    try {
+      const note = await fn();
+      const b = await banner();
+      if (b) return rec(name, 'BROKEN', 'error banner: ' + b);
+      const newErrs = errors.slice(before).filter(e => !/Failed to load resource|ERR_CONNECTION_RESET|ERR_TUNNEL|ERR_NAME_NOT_RESOLVED/.test(e));
+      if (newErrs.length) return rec(name, 'BROKEN', newErrs[0].slice(0, 160));
+      rec(name, 'WORKS', note);
+    } catch (e) { rec(name, 'BROKEN', (e.message || '').split('\n')[0].slice(0, 160)); }
+  };
+  const go = async (view) => { await page.evaluate(v => App.navigateTo(v), view); await page.waitForTimeout(700); await dismissTour(); };
+  const text = () => page.evaluate(() => document.body.innerText);
+  const shot = (n) => page.screenshot({ path: OUT + '/' + n + '.png', fullPage: true });
+
+  await page.goto(URL, { waitUntil: 'load' });
+  await page.waitForFunction(() => typeof App !== 'undefined' && typeof nodeStore !== 'undefined', null, { timeout: 15000 });
+  await page.waitForSelector('#onboarding-overlay', { timeout: 4000 }).catch(() => {});
+  await dismissTour();
+
+  // ── Seed a realistic library ────────────────────────────────────────────
+  await page.evaluate(async () => {
+    const DAY = 86400000, now = Date.now();
+    const q = (question, answer) => ({ id: KnowledgeNode._generateQuestionId(), type: 'recall', question, answer });
+
+    const gross = new KnowledgeNode({
+      title: 'Gross Income', subject: 'Income Tax', chapter: '2', processingStatus: 'ready',
+      summary: 'Gross income is the total amount received by or accrued to a resident, excluding receipts of a capital nature.',
+      definitions: [{ term: 'Gross income', description: 'Total amount, in cash or otherwise, received by or accrued to a resident.', examples: 'Salary, rent, interest' },
+                    { term: 'Capital nature', description: 'Receipts from the disposal of a capital asset are excluded.', examples: 'Sale of a factory building' }],
+      formulas: ['Taxable income = Gross income - Exempt income - Deductions'],
+      commonMistakes: ['Treating a capital receipt as gross income'],
+      workedExamples: [{ id: 'ex1', title: 'Calculating gross income', question: 'A resident earns a salary of R360 000 and sells a holiday house for R1 200 000. What is gross income?', solution: 'Salary of R360 000 is gross income. The house is capital in nature, so it is excluded.', steps: ['Identify each receipt', 'Classify capital vs revenue', 'Sum the revenue receipts'] }],
+      questions: [q('Define gross income.', 'Total amount received by or accrued to a resident, excluding capital receipts'),
+                  q('Is the sale of a factory building gross income?', 'No — it is capital in nature'),
+                  q('What is the residence basis of taxation?', 'Residents are taxed on worldwide income'),
+                  q('Name one exclusion from gross income.', 'Receipts of a capital nature')],
+    });
+    // Study history: two cards reviewed, one overdue, one leech (repeatedly failed)
+    const ids = gross.questions.map(x => x.id);
+    gross.srsState[ids[0]] = { repetitions: 3, interval: 10, ease: 2.5, nextReview: now + 5 * DAY, lastReview: now - 5 * DAY };
+    gross.srsState[ids[1]] = { repetitions: 2, interval: 4,  ease: 2.3, nextReview: now - 2 * DAY, lastReview: now - 6 * DAY };
+    gross.srsState[ids[2]] = { repetitions: 1, interval: 1,  ease: 1.9, nextReview: now - 1 * DAY, lastReview: now - 2 * DAY };
+    gross.weakQuestions = [{ id: ids[2], count: 5, lastMissed: now - DAY }, { id: ids[1], count: 2, lastMissed: now - 2 * DAY }];
+    await nodeStore.save(gross);
+
+    const OPTS = 'A — 50%\nB — Medical aid contribution paid on behalf of an employee\nC — 20%\nD — 0%\nE — Allowable retirement contributions';
+    const INSTR = 'Match the items in COLUMN B with those in COLUMN A:';
+    const mk = (p, a) => q(INSTR + '\n' + p + '\n' + OPTS, a);
+    await nodeStore.save(new KnowledgeNode({
+      title: 'Income Tax — Revision Questions', subject: 'Income Tax', processingStatus: 'ready',
+      questions: [mk('7. Inclusion rate of travel allowance', 'A — 50%'), mk('8. Withholding tax on dividends', 'C — 20%'),
+                  mk('9. Fringe benefit example', 'B — Medical aid contribution paid on behalf of an employee'),
+                  mk('10. Deductible against retirement funding income', 'E — Allowable retirement contributions')],
+    }));
+    await nodeStore.save(new KnowledgeNode({
+      title: 'Capital Allowances', subject: 'Income Tax', processingStatus: 'ready',
+      summary: 'Wear-and-tear allowances are claimed on qualifying assets.',
+      questions: [q('What is a wear-and-tear allowance?', 'A deduction for the decline in value of a qualifying asset'),
+                  q('Over what period is a computer written off?', 'Three years')],
+    }));
+    // An analysed past paper drives Past Paper Drill + exam-fit in readiness
+    localStorage.setItem('kn_exam_style_income_tax', JSON.stringify({ papers: [{ name: '2024 Paper 1',
+      analysis: { style: 'scenario-based with calculations', questionTypes: ['calculation', 'discussion'], topicAreas: ['gross income', 'deductions'] },
+      questions: [{ question: 'Calculate the taxable income of a resident earning R500 000.', answer: 'R500 000 less allowable deductions.' },
+                  { question: 'Discuss whether a capital receipt forms part of gross income.', answer: 'It does not — capital receipts are excluded.' }] }] }));
+  });
+  rec('Seed library', 'WORKS', '3 topics, SRS history, weak spots, analysed past paper');
+
+  // ── 1. Library + its tabs (Notes / Examples / Questions / Mastery) ──────
+  await feat('Library', async () => {
+    await go('library');
+    const t = await text();
+    if (!/Gross Income/.test(t)) throw new Error('topics not listed');
+    await shot('01-library');
+    return 'lists all 3 topics with mastery';
+  });
+
+  await feat('Worked Examples', async () => {
+    await page.evaluate(() => { const n = nodeStore.getAll().find(x => x.title === 'Gross Income'); NodeDetailView.open(n.id); });
+    await page.waitForTimeout(800); await dismissTour();
+    const tabs = await page.locator('.detail-tab-btn').allInnerTexts().catch(() => []);
+    await page.locator('.detail-tab-btn', { hasText: /example/i }).first().click({ timeout: 5000 });
+    await page.waitForTimeout(500);
+    const t = await text();
+    if (!/Calculating gross income/.test(t)) throw new Error('example not shown; tabs=' + tabs.join('/'));
+    await shot('02-examples');
+    return 'worked example opens from the Examples tab';
+  });
+
+  await feat('Review in your textbook', async () => {
+    await page.locator('.detail-tab-btn', { hasText: /mastery/i }).first().click({ timeout: 5000 });
+    await page.waitForTimeout(600);
+    const t = await text();
+    if (!/textbook/i.test(t)) throw new Error('missed-question list not found on Mastery tab');
+    await shot('03-review-in-textbook');
+    return 'lists the questions answered wrong, worst first';
+  });
+
+  // ── 2. Review / spaced repetition ───────────────────────────────────────
+  await feat('Review / Spaced Repetition', async () => {
+    await go('review');
+    const t = await text();
+    await shot('04-review');
+    if (!/Today|Due|Review/i.test(t)) throw new Error('review view empty');
+    return 'due cards surface with Today / All / Weak Spots modes';
+  });
+
+  await feat('Weak Spots mode', async () => {
+    const btn = page.locator('text=Weak Spots').first();
+    if (!(await btn.count())) throw new Error('Weak Spots control not found');
+    await btn.click({ timeout: 5000 }); await page.waitForTimeout(700);
+    await shot('05-weak-spots');
+    return 'hardest-missed questions across the library';
+  });
+
+  await feat('Leech Breaker', async () => {
+    const r = await page.evaluate(() => {
+      if (typeof LeechDetector === 'undefined') return { missing: true };
+      const n = nodeStore.getAll().find(x => x.title === 'Gross Income');
+      const leeches = (n.questions || []).filter(q => LeechDetector.isLeechCard(n, q.id));
+      return { count: leeches.length, all: LeechDetector.leeches(nodeStore.getAll()).length, threshold: LeechDetector.THRESHOLD };
+    });
+    if (r.missing) throw new Error('LeechDetector not loaded');
+    if (!r.count) throw new Error('a 5-times-failed card was not flagged as a leech');
+    return r.count + ' card over the ' + r.threshold + '-fail threshold flagged for understanding, not more drilling';
+  });
+
+  await feat('New-Card Pacing', async () => {
+    const b = await page.evaluate(() => ({ light: NewCardPacer.budget('light'), normal: NewCardPacer.budget('normal'), deep: NewCardPacer.budget('deep') }));
+    if (!(b.light < b.normal && b.normal < b.deep)) throw new Error('budgets not ordered: ' + JSON.stringify(b));
+    return 'daily new-card budget scales light ' + b.light + ' < normal ' + b.normal + ' < deep ' + b.deep;
+  });
+
+  // ── 3. Exam modes ───────────────────────────────────────────────────────
+  await feat('Exam — Report Card', async () => {
+    await go('competency');
+    await page.locator('.comp-mode-btn[data-mode="report"]').click(); await page.waitForTimeout(300);
+    await page.locator('#comp-start-btn').click(); await page.waitForTimeout(2500);
+    const t = await text();
+    await shot('06-report-card');
+    if (!/Income Tax/.test(t)) throw new Error('no subject breakdown produced');
+    return 'strengths vs gaps per subject, on-device';
+  });
+
+  await feat('Exam — Timed Quiz', async () => {
+    await page.locator('.comp-mode-btn[data-mode="timed"]').click(); await page.waitForTimeout(300);
+    await page.locator('#comp-start-btn').click(); await page.waitForTimeout(1200);
+    const t = await text();
+    if (!/\d+:\d\d/.test(t)) throw new Error('countdown timer not shown');
+    await shot('07-timed-quiz');
+    const hasAnswerBox = await page.locator('#timed-answer').count();
+    if (!hasAnswerBox) throw new Error('no answer input rendered');
+    return 'countdown runs, questions answerable one at a time';
+  });
+
+  await feat('Exam — AI Exam (matching, free)', async () => {
+    await go('competency');
+    await page.locator('.comp-mode-btn[data-mode="ai-quiz"]').click(); await page.waitForTimeout(300);
+    await page.locator('#comp-start-btn').click();
+    await page.waitForSelector('#ai-jump', { timeout: 10000 });
+    const info = await page.evaluate(() => ({ total: CompetencyView._session.length,
+      matchAt: CompetencyView._session.findIndex(s => !!s.match) }));
+    if (info.matchAt < 0) throw new Error('no matching set in the paper; slots=' + info.total);
+    // Jump to the slot holding the matching set (smart selection may not put it first)
+    await page.locator('#ai-jump [data-q="' + info.matchAt + '"]').click();
+    await page.waitForSelector('#mp-rows .mp-row', { timeout: 10000 });
+    await shot('08-ai-exam-matching');
+    return 'paper of ' + info.total + ' slots; matching set at slot ' + (info.matchAt + 1) + ', renders as the two-column matcher';
+  });
+
+  // ── 4. Progress / dashboard surfaces ────────────────────────────────────
+  await feat('Exam Readiness', async () => {
+    await go('dashboard');
+    const t = await text();
+    await shot('09-dashboard');
+    if (!/readiness/i.test(t)) throw new Error('readiness card not on Progress');
+    const s = await page.evaluate(() => ExamReadiness.assess(nodeStore.getAll(), null));
+    if (typeof s.score !== 'number') throw new Error('no score computed');
+    return 'score ' + s.score + '/100 with prioritised next actions, no AI cost';
+  });
+
+  await feat('Past Paper Drill', async () => {
+    const r = await page.evaluate(() => {
+      if (typeof PastPaperDrill === 'undefined') return { missing: true };
+      return { has: typeof PastPaperDrill.open === 'function' || typeof PastPaperDrill.start === 'function',
+               keys: Object.keys(PastPaperDrill).slice(0, 8) };
+    });
+    if (r.missing) throw new Error('PastPaperDrill not loaded');
+    if (!r.has) throw new Error('no open/start entry point; keys=' + r.keys.join(','));
+    return 'authentic past-paper questions replayable offline';
+  });
+
+  await feat('Streak tracking', async () => {
+    const s = await page.evaluate(() => { StreakTracker.recordActivity(); return StreakTracker.getStats(); });
+    if (typeof s.streak !== 'number') throw new Error('no streak stats');
+    return 'streak ' + s.streak + 'd (longest ' + s.longest + ')';
+  });
+
+  // ── 5. Study surfaces ───────────────────────────────────────────────────
+  await feat('Guided Study', async () => {
+    await go('guided');
+    const t = await text();
+    await shot('10-guided');
+    if (!/Gross Income|study|topic/i.test(t)) throw new Error('guided view empty');
+    return 'topic picker + 6-step walkthrough (question-bank topics get a drill)';
+  });
+
+  await feat('Study Plan', async () => {
+    await go('studyplan');
+    const t = await text();
+    await shot('11-studyplan');
+    if (!/plan/i.test(t)) throw new Error('study plan view empty');
+    return 'view renders; plan creation is the builder flow';
+  });
+
+  await feat('Add / Scan Content (entry)', async () => {
+    await go('upload');
+    const t = await text();
+    await shot('12-upload');
+    if (!/Revision Questions/i.test(t) || !/Past Exam Paper/i.test(t)) throw new Error('upload entry points missing');
+    return 'upload zone + Revision Questions + Past Exam Paper entry points present';
+  });
+
+  await feat('Study Colors', async () => {
+    const r = await page.evaluate(() => {
+      if (typeof AccentTheme === 'undefined') return { missing: true };
+      const read = () => getComputedStyle(document.documentElement).getPropertyValue('--accent').trim();
+      const before = read(), seen = {};
+      for (const m of ['focus', 'growth', 'energy', 'amber']) { AccentTheme.set(m); seen[m] = read(); }
+      return { before, seen, persisted: AccentTheme.get() };
+    });
+    if (r.missing) throw new Error('AccentTheme not loaded');
+    const distinct = new Set(Object.values(r.seen));
+    if (distinct.size < 3) throw new Error('accent did not actually change: ' + JSON.stringify(r.seen));
+    await shot('12b-study-colors');
+    return 'focus/growth/energy/amber give distinct accents ' + JSON.stringify(r.seen) + ', choice persists';
+  });
+
+  // ── 6. AI-dependent features: confirm they degrade gracefully ───────────
+  await feat('AI features without a key (graceful)', async () => {
+    const r = await page.evaluate(() => ({ hasKey: AIService.hasApiKey(), demo: /Demo mode|no AI configured/i.test(document.body.innerText) }));
+    if (r.hasKey) throw new Error('unexpected API key present');
+    // Opening the coach with no key must warn, not crash.
+    await page.evaluate(() => { try { StudyCoach.open(); } catch (e) { window.__coachThrew = e.message; } });
+    await page.waitForTimeout(600);
+    const threw = await page.evaluate(() => window.__coachThrew || '');
+    if (threw) throw new Error('StudyCoach.open threw: ' + threw);
+    await shot('13-no-ai-key');
+    return 'demo banner shown; coach prompts for a key instead of crashing';
+  });
+
+  await browser.close();
+
+  // ── Report ──────────────────────────────────────────────────────────────
+  const broken = rows.filter(r => r.status === 'BROKEN');
+  console.log('\n' + rows.length + ' surfaces exercised — ' + (rows.length - broken.length) + ' OK, ' + broken.length + ' BROKEN');
+  if (broken.length) { console.log('\nBROKEN:'); broken.forEach(b => console.log('  - ' + b.feature + ': ' + b.note)); }
+  require('fs').writeFileSync(OUT + '/report.json', JSON.stringify(rows, null, 2));
+  process.exit(broken.length ? 1 : 0);
+})().catch(e => { console.error('SWEEP ERROR: ' + e.message); process.exit(2); });

--- a/knowledgenode/qa/browser/matching-drive.js
+++ b/knowledgenode/qa/browser/matching-drive.js
@@ -1,0 +1,151 @@
+/**
+ * Drive the real app in Chromium: seed a matching worksheet, play the exam,
+ * and verify coach memory survives a genuine page reload.
+ */
+const { chromium } = require('/opt/node22/lib/node_modules/playwright');
+const OUT = require('path').join(__dirname,'shots','matching');
+const URL = 'http://127.0.0.1:8099/index.html';
+
+const OPTS = 'A — 50%\nB — Medical aid contribution paid on behalf of an employee\nC — 20%\nD — 0%\nE — Allowable retirement contributions';
+const INSTR = 'Match the items in COLUMN B with those in COLUMN A:';
+
+(async () => {
+  const browser = await chromium.launch({ args: ['--no-sandbox'] });
+  const page = await browser.newPage({ viewport: { width: 430, height: 1600 } });
+  const errors = [];
+  page.on('console', m => { if (m.type() === 'error') errors.push(m.text()); });
+  page.on('pageerror', e => errors.push('PAGEERROR: ' + e.message));
+
+  const step = [];
+  const log = (n, ok, x) => { step.push({ n, ok, x }); console.log((ok ? '  PASS  ' : '  FAIL  ') + n + (x ? '  → ' + x : '')); };
+
+  await page.goto(URL, { waitUntil: 'load' });
+  await page.waitForFunction(() => typeof App!=='undefined' && typeof nodeStore!=='undefined' && typeof CompetencyView!=='undefined', null, { timeout: 15000 });
+  log('app boots in a real browser', true);
+
+  // The red diagnostic banner is the app's own "something threw" signal.
+  const banner = await page.evaluate(() => {
+    const b = document.getElementById('kn-error-banner');
+    return b && b.style.display !== 'none' ? b.textContent.trim() : '';
+  });
+  log('no JS error banner on load', !banner, banner);
+
+  // ── Seed a matching worksheet the way an import would ──
+  await page.evaluate(async ({ OPTS, INSTR }) => {
+    const mk = (p, a) => ({ id: KnowledgeNode._generateQuestionId(), type: 'recall', question: INSTR + '\n' + p + '\n' + OPTS, answer: a });
+    const n = new KnowledgeNode({
+      title: 'Income Tax — Revision Questions', subject: 'Income Tax', processingStatus: 'ready',
+      questions: [
+        mk('7. Inclusion rate of travel allowance for PAYE purposes when employee uses vehicle 50% for business purposes', 'A — 50%'),
+        mk('8. Current withholding tax on dividends', 'C — 20%'),
+        mk('9. Fringe benefit example', 'B — Medical aid contribution paid on behalf of an employee'),
+        mk('10. Deductible against retirement funding income', 'E — Allowable retirement contributions'),
+      ],
+    });
+    await nodeStore.save(n);
+  }, { OPTS, INSTR });
+  log('a matching worksheet was imported', true);
+
+  // First run shows the onboarding tour (it can appear a moment after load, and
+  // again once a topic exists) — dismiss it the way a user would, whenever it shows.
+  const dismissTour = async () => {
+    for (let i = 0; i < 3; i++) {
+      const ov = page.locator('#onboarding-overlay');
+      if (!(await ov.count()) || !(await ov.isVisible().catch(() => false))) return false;
+      await page.locator('#ob-skip').click({ timeout: 5000 }).catch(() => {});
+      await page.waitForSelector('#onboarding-overlay', { state: 'hidden', timeout: 5000 }).catch(() => {});
+    }
+    return true;
+  };
+  await page.waitForSelector('#onboarding-overlay', { timeout: 4000 }).catch(() => {});
+  await dismissTour();
+  log('the first-run tour can be dismissed', !(await page.locator('#onboarding-overlay').isVisible().catch(() => false)));
+
+  // ── Navigate to the Exam tab the way the nav button does ──
+  await page.evaluate(() => App.navigateTo('competency'));
+  await page.waitForSelector('#comp-content', { timeout: 10000 });
+  log('the Exam tab opens', true);
+  await page.screenshot({ path: OUT + '/shot-0-exam-tab.png', fullPage: true });
+
+  // ── Start the AI Exam by clicking the real buttons ──
+  await page.locator('.comp-mode-btn[data-mode="ai-quiz"]').click();
+  log('the AI Exam mode button selects', await page.locator('.comp-mode-btn[data-mode="ai-quiz"].active').count() === 1);
+  await page.locator('#comp-start-btn').click();
+  await page.waitForSelector('#mp-rows .mp-row', { timeout: 10000 });
+
+  const rows = await page.locator('#mp-rows .mp-row').count();
+  const bank = await page.locator('#mp-bank .mp-opt').count();
+  log('Column A renders one row per item', rows === 4, 'rows=' + rows);
+  log('Column B renders the shared answer bank', bank === 5, 'options=' + bank);
+  const headings = await page.evaluate(() => document.body.innerText);
+  log('the two columns are labelled', /COLUMN A/i.test(headings) && /COLUMN B/i.test(headings));
+  log('the instruction shows once as a heading', (headings.match(/Match the items in COLUMN B/g) || []).length === 1);
+  await page.screenshot({ path: OUT + '/shot-1-unanswered.png', fullPage: true });
+
+  await dismissTour();
+  // ── Tap to match: item then option ──
+  await page.locator('#mp-rows .mp-row').nth(0).click();
+  await page.locator('#mp-bank .mp-opt[data-letter="A"]').click();
+  await page.locator('#mp-rows .mp-row').nth(1).click();
+  await page.locator('#mp-bank .mp-opt[data-letter="C"]').click();
+  await page.locator('#mp-rows .mp-row').nth(2).click();
+  await page.locator('#mp-bank .mp-opt[data-letter="B"]').click();
+  await page.locator('#mp-rows .mp-row').nth(3).click();
+  await page.locator('#mp-bank .mp-opt[data-letter="D"]').click();   // deliberately WRONG (should be E)
+
+  const badges = await page.locator('#mp-rows .mp-badge').allInnerTexts();
+  log('each tapped item shows its assigned letter', badges.join('') === 'ACBD', 'badges=' + badges.join(''));
+  await page.screenshot({ path: OUT + '/shot-2-matched.png', fullPage: true });
+
+  // ── Change of mind on the last one ──
+  await page.locator('#mp-rows .mp-row').nth(3).click();
+  await page.locator('#mp-bank .mp-opt[data-letter="E"]').click();
+  const after = await page.locator('#mp-rows .mp-badge').allInnerTexts();
+  log('re-tapping changes a choice (D → E)', after.join('') === 'ACBE', 'badges=' + after.join(''));
+
+  // ── Submit: must mark with ZERO network calls ──
+  let requests = 0;
+  page.on('request', r => { if (!r.url().startsWith('http://127.0.0.1:8099')) requests++; });
+  page.on('dialog', d => d.accept());
+  await page.evaluate(() => CompetencyView._finishAIExam());
+  await page.waitForSelector('text=AI Exam Results', { timeout: 15000 });
+  const resultText = await page.evaluate(() => document.body.innerText);
+  log('the exam is marked and results shown', /AI Exam Results/.test(resultText));
+  log('all four pairs marked correct (100 average)', /100\/100 average/.test(resultText), (resultText.match(/\d+\/100 average/) || [])[0]);
+  log('marking made no outbound network call', requests === 0, 'external requests=' + requests);
+  await page.screenshot({ path: OUT + '/shot-3-results.png', fullPage: true });
+
+  // ── Coach memory across a REAL reload ──
+  await page.evaluate(() => {
+    CoachFacts.clear(); CoachEngine.resetMemory();
+    CoachEngine.extractSignal('Noted.\n[[FACT: exam dates = 31 August]]\n[[SIGNAL:x]]');
+    CoachEngine.extractSignal('Corrected.\n[[FACT: exam dates = first week of December]]\n[[SIGNAL:x]]');
+    CoachEngine.extractSignal('Got it.\n[[FACT: daily study time = 30 min morning + 30 min evening]]\n[[SIGNAL:x]]');
+    CoachEngine.history = [{ role: 'user', text: 'i can do 30 minutes morning and evening' }, { role: 'coach', text: 'Noted.' }];
+    CoachEngine.saveHistory();
+  });
+  await page.reload({ waitUntil: 'load' });
+  await page.waitForFunction(() => typeof CoachFacts!=='undefined' && typeof CoachEngine!=='undefined', null, { timeout: 15000 });
+  const mem = await page.evaluate(() => {
+    CoachEngine.loadHistory();
+    return { facts: CoachFacts.all(), block: CoachFacts.block(), hist: CoachEngine.history.length };
+  });
+  log('facts survive a real page reload', mem.facts.length === 2, JSON.stringify(mem.facts.map(f => f.key)));
+  log('the corrected exam date replaced the old one', /first week of December/.test(mem.block) && !/31 August/.test(mem.block));
+  log('the conversation survives a reload', mem.hist === 2, 'messages=' + mem.hist);
+
+  const banner2 = await page.evaluate(() => {
+    const b = document.getElementById('kn-error-banner');
+    return b && b.style.display !== 'none' ? b.textContent.trim() : '';
+  });
+  log('no JS error banner after the whole run', !banner2, banner2);
+  // This sandbox blocks outbound CDNs (Google Fonts, pdf.js, tesseract), so
+  // those load failures are environmental, not app faults. Everything else counts.
+  const appErrors = errors.filter(e => !/Failed to load resource|ERR_CONNECTION_RESET|ERR_TUNNEL_CONNECTION_FAILED|ERR_NAME_NOT_RESOLVED/.test(e));
+  log('no app-level console errors (CDN blocks in this sandbox ignored)', appErrors.length === 0, appErrors.slice(0, 3).join(' | '));
+
+  await browser.close();
+  const failed = step.filter(s => !s.ok).length;
+  console.log('\n' + (failed ? failed + ' CHECK(S) FAILED' : 'ALL ' + step.length + ' real-browser checks passed'));
+  process.exit(failed ? 1 : 0);
+})().catch(e => { console.error('DRIVER ERROR: ' + e.message); process.exit(2); });

--- a/knowledgenode/qa/browser/mock-ai-server.js
+++ b/knowledgenode/qa/browser/mock-ai-server.js
@@ -1,0 +1,117 @@
+/**
+ * mockai.js — serves the app AND a fake OpenAI-compatible AI endpoint from the
+ * SAME origin (the app's CSP allows connect-src 'self', so a same-origin
+ * endpoint is reachable where a random localhost port would be blocked).
+ *
+ * This exercises the app's real network path — request building, HTTP, JSON
+ * parsing, tag extraction, error handling — with deterministic replies and no
+ * API key, no cost, no rate limits. It cannot judge answer QUALITY; that is the
+ * one thing that needs a real key.
+ *
+ *   node mockai.js [port] [wwwdir]
+ *   POST /v1/chat/completions   → canned reply chosen by prompt content
+ *   POST /__fail/<code>/v1/...  → forces an HTTP error, to test failure paths
+ */
+const http = require('http'), fs = require('fs'), path = require('path');
+const PORT = +(process.argv[2] || 8099);
+const WWW = process.argv[3] || require('path').join(__dirname,'..','..','www');
+const MIME = { '.html':'text/html', '.js':'text/javascript', '.css':'text/css', '.json':'application/json',
+               '.svg':'image/svg+xml', '.png':'image/png', '.jpg':'image/jpeg', '.webmanifest':'application/manifest+json' };
+
+let calls = [];   // every request the app made, for assertions
+
+/** Pick a canned reply based on what the app asked for. */
+function reply(body) {
+  const msgs = body.messages || [];
+  const sys = String((body.system) || msgs.filter(m => m.role === 'system').map(m => m.content).join('\n'));
+  const user = String(msgs.filter(m => m.role === 'user').map(m => typeof m.content === 'string' ? m.content : JSON.stringify(m.content)).join('\n'));
+  const all = sys + '\n' + user;
+
+  // Study coach — must exercise the FACT/SIGNAL/ACTION tag pipeline.
+  if (/study coach|CONFIRMED FACTS|\[\[SIGNAL:/.test(all)) {
+    let out = 'Start with Gross Income — it is your weakest topic and it is due for review today. Do one 30-minute pass tonight.';
+    if (/december|exam date|how many hours|how much time/i.test(user))
+      out += '\n[[FACT: exam dates = first week of December]]\n[[FACT: daily study time = 30 min morning + 30 min evening]]';
+    if (/start|where should i/i.test(user)) out += '\n[[ACTION:startGuided|node=Gross Income]]';
+    out += '\n[[SIGNAL:Student wants a concrete starting point; weakest area is Gross Income.]]';
+    return out;
+  }
+  // Question extraction from an upload (revision questions / past paper).
+  if (/Extract EVERY question|"questions":\[/.test(all)) {
+    return JSON.stringify({ questions: [
+      { question: 'Define gross income.', answer: 'The total amount received by or accrued to a resident, excluding capital receipts.' },
+      { question: 'Match: 1. Dividends withholding tax\nA — 50%\nB — 20%\nC — 0%', answer: 'B — 20%' },
+      { question: 'Calculate the taxable income of a resident earning R500 000 with R36 000 deductions.', answer: 'R464 000' },
+    ] });
+  }
+  // Marking. The app states its output contract in the prompt, so honour that:
+  // a batch call asks for {"results":[...]}, a single answer asks for a flat object.
+  if (/"results"\s*:/.test(all)) {
+    const n = Math.max(1, (all.match(/^\s*\d+\.\s+Question:/gm) || ['x']).length);
+    return JSON.stringify({ results: Array.from({ length: n }, () => (
+      { score: 82, correct: true, feedback: 'Good — you captured the key elements.', keyPointsMissed: [] })) });
+  }
+  if (/"keyPointsMissed"/.test(all)) {
+    return JSON.stringify({ correct: true, score: 82, feedback: 'Good — you captured the key elements.', keyPointsMissed: [] });
+  }
+  // Lecture slides.
+  if (/slide/i.test(all)) {
+    return JSON.stringify({ slides: [
+      { title: 'Gross Income', bullets: ['Total amount received or accrued', 'Excludes capital receipts'], narration: 'Gross income is the starting point of the tax calculation.' },
+      { title: 'Worked example', bullets: ['Salary R360 000 is income', 'House sale is capital'], narration: 'Classify each receipt before summing.' },
+    ] });
+  }
+  // Understanding check.
+  if (/understanding|evaluate their answer|gaps/i.test(all)) {
+    return JSON.stringify({ score: 70, feedback: 'Solid grasp of the definition; be clearer on the capital exclusion.', keyPointsMissed: ['capital nature exclusion'] });
+  }
+  // Note processing / generated questions.
+  if (/recall|application/.test(all)) {
+    return JSON.stringify({ recall: [{ question: 'What is gross income?', answer: 'Total received or accrued, excluding capital.', accept: ['total amount received'] }],
+                            application: [{ question: 'A resident sells a factory. Is it gross income?', answer: 'No — capital in nature.' }] });
+  }
+  return 'Mock reply.';
+}
+
+http.createServer((req, res) => {
+  const u = new URL(req.url, 'http://x');
+  let p = u.pathname;
+
+  // Forced-failure route so error handling can be tested.
+  const failMatch = p.match(/^\/__fail\/(\d{3})(\/.*)$/);
+  const forcedCode = failMatch ? +failMatch[1] : 0;
+  if (failMatch) p = failMatch[2];
+
+  if (req.method === 'POST' && /\/(chat\/completions|messages|generateContent)$/.test(p)) {
+    let raw = '';
+    req.on('data', c => raw += c);
+    req.on('end', () => {
+      let body = {}; try { body = JSON.parse(raw || '{}'); } catch (e) {}
+      calls.push({ at: Date.now(), path: p, body });
+      res.setHeader('Access-Control-Allow-Origin', '*');
+      if (forcedCode) { res.writeHead(forcedCode, { 'Content-Type': 'application/json' });
+        return res.end(JSON.stringify({ error: { message: 'Forced ' + forcedCode + ' for testing' } })); }
+      const text = reply(body);
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({
+        id: 'mock', object: 'chat.completion', model: body.model || 'mock',
+        choices: [{ index: 0, message: { role: 'assistant', content: text }, finish_reason: 'stop' }],
+        content: [{ type: 'text', text }],                       // Anthropic shape too
+        candidates: [{ content: { parts: [{ text }] } }],        // Gemini shape too
+        usage: { prompt_tokens: 100, completion_tokens: 50 },
+      }));
+    });
+    return;
+  }
+  if (p === '/__calls') { res.writeHead(200, { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' });
+    return res.end(JSON.stringify(calls)); }
+  if (p === '/__reset') { calls = []; res.writeHead(200); return res.end('ok'); }
+  if (req.method === 'OPTIONS') { res.writeHead(204, { 'Access-Control-Allow-Origin': '*', 'Access-Control-Allow-Headers': '*' }); return res.end(); }
+
+  // Static files
+  if (p === '/') p = '/index.html';
+  const file = path.join(WWW, decodeURIComponent(p));
+  if (!file.startsWith(WWW) || !fs.existsSync(file) || fs.statSync(file).isDirectory()) { res.writeHead(404); return res.end('not found'); }
+  res.writeHead(200, { 'Content-Type': MIME[path.extname(file)] || 'application/octet-stream', 'Cache-Control': 'no-store' });
+  fs.createReadStream(file).pipe(res);
+}).listen(PORT, () => console.log('mock AI + app on http://127.0.0.1:' + PORT));

--- a/knowledgenode/qa/browser/option-labels-drive.js
+++ b/knowledgenode/qa/browser/option-labels-drive.js
@@ -1,0 +1,122 @@
+/**
+ * Two display fixes, driven in a real browser:
+ *
+ *   1. Option letters get a closing bracket — "A Employees…" used to run the
+ *      letter straight into the text; it now reads "A) Employees…".
+ *   2. Weak-topic names on the exam Report Card are separate pills. They had no
+ *      styling at all, so they collapsed into one unreadable run
+ *      ("Revision question 8Revision question 7Revision question 6…").
+ *
+ *   node mock-ai-server.js 8099 &
+ *   node option-labels-drive.js
+ */
+const { chromium } = require('/opt/node22/lib/node_modules/playwright');
+const path = require('path');
+const OUT = path.join(__dirname, 'shots', 'labels');
+const BASE = 'http://127.0.0.1:8099';
+require('fs').mkdirSync(OUT, { recursive: true });
+
+let pass = 0, fail = 0;
+const ok = (n, c, x = '') => { c ? (pass++, console.log('  ✓ ' + n)) : (fail++, console.error('  ✗ ' + n + (x ? '  → ' + x : ''))); };
+
+const BARE = 'Provisional tax is payable by:\n'
+  + 'A Employees who earn salary income above R 1 million\n'
+  + 'B Sole proprietors\n'
+  + 'C Individuals (over the age of 65) who earn rental, interest or dividends of R 100 000\n'
+  + 'D All of the above';
+
+(async () => {
+  const browser = await chromium.launch({ args: ['--no-sandbox'] });
+  const page = await browser.newPage({ viewport: { width: 430, height: 1400 } });
+  const errors = [];
+  page.on('pageerror', e => errors.push('PAGEERROR: ' + e.message));
+  page.on('dialog', d => d.accept());
+
+  await page.goto(BASE + '/index.html', { waitUntil: 'load' });
+  await page.waitForFunction(() => typeof App !== 'undefined' && typeof KNText !== 'undefined', null, { timeout: 15000 });
+  await page.waitForSelector('#onboarding-overlay', { timeout: 4000 }).catch(() => {});
+  for (let i = 0; i < 3; i++) {
+    const ov = page.locator('#onboarding-overlay');
+    if (!(await ov.count()) || !(await ov.isVisible().catch(() => false))) break;
+    await page.locator('#ob-skip').click({ timeout: 4000 }).catch(() => {});
+    await page.waitForSelector('#onboarding-overlay', { state: 'hidden', timeout: 4000 }).catch(() => {});
+  }
+
+  console.log('Option labels and topic pills');
+
+  console.log('1) Bare-letter options are labelled "A)" when shown as text');
+  const labelled = await page.evaluate(t => KNText.html(t), BARE);
+  ok('"A)" appears', /A\)/.test(labelled), labelled.slice(0, 90));
+  ok('every option is bracketed', ['A','B','C','D'].every(L => labelled.includes(L + ')')));
+  ok('the letter no longer runs into the option text', !/A Employees/.test(labelled));
+  ok('the option text itself is intact', /Employees who earn salary income/.test(labelled));
+  ok('the stem is untouched', /Provisional tax is payable by:/.test(labelled));
+  const prose = await page.evaluate(() => KNText.html('A resident must pay tax.\nBecause of the rule.\nCarry on.'));
+  ok('ordinary prose is not relabelled', !/A\)/.test(prose), prose.slice(0, 70));
+
+  console.log('2) The same question becomes tappable choices in a quiz');
+  // Seed the whole library once — a worksheet imported as eight separate
+  // "Revision question N" topics, which is what the student actually has.
+  await page.evaluate(async (q) => {
+    for (let i = 1; i <= 8; i++) {
+      await nodeStore.save(new KnowledgeNode({
+        title: 'Revision question ' + i, subject: 'Income Tax Returns', processingStatus: 'ready',
+        questions: [{ id: KnowledgeNode._generateQuestionId(), type: 'recall',
+                      question: i === 1 ? q : 'Question ' + i, answer: i === 1 ? 'D All of the above' : 'a' }],
+      }));
+    }
+  }, BARE);
+  await page.evaluate(() => App.navigateTo('competency'));
+  await page.waitForSelector('#comp-content', { timeout: 10000 });
+  await page.locator('.comp-mode-btn[data-mode="ai-quiz"]').click();
+  await page.locator('#comp-start-btn').click();
+  await page.waitForSelector('#ai-jump', { timeout: 10000 });
+  // Smart selection may not put the multiple-choice question first — jump to it.
+  const at = await page.evaluate(() => CompetencyView._session
+    .findIndex(s => !s.match && MatchOptions.parse(s.q.question)));
+  if (at < 0) throw new Error('the MCQ was not in the paper');
+  await page.locator('#ai-jump [data-q="' + at + '"]').click();
+  await page.waitForSelector('.match-opt', { timeout: 10000 });
+  const opts = await page.locator('.match-opt').count();
+  ok('the question renders as tappable options, not a text blob', opts === 4, 'options=' + opts);
+  const badges = await page.locator('.match-opt span:first-child').allInnerTexts();
+  ok('each badge shows the bracket', badges.join(',') === 'A),B),C),D)', badges.join(','));
+  // Scope to the quiz card — other views keep hidden textareas in the DOM.
+  const noBox = await page.locator('.quiz-card textarea[placeholder]').count();
+  ok('no "write your answer" box for a multiple-choice question', noBox === 0, 'found ' + noBox);
+  await page.screenshot({ path: OUT + '/01-bracketed-options.png', fullPage: true });
+
+  console.log('3) Report Card topic names are separate, readable pills');
+  // Leave the exam and come back so the panel is not left mid-session.
+  await page.evaluate(() => App.navigateTo('library'));
+  await page.waitForTimeout(500);
+  await page.evaluate(() => { App.navigateTo('competency'); CompetencyView._started = false; CompetencyView.refresh(); });
+  await page.waitForSelector('.comp-mode-btn[data-mode="report"]', { timeout: 10000 });
+  await page.locator('.comp-mode-btn[data-mode="report"]').click();
+  await page.locator('#comp-start-btn').click();
+  await page.waitForSelector('.comp-topic-pill', { timeout: 15000 });
+  const pills = await page.locator('.comp-topic-pill').count();
+  ok('weak topics render as individual pills', pills >= 3, 'pills=' + pills);
+  const spaced = await page.evaluate(() => {
+    const els = [...document.querySelectorAll('.comp-topic-pill')].slice(0, 2);
+    if (els.length < 2) return { ok: false, why: 'not enough pills' };
+    const a = els[0].getBoundingClientRect(), b = els[1].getBoundingClientRect();
+    const apart = (b.left >= a.right - 1) || (b.top >= a.bottom - 1);
+    const styled = getComputedStyle(els[0]).borderRadius !== '0px';
+    return { ok: apart && styled, apart, styled };
+  });
+  ok('pills are visually separated, not run together', spaced.ok, JSON.stringify(spaced));
+  const runOn = await page.evaluate(() => /question \d+Revision/.test(document.body.innerText));
+  ok('topic names no longer collide ("…8Revision question 7")', !runOn);
+  await page.screenshot({ path: OUT + '/02-topic-pills.png', fullPage: true });
+
+  console.log('4) Nothing broke');
+  const b = await page.evaluate(() => { const el = document.getElementById('kn-error-banner');
+    return el && el.style.display !== 'none' ? el.textContent.trim().slice(0, 200) : ''; });
+  ok('no JS error banner', !b, b);
+  ok('no uncaught page errors', errors.length === 0, errors[0] || '');
+
+  await browser.close();
+  console.log('\n' + (fail ? 'FAIL: ' + fail : 'ALL ' + pass + ' label checks passed'));
+  process.exit(fail ? 1 : 0);
+})().catch(e => { console.error('DRIVER ERROR: ' + e.message); process.exit(2); });

--- a/knowledgenode/qa/browser/review-routing-drive.js
+++ b/knowledgenode/qa/browser/review-routing-drive.js
@@ -1,0 +1,129 @@
+/**
+ * Full calculations are hidden from review and kept for the exam.
+ *
+ * The important half of this is the second half: hiding them must not make them
+ * disappear from the app, and every "due" counter must agree with what review
+ * will actually serve — otherwise the app promises cards it then refuses to show.
+ *
+ *   node mock-ai-server.js 8099 &
+ *   node review-routing-drive.js
+ */
+const { chromium } = require('/opt/node22/lib/node_modules/playwright');
+const path = require('path');
+const OUT = path.join(__dirname, 'shots', 'routing');
+const BASE = 'http://127.0.0.1:8099';
+require('fs').mkdirSync(OUT, { recursive: true });
+
+let pass = 0, fail = 0;
+const ok = (n, c, x = '') => { c ? (pass++, console.log('  ✓ ' + n)) : (fail++, console.error('  ✗ ' + n + (x ? '  → ' + x : ''))); };
+
+const CHRIS = 'Chris, whose age next birthday will be 65, donated a usufructuary interest in a house in East London '
+  + 'valued at R 3 250 000 to his sister, Catherine (aged 57) and the bare dominium to his son Nicholas. '
+  + 'Chris made no other donations in the year.\n\nCalculate the donations tax payable by Chris.';
+const CHRIS_A = 'Value of usufruct:\nAnnual Value: 12% x R 3 250 000 = R 390 000\nPresent value based on life expectancy\nDonations tax = R 626 000';
+
+(async () => {
+  const browser = await chromium.launch({ args: ['--no-sandbox'] });
+  const page = await browser.newPage({ viewport: { width: 430, height: 1400 } });
+  const errors = [];
+  page.on('pageerror', e => errors.push('PAGEERROR: ' + e.message));
+  page.on('dialog', d => d.accept());
+
+  await page.goto(BASE + '/index.html', { waitUntil: 'load' });
+  await page.waitForFunction(() => typeof App !== 'undefined' && typeof QuestionKind !== 'undefined', null, { timeout: 15000 });
+  await page.waitForSelector('#onboarding-overlay', { timeout: 4000 }).catch(() => {});
+  for (let i = 0; i < 3; i++) {
+    const ov = page.locator('#onboarding-overlay');
+    if (!(await ov.count()) || !(await ov.isVisible().catch(() => false))) break;
+    await page.locator('#ob-skip').click({ timeout: 4000 }).catch(() => {});
+    await page.waitForSelector('#onboarding-overlay', { state: 'hidden', timeout: 4000 }).catch(() => {});
+  }
+
+  // A topic holding both kinds, every card already due so nothing is hidden by scheduling.
+  await page.evaluate(async ({ cq, ca }) => {
+    const DAY = 86400000, now = Date.now();
+    const q = (question, answer) => ({ id: KnowledgeNode._generateQuestionId(), type: 'recall', question, answer });
+    const n = new KnowledgeNode({ title: 'Revision question 3', subject: 'Income Tax Returns', processingStatus: 'ready',
+      questions: [
+        q('Define gross income.', 'Total amount received or accrued, excluding capital receipts'),
+        q('What annual value percentage is used to value a usufruct?', '12%'),
+        q('Name one exclusion from gross income.', 'Receipts of a capital nature'),
+        q(cq, ca),
+      ] });
+    n.questions.forEach(x => { n.srsState[x.id] = { repetitions: 2, interval: 3, ease: 2.4, nextReview: now - DAY, lastReview: now - 4 * DAY }; });
+    n.weakQuestions = [{ id: n.questions[3].id, count: 5, lastMissed: now }];   // the calculation, previously struggled
+    await nodeStore.save(n);
+  }, { cq: CHRIS, ca: CHRIS_A });
+
+  console.log('Routing calculations out of review');
+
+  console.log('1) The node itself splits the two streams');
+  const split = await page.evaluate(() => {
+    const n = nodeStore.getAll()[0];
+    return { review: n.reviewableQuestions().length, calc: n.calculationQuestions().length, total: n.questions.length };
+  });
+  ok('3 reviewable, 1 calculation, 4 in total', split.review === 3 && split.calc === 1 && split.total === 4, JSON.stringify(split));
+
+  console.log('2) Review never serves the calculation');
+  const sessions = await page.evaluate(() => {
+    const nodes = nodeStore.getAll();
+    const has = s => s.some(i => /Calculate the donations tax/.test(i.question.question));
+    return {
+      due:  has(ReviewView._buildDueSession(nodes)),
+      all:  has(ReviewView._buildAllSession(nodes)),
+      weak: has(ReviewView._buildWeakSession(nodes)),
+      dueLen: ReviewView._buildDueSession(nodes).length,
+    };
+  });
+  ok('not in today\'s session', sessions.due === false);
+  ok('not in the All session', sessions.all === false);
+  ok('not in Weak Spots, despite an old struggle record', sessions.weak === false);
+  ok('the other three cards are still served', sessions.dueLen === 3, 'due session length=' + sessions.dueLen);
+
+  console.log('3) Every due counter agrees with what review will serve');
+  const counts = await page.evaluate(() => {
+    const n = nodeStore.getAll()[0];
+    const now = Date.now();
+    let dash = 0;
+    for (const q of n.reviewableQuestions()) {
+      const s = n.srsState[q.id];
+      if (s && s.repetitions > 0 && s.nextReview <= now) dash++;
+    }
+    return { due: n.dueQuestions().length, dash };
+  });
+  ok('dueQuestions() counts 3, not 4', counts.due === 3, 'due=' + counts.due);
+  ok('the dashboard tally matches', counts.dash === counts.due, JSON.stringify(counts));
+
+  await page.evaluate(() => App.navigateTo('review'));
+  await page.waitForTimeout(900);
+  const shown = await page.evaluate(() => document.body.innerText);
+  ok('review tells the student where the calculation went', /kept out of review/i.test(shown), shown.slice(0, 200));
+  ok('and points them at the exam', /Exam tab/i.test(shown));
+  await page.screenshot({ path: OUT + '/01-review-note.png', fullPage: true });
+
+  console.log('4) The exam still has it — nothing is lost');
+  const inExam = await page.evaluate(() => {
+    const nodes = nodeStore.getAll().filter(n => n.processingStatus === 'ready');
+    const s = CompetencyView._buildSession(nodes, 8);
+    return { total: s.length, hasCalc: s.some(x => /Calculate the donations tax/.test(x.q.question)) };
+  });
+  ok('the calculation is in the exam paper', inExam.hasCalc, JSON.stringify(inExam));
+  ok('the exam draws on all four questions', inExam.total === 4, 'paper=' + inExam.total);
+
+  console.log('5) Mastery is not left permanently stuck');
+  const mast = await page.evaluate(() => {
+    const n = nodeStore.getAll()[0];
+    return { score: n.computeMastery(), reviewable: n.reviewableQuestions().length };
+  });
+  ok('mastery still computes from reviewed cards', typeof mast.score === 'number' && mast.score >= 0, JSON.stringify(mast));
+
+  console.log('6) Nothing broke');
+  const b = await page.evaluate(() => { const el = document.getElementById('kn-error-banner');
+    return el && el.style.display !== 'none' ? el.textContent.trim().slice(0, 200) : ''; });
+  ok('no JS error banner', !b, b);
+  ok('no uncaught page errors', errors.length === 0, errors[0] || '');
+
+  await browser.close();
+  console.log('\n' + (fail ? 'FAIL: ' + fail : 'ALL ' + pass + ' routing checks passed'));
+  process.exit(fail ? 1 : 0);
+})().catch(e => { console.error('DRIVER ERROR: ' + e.message); process.exit(2); });

--- a/knowledgenode/qa/browser/shared-memory-drive.js
+++ b/knowledgenode/qa/browser/shared-memory-drive.js
@@ -1,0 +1,105 @@
+/**
+ * Shared memory: what the student tells the coach must be known by EVERY AI
+ * surface — the tutor, the Director, gap analysis, understanding checks — not
+ * just the chat it was said in. Nothing already explained should be asked twice
+ * by any part of the app.
+ *
+ *   node mock-ai-server.js 8099 &
+ *   node shared-memory-drive.js
+ */
+const { chromium } = require('/opt/node22/lib/node_modules/playwright');
+const BASE = 'http://127.0.0.1:8099';
+let pass = 0, fail = 0;
+const ok = (n, c, x = '') => { c ? (pass++, console.log('  ✓ ' + n)) : (fail++, console.error('  ✗ ' + n + (x ? '  → ' + x : ''))); };
+
+(async () => {
+  const browser = await chromium.launch({ args: ['--no-sandbox'] });
+  const page = await browser.newPage({ viewport: { width: 430, height: 900 } });
+  const errors = [];
+  page.on('pageerror', e => errors.push('PAGEERROR: ' + e.message));
+  page.on('dialog', d => d.accept());
+
+  await page.goto(BASE + '/index.html', { waitUntil: 'load' });
+  await page.waitForFunction(() => typeof AIService !== 'undefined' && typeof LearnerContext !== 'undefined', null, { timeout: 15000 });
+  await page.evaluate(async (base) => {
+    AIService.saveConfig('custom', 'k', 'm', base + '/v1/chat/completions');
+    AIService.loadConfig();
+    await nodeStore.save(new KnowledgeNode({ title: 'Gross Income', subject: 'Income Tax', processingStatus: 'ready',
+      summary: 'Gross income is the total received or accrued.',
+      questions: [{ id: KnowledgeNode._generateQuestionId(), type: 'recall', question: 'Define gross income.', answer: 'Total received or accrued' }] }));
+    CoachFacts.clear(); CoachEngine.resetMemory();
+  }, BASE);
+  const calls = async () => (await page.request.get(BASE + '/__calls')).json();
+  const reset = async () => { await page.request.get(BASE + '/__reset'); };
+
+  console.log('Shared AI memory');
+
+  console.log('1) The student tells the coach something once');
+  await page.evaluate(() => CoachEngine.turn('my exams are in december and i can do 30 minutes morning and evening'));
+  const facts = await page.evaluate(() => CoachFacts.all().map(f => f.key + '=' + f.value));
+  ok('the coach recorded it', facts.some(f => /december/i.test(f)), JSON.stringify(facts));
+
+  console.log('2) It is in the SHARED context every AI surface builds from');
+  const inShared = await page.evaluate(() => LearnerContext.forSession());
+  ok('LearnerContext.forSession() carries the facts', /CONFIRMED FACTS/.test(inShared));
+  ok('the December date is in the shared context', /first week of December/.test(inShared));
+  ok('the study time is in the shared context', /30 min morning/.test(inShared));
+
+  console.log('3) Other AI features therefore know it too');
+  await reset();
+  await page.evaluate(async () => {
+    try { await AIService.analyzeSessionGaps({ topic: 'Gross Income', score: 40 }, nodeStore.getAll()); } catch (e) {}
+  });
+  let c = await calls();
+  ok('gap analysis made a call', c.length > 0);
+  ok('gap analysis was told the December date', /first week of December/.test(JSON.stringify(c)), 'facts missing from gap analysis');
+
+  await reset();
+  await page.evaluate(async () => {
+    const n = nodeStore.getAll()[0];
+    try { await AIService.checkAnswer(n.questions[0].question, n.questions[0].answer, 'total received', n.subject, n); } catch (e) {}
+  });
+  c = await calls();
+  ok('the understanding check made a call', c.length > 0);
+
+  console.log('4) The tutor shares the same memory as the chat');
+  await reset();
+  await page.evaluate(async () => {
+    const n = nodeStore.getAll()[0];
+    CoachEngine.startTutor(n.id);
+    await CoachEngine.turn('tutor me through this');
+  });
+  c = await calls();
+  ok('tutoring is told the same facts', /first week of December/.test(JSON.stringify(c)), 'tutor did not receive the facts');
+  const shared = await page.evaluate(() => ({ len: CoachEngine.history.length, mode: CoachEngine.mode.kind }));
+  ok('tutoring runs on the same single conversation, not a separate one',
+     shared.len >= 2 && shared.mode === 'tutor', JSON.stringify(shared));
+  await page.evaluate(() => CoachEngine.end());
+
+  console.log('5) Memory survives a full app restart');
+  await page.reload({ waitUntil: 'load' });
+  await page.waitForFunction(() => typeof CoachFacts !== 'undefined', null, { timeout: 15000 });
+  const after = await page.evaluate(() => {
+    CoachEngine.loadHistory();
+    return { facts: CoachFacts.all().length, ctx: LearnerContext.forSession(), hist: CoachEngine.history.length };
+  });
+  ok('facts survive the restart', after.facts >= 2, 'facts=' + after.facts);
+  ok('every AI surface still sees them after the restart', /first week of December/.test(after.ctx));
+  ok('the conversation survives the restart', after.hist >= 2, 'messages=' + after.hist);
+
+  console.log('6) A correction replaces, so no AI is left with the stale value');
+  await page.evaluate(() => CoachFacts.set('exam dates', 'moved to 15 January'));
+  const corrected = await page.evaluate(() => LearnerContext.forSession());
+  ok('the new value is in the shared context', /15 January/.test(corrected));
+  ok('the old value is gone everywhere', !/first week of December/.test(corrected));
+
+  console.log('7) Nothing broke');
+  const b = await page.evaluate(() => { const el = document.getElementById('kn-error-banner');
+    return el && el.style.display !== 'none' ? el.textContent.trim().slice(0, 200) : ''; });
+  ok('no JS error banner', !b, b);
+  ok('no uncaught page errors', errors.length === 0, errors[0] || '');
+
+  await browser.close();
+  console.log('\n' + (fail ? 'FAIL: ' + fail : 'ALL ' + pass + ' shared-memory checks passed'));
+  process.exit(fail ? 1 : 0);
+})().catch(e => { console.error('DRIVER ERROR: ' + e.message); process.exit(2); });

--- a/knowledgenode/qa/coach-memory-check.js
+++ b/knowledgenode/qa/coach-memory-check.js
@@ -1,0 +1,117 @@
+// BUG: the study coach forgot what it had been told and re-asked the same
+// questions ("how many hours per day can you study?") over and over.
+// Three compounding defects, all covered here:
+//   1. only the last 4 messages (2 exchanges) were sent to the AI in advise mode
+//   2. no durable store of facts the student stated — they rolled off forever
+//   3. the conversation lived in memory only — reopening the app wiped it
+// This suite replays the user's real planning conversation.
+const fs=require('fs'), path=require('path'), vm=require('vm');
+const { JSDOM } = require('jsdom');
+require('fake-indexeddb/auto');
+const WWW=process.env.WWW||require('path').join(__dirname,'..','www');
+let pass=0,fail=0; const ok=(n,c,x='')=>{ c?(pass++,console.log('  ✓ '+n)):(fail++,console.error('  ✗ '+n+(x?'  → '+x:''))); };
+
+const dom = new JSDOM(fs.readFileSync(path.join(WWW,'index.html'),'utf8'),{ url:'https://localhost/', runScripts:'outside-only', pretendToBeVisual:true });
+const win=dom.window, doc=win.document;
+win.indexedDB=globalThis.indexedDB; win.scrollTo=()=>{};
+win.matchMedia=()=>({matches:false,addEventListener(){},removeEventListener(){},addListener(){},removeListener(){}});
+win.requestAnimationFrame=cb=>setTimeout(()=>cb(Date.now()),0); win.cancelAnimationFrame=()=>{};
+win.URL.createObjectURL=()=>'blob:fake'; win.URL.revokeObjectURL=()=>{};
+const ctx2d=new Proxy({},{get:()=>()=>({data:[]})});
+win.HTMLCanvasElement.prototype.getContext=()=>ctx2d; win.HTMLElement.prototype.scrollIntoView=()=>{};
+win.HTMLCanvasElement.prototype.toDataURL=()=>'data:image/jpeg;base64,AAAA';
+win.fetch=async()=>({ok:false,status:404,json:async()=>({}),text:async()=>''});
+win.console.error=()=>{}; win.console.warn=()=>{};
+let big='';
+for(const s of [...doc.querySelectorAll('script')]){ const src=s.getAttribute('src');
+  if(src){ if(/^https?:/.test(src))continue; big+='\n'+fs.readFileSync(path.join(WWW,src.split('?')[0]),'utf8'); } else big+='\n'+s.textContent; }
+big+='\n;try{window.CoachEngine=CoachEngine;window.CoachFacts=CoachFacts;window.AIService=AIService;window.StudyCoach=StudyCoach;}catch(e){}';
+vm.runInContext(big, dom.getInternalVMContext(), {filename:'app.js'});
+doc.dispatchEvent(new win.Event('DOMContentLoaded')); win.dispatchEvent(new win.Event('load'));
+const W=win;
+
+setTimeout(async ()=>{
+  console.log('Study coach memory');
+  const CF=W.CoachFacts, CE=W.CoachEngine;
+  CF.clear(); CE.resetMemory();
+
+  console.log('1) Durable facts survive, and CORRECTIONS replace (not duplicate)');
+  CF.set('exam dates','31 August');
+  CF.set('Exam Dates','first week of December');   // same fact, different casing/spacing
+  ok('a corrected fact overwrites instead of duplicating', CF.all().filter(f=>/exam/.test(f.key)).length===1, JSON.stringify(CF.all()));
+  ok('the NEW value is what is kept', CF.get('exam_dates')==='first week of December', CF.get('exam_dates'));
+  CF.set('daily study time','30 min morning + 30 min evening');
+  CF.set('subjects','Financial Statements, Cost & Management Accounting, Income Tax Returns, Business Law & Accounting Control (4 total)');
+  const blk=CF.block();
+  ok('the facts block names the December exam', /first week of December/.test(blk));
+  ok('the facts block names the daily study time', /30 min morning/.test(blk));
+  ok('the facts block names the 4 subjects', /4 total/.test(blk));
+  ok('the block forbids re-asking answered questions', /[Nn]ever ask the student for anything already answered/.test(blk));
+  ok('a student-stated fact outranks stale app data (deleted study plan)', /the fact here WINS/.test(blk));
+
+  console.log('2) The coach records facts via hidden [[FACT:]] lines (no extra AI call)');
+  const reply='Got it — December it is.\n[[FACT: work schedule = works Monday to Friday]]\n[[SIGNAL:Student planning around work.]]';
+  const { clean, signal } = CE.extractSignal(reply);
+  ok('the [[FACT:]] line is stripped from what the student sees', !/FACT/.test(clean), clean);
+  ok('the [[SIGNAL:]] line is still stripped too', !/SIGNAL/.test(clean));
+  ok('the visible reply text survives', /December it is/.test(clean));
+  ok('the signal is still extracted for the Director', /planning around work/.test(signal||''));
+  ok('the fact was absorbed into durable memory', CF.get('work_schedule')==='works Monday to Friday', CF.get('work_schedule'));
+
+  console.log('3) The conversation survives closing and reopening the app');
+  CE.history=[{role:'user',text:'i can do 30 minutes morning and evening'},{role:'coach',text:'Noted.'}];
+  CE.saveHistory();
+  CE.history=[];                                   // simulate app restart
+  CE.loadHistory();
+  ok('history is restored after a restart', CE.history.length===2, 'len='+CE.history.length);
+  ok('the restored message is the real one', /30 minutes morning and evening/.test(CE.history[0].text));
+  ok('facts also survive the restart', CF.get('exam_dates')==='first week of December');
+
+  console.log('4) A failed AI call is shown but never fed back as context');
+  CE.history=[{role:'user',text:'yes'},{role:'coach',text:'Sorry — I could not reach the AI just now.',error:true},{role:'user',text:'that works'}];
+  let captured=null;
+  const realCoach=W.AIService.studyCoach;
+  W.AIService.studyCoach=async(q,hist)=>{ captured=hist; return 'ok'; };
+  await CE.turn('that works');
+  ok('the error message is NOT sent back to the AI', !captured.some(h=>/could not reach the AI/.test(h.text)), JSON.stringify(captured.map(h=>h.text)));
+  ok('the real messages ARE still sent', captured.some(h=>h.text==='yes'));
+  W.AIService.studyCoach=realCoach;
+
+  console.log('5) The history window is deep enough for a planning conversation');
+  // Replay the shape of the real bug: capacity stated, then 8 more turns.
+  CE.resetMemory(); CF.clear();
+  CE.history=[{role:'user',text:'i can do 30 minutes at night and 30 in the morning'}];
+  for(let i=0;i<8;i++){ CE.history.push({role:'coach',text:'reply '+i}); CE.history.push({role:'user',text:'follow up '+i}); }
+  let cap2=null;
+  W.AIService._callClaudeWithCache=async(sys,messages)=>{ cap2={sys,messages}; return 'ok'; };
+  await W.AIService.studyCoach('build the plan', CE.history);
+  const sent=cap2.messages[0].content;
+  ok('the capacity stated 17 messages ago is STILL in the prompt',
+    /30 minutes at night and 30 in the morning/.test(sent), 'window too shallow');
+  ok('the whole replayed conversation is included', (sent.match(/follow up /g)||[]).length===8, (sent.match(/follow up /g)||[]).length+'');
+  // and the old behaviour would have failed this:
+  const oldWindow=CE.history.slice(-4).map(h=>h.text).join('\n');
+  ok('(proof) the OLD 4-message window would have LOST it', !/30 minutes at night/.test(oldWindow));
+
+  console.log('6) Facts reach the AI on every turn, via the system prompt');
+  CF.set('exam dates','first week of December');
+  await W.AIService.studyCoach('anything', []);
+  ok('the CONFIRMED FACTS block is in the system prompt', /CONFIRMED FACTS/.test(cap2.sys));
+  ok('the December exam date reaches the AI even with an EMPTY history', /first week of December/.test(cap2.sys));
+  ok('the coach is instructed how to record new facts', /\[\[FACT:/.test(cap2.sys));
+
+  console.log('7) Long conversations stay within a safe size');
+  const huge=[]; for(let i=0;i<120;i++) huge.push({role:i%2?'coach':'user',text:'x'.repeat(400)});
+  await W.AIService.studyCoach('q', huge);
+  ok('a 120-message history is trimmed, not sent whole', cap2.messages[0].content.length < 20000, 'len='+cap2.messages[0].content.length);
+  ok('it still notes that earlier messages were dropped', /earlier message\(s\) not shown/.test(cap2.messages[0].content));
+
+  console.log('8) Reset genuinely forgets everything');
+  CE.resetMemory();
+  ok('history cleared', CE.history.length===0);
+  ok('facts cleared', CF.all().length===0);
+  ok('nothing comes back after a reload', (CE.loadHistory(), CE.history.length===0));
+
+  console.log('\n'+(fail? 'FAIL: '+fail : 'ALL '+pass+' checks passed'));
+  process.exit(fail?1:0);
+}, 500);

--- a/knowledgenode/qa/exam-selection-check.js
+++ b/knowledgenode/qa/exam-selection-check.js
@@ -1,0 +1,93 @@
+// Smart mock-exam selection: instead of a pure random draw, the exam weights
+// questions by how valuable they are to be tested on (struggled / due / never
+// tested / examiner-relevant) while keeping subject breadth and variety.
+const fs=require('fs'), path=require('path'), vm=require('vm');
+const { JSDOM } = require('jsdom');
+require('fake-indexeddb/auto');
+const WWW=process.env.WWW||require('path').join(__dirname,'..','www');
+let pass=0,fail=0; const ok=(n,c,x='')=>{ c?(pass++,console.log('  ✓ '+n)):(fail++,console.error('  ✗ '+n+(x?'  → '+x:''))); };
+const dom = new JSDOM(fs.readFileSync(path.join(WWW,'index.html'),'utf8'),{ url:'https://localhost/', runScripts:'outside-only', pretendToBeVisual:true });
+const win=dom.window, doc=win.document;
+win.indexedDB=globalThis.indexedDB; win.scrollTo=()=>{};
+win.matchMedia=()=>({matches:false,addEventListener(){},removeEventListener(){},addListener(){},removeListener(){}});
+win.requestAnimationFrame=cb=>setTimeout(()=>cb(Date.now()),0); win.cancelAnimationFrame=()=>{};
+win.URL.createObjectURL=()=>'blob:fake'; win.URL.revokeObjectURL=()=>{};
+const ctx2d=new Proxy({},{get:()=>()=>({data:[]})});
+win.HTMLCanvasElement.prototype.getContext=()=>ctx2d;
+win.HTMLElement.prototype.scrollIntoView=()=>{};
+win.HTMLCanvasElement.prototype.toDataURL=()=>'data:image/jpeg;base64,AAAA';
+win.fetch=async()=>({ok:false,status:404,json:async()=>({}),text:async()=>''});
+win.console.error=()=>{}; win.console.warn=()=>{};
+let big='';
+for(const s of [...doc.querySelectorAll('script')]){
+  const src=s.getAttribute('src');
+  if(src){ if(/^https?:/.test(src))continue; big+='\n'+fs.readFileSync(path.join(WWW,src.split('?')[0]),'utf8'); }
+  else big+='\n'+s.textContent;
+}
+big+='\n;try{window.CompetencyView=CompetencyView;window.KnowledgeNode=KnowledgeNode;window.LearnerMemory=LearnerMemory;}catch(e){}';
+vm.runInContext(big, dom.getInternalVMContext(), {filename:'app.js'});
+doc.dispatchEvent(new win.Event('DOMContentLoaded')); win.dispatchEvent(new win.Event('load'));
+const W=win;
+
+const runs = (fn, n=200) => { let hit=0; for(let i=0;i<n;i++) if(fn()) hit++; return hit/n; };
+
+setTimeout(()=>{
+  console.log('Smart mock-exam selection');
+  const CV = W.CompetencyView;
+
+  console.log('1) Weak (struggled) questions are favoured over untouched ones');
+  // one topic: q_weak struggled 3x, q_plain never studied
+  const nodeW = new W.KnowledgeNode({ title:'A', subject:'Tax', processingStatus:'ready',
+    questions:[{id:'weak',type:'recall',question:'weak q',answer:'a'},{id:'plain',type:'recall',question:'plain q',answer:'b'}] });
+  W.LearnerMemory.recordStruggle(nodeW, nodeW.questions[0], 1);
+  W.LearnerMemory.recordStruggle(nodeW, nodeW.questions[0], 1);
+  W.LearnerMemory.recordStruggle(nodeW, nodeW.questions[0], 1);
+  // pick 1 of 2, many times — the weak one should win far more often than chance
+  const weakRate = runs(() => CV._buildSession([nodeW], 1)[0].q.id === 'weak');
+  ok('the struggled question is picked well above 50% of the time', weakRate > 0.65, 'rate='+weakRate.toFixed(2));
+
+  console.log('2) Due/overdue questions are favoured');
+  const nodeD = new W.KnowledgeNode({ title:'B', subject:'Tax', processingStatus:'ready',
+    questions:[{id:'due',type:'recall',question:'due q',answer:'a'},{id:'fresh',type:'recall',question:'fresh q',answer:'b'}] });
+  nodeD.srsState['due']  = { repetitions:2, nextReview: Date.now()-86400000, interval:5, ease:2.5 }; // overdue
+  nodeD.srsState['fresh']= { repetitions:2, nextReview: Date.now()+30*86400000, interval:30, ease:2.5 }; // not due
+  const dueRate = runs(() => CV._buildSession([nodeD], 1)[0].q.id === 'due');
+  ok('the overdue question is picked more often than the fresh one', dueRate > 0.6, 'rate='+dueRate.toFixed(2));
+
+  console.log('3) Subject breadth — no single topic dominates the paper');
+  const mk = (t, base) => new W.KnowledgeNode({ title:t, subject:t, processingStatus:'ready',
+    questions: Array.from({length:10},(_,i)=>({id:base+i,type:'recall',question:'q',answer:'a'})) });
+  const nA = mk('Acc','a'), nB = mk('Law','b'), nC = mk('Maths','c');
+  const sess = CV._buildSession([nA,nB,nC], 9);
+  ok('exam has the requested number of questions', sess.length===9);
+  const bySubj = {}; sess.forEach(x => bySubj[x.node.subject]=(bySubj[x.node.subject]||0)+1);
+  ok('all three subjects are represented (breadth, not one topic)', Object.keys(bySubj).length===3, JSON.stringify(bySubj));
+  ok('no subject dominates (each ≤ 4 of 9)', Object.values(bySubj).every(c=>c<=4), JSON.stringify(bySubj));
+
+  console.log('4) Examiner relevance — past-paper subjects get a boost');
+  W.localStorage.setItem('kn_exam_style_tax', JSON.stringify({ papers:[{ name:'2024', analysis:{ topicAreas:['x'] } }] }));
+  ok('_hasPastPaper detects an analysed paper', CV._hasPastPaper('Tax') === true && CV._hasPastPaper('Nothing') === false);
+  // two topics, equal otherwise; the one WITH a past paper should be favoured
+  const nPaper = new W.KnowledgeNode({ title:'P', subject:'Tax',    processingStatus:'ready', questions:[{id:'p1',type:'recall',question:'q',answer:'a'}] });
+  const nNone  = new W.KnowledgeNode({ title:'N', subject:'Random', processingStatus:'ready', questions:[{id:'n1',type:'recall',question:'q',answer:'a'}] });
+  const paperRate = runs(() => CV._buildSession([nPaper,nNone], 1)[0].node.subject === 'Tax');
+  ok('a past-paper subject is favoured over one without', paperRate > 0.55, 'rate='+paperRate.toFixed(2));
+  W.localStorage.removeItem('kn_exam_style_tax');
+
+  console.log('5) Shape, bounds, variety, and no-crash edges');
+  ok('returns the same {q,node} shape as before', sess[0].q && sess[0].node && typeof sess[0].q.question==='string');
+  ok('never returns more than max', CV._buildSession([nA], 3).length===3);
+  ok('returns everything when fewer questions than max exist', CV._buildSession([nPaper], 8).length===1);
+  ok('empty library → empty session, no crash', CV._buildSession([], 8).length===0);
+  ok('no duplicate questions in a session', (()=>{ const s=CV._buildSession([nA,nB,nC],9); return new Set(s.map(x=>x.q.id)).size===s.length; })());
+  // variety: two exams over a big pool should differ at least sometimes
+  const differ = runs(()=>{ const a=CV._buildSession([nA,nB,nC],5).map(x=>x.q.id).join(); const b=CV._buildSession([nA,nB,nC],5).map(x=>x.q.id).join(); return a!==b; }, 20);
+  ok('repeated exams vary (not identical every time)', differ > 0.3, 'differ='+differ.toFixed(2));
+
+  console.log('6) Free/local — the selector makes no AI/network call');
+  const src = fs.readFileSync(path.join(WWW,'js/ui/CompetencyView.js'),'utf8');
+  ok('selection logic is on-device only', /_buildSession[\s\S]*?scored\.sort/.test(src) && !/_buildSession[\s\S]{0,600}_callWithFunction/.test(src));
+
+  console.log('\n'+(fail? 'FAIL: '+fail : 'ALL '+pass+' checks passed'));
+  process.exit(fail?1:0);
+}, 400);

--- a/knowledgenode/qa/grader-numbers-check.js
+++ b/knowledgenode/qa/grader-numbers-check.js
@@ -1,0 +1,43 @@
+// Gap fix: the free on-device grader now understands thousands-separators
+// (spaces/commas) in amounts — "R 100 000", "R1 385 600", "100,000" — so the
+// numeric answers this app is full of grade instantly for free instead of
+// wrongly falling through to a paid AI call. Must stay conservative: a genuinely
+// wrong amount must NOT match.
+const path=require('path');
+const WWW = process.env.WWW || path.join(__dirname,'..','www');
+const LG=require(path.join(WWW,'js/core/LocalGrader.js'));
+let pass=0,fail=0; const ok=(n,c,x='')=>{ c?(pass++,console.log('  ✓ '+n)):(fail++,console.error('  ✗ '+n+(x?'  → '+x:''))); };
+
+console.log('Free grading of separated amounts');
+
+console.log('1) _num parses grouped amounts as one number');
+ok('"R 100 000" → 100000', JSON.stringify(LG._num('R 100 000'))==='[100000]');
+ok('"R1 385 600" → 1385600', JSON.stringify(LG._num('R1 385 600'))==='[1385600]');
+ok('"1 000 000" (multi-group) → 1000000', JSON.stringify(LG._num('1 000 000'))==='[1000000]');
+ok('"100,000.50" → 100000.5', JSON.stringify(LG._num('100,000.50'))==='[100000.5]');
+ok('percentages still work (15% → 0.15)', JSON.stringify(LG._num('15%'))==='[0.15]');
+
+console.log('2) These now grade FREE (correct answers)');
+[
+  ['R 100 000', ['100000']],
+  ['R36 000',   ['36000']],
+  ['100,000',   ['100000']],
+  ['the answer is R 5 000', ['5000']],
+  ['R 1 385 600', ['1385600']],
+  ['R 100 000', ['R 100 000']],
+  ['1 000 000', ['1000000']],
+].forEach(([s,a]) => ok('"'+s+'" vs '+JSON.stringify(a)+' → correct', LG.match(s,a).verdict==='correct'));
+
+console.log('3) Still conservative — wrong amounts do NOT match');
+ok('"R 99 000" vs 100000 stays unknown', LG.match('R 99 000',['100000']).verdict==='unknown');
+ok('"R 10 000" vs 100000 stays unknown (missing a group)', LG.match('R 10 000',['100000']).verdict==='unknown');
+ok('empty answer stays unknown', LG.match('',['100000']).verdict==='unknown');
+
+console.log('4) No regression on existing rules');
+ok('exact text still matches', LG.match('an asset',['An asset']).verdict==='correct');
+ok('term containment still matches', LG.match('it is an asset',['asset']).verdict==='correct');
+ok('MCQ letter still matches', LG.match('a',['A — worldwide income']).verdict==='correct');
+ok('plain prose with no numbers is untouched', LG.match('gross income means total received',['asset']).verdict==='unknown');
+
+console.log('\n'+(fail? 'FAIL: '+fail : 'ALL '+pass+' checks passed'));
+process.exit(fail?1:0);

--- a/knowledgenode/qa/leech-intervention-check.js
+++ b/knowledgenode/qa/leech-intervention-check.js
@@ -1,0 +1,116 @@
+// Leech detection + intervention: a card failed too many times stops being
+// re-drilled and the learner is routed to understand the concept instead —
+// plus leeches surface as a high-priority Exam Readiness action. Free/local.
+const fs=require('fs'), path=require('path'), vm=require('vm');
+const { JSDOM } = require('jsdom');
+require('fake-indexeddb/auto');
+const WWW=process.env.WWW||require('path').join(__dirname,'..','www');
+let pass=0,fail=0; const ok=(n,c,x='')=>{ c?(pass++,console.log('  ✓ '+n)):(fail++,console.error('  ✗ '+n+(x?'  → '+x:''))); };
+
+// ── Part A: LeechDetector unit (pure) ──
+const LD = require(path.join(WWW,'js/core/LeechDetector.js'));
+console.log('A) LeechDetector — pure detection');
+ok('threshold is a sane small number', LD.THRESHOLD >= 3 && LD.THRESHOLD <= 8);
+ok('a count below threshold is NOT a leech', !LD.isLeech(LD.THRESHOLD - 1));
+ok('a count at threshold IS a leech', LD.isLeech(LD.THRESHOLD));
+ok('accepts a struggle record too', LD.isLeech({ count: LD.THRESHOLD + 2 }));
+const nodeA = { id:'nA', title:'Tax', questions:[{id:'q1'},{id:'q2'},{id:'q3'}],
+  weakQuestions:[{id:'q1',count:LD.THRESHOLD+1},{id:'q2',count:2}] };
+ok('countFor reads the struggle log', LD.countFor(nodeA,'q1') === LD.THRESHOLD+1 && LD.countFor(nodeA,'q3') === 0);
+ok('isLeechCard flags only the over-threshold card', LD.isLeechCard(nodeA,'q1') && !LD.isLeechCard(nodeA,'q2') && !LD.isLeechCard(nodeA,'q3'));
+const nodeB = { id:'nB', title:'Law', questions:[{id:'x'}], weakQuestions:[{id:'x',count:LD.THRESHOLD+5}] };
+const all = LD.leeches([nodeA,nodeB]);
+ok('leeches() collects across nodes, worst first', all.length===2 && all[0].node.id==='nB' && all[0].count > all[1].count);
+ok('leeches() ignores struggles below threshold', !all.some(l => l.question.id==='q2'));
+const src = fs.readFileSync(path.join(WWW,'js/core/LeechDetector.js'),'utf8');
+ok('detector is free/local (no AI/network)', !/_callWithFunction|AIService|fetch\(/.test(src));
+
+// ── Part B: Review intervention (DOM) ──
+const dom = new JSDOM(fs.readFileSync(path.join(WWW,'index.html'),'utf8'),{ url:'https://localhost/', runScripts:'outside-only', pretendToBeVisual:true });
+const win=dom.window, doc=win.document;
+win.indexedDB=globalThis.indexedDB; win.scrollTo=()=>{};
+win.matchMedia=()=>({matches:false,addEventListener(){},removeEventListener(){},addListener(){},removeListener(){}});
+win.requestAnimationFrame=cb=>setTimeout(()=>cb(Date.now()),0); win.cancelAnimationFrame=()=>{};
+win.URL.createObjectURL=()=>'blob:fake'; win.URL.revokeObjectURL=()=>{};
+const ctx2d=new Proxy({},{get:()=>()=>({data:[]})});
+win.HTMLCanvasElement.prototype.getContext=()=>ctx2d;
+win.HTMLElement.prototype.scrollIntoView=()=>{};
+win.HTMLCanvasElement.prototype.toDataURL=()=>'data:image/jpeg;base64,AAAA';
+win.fetch=async()=>({ok:false,status:404,json:async()=>({}),text:async()=>''});
+win.console.error=()=>{}; win.console.warn=()=>{};
+let big='';
+for(const s of [...doc.querySelectorAll('script')]){
+  const src=s.getAttribute('src');
+  if(src){ if(/^https?:/.test(src))continue; big+='\n'+fs.readFileSync(path.join(WWW,src.split('?')[0]),'utf8'); }
+  else big+='\n'+s.textContent;
+}
+big+='\n;try{window.ReviewView=ReviewView;window.LeechDetector=LeechDetector;window.LearnerMemory=LearnerMemory;window.nodeStore=nodeStore;window.KnowledgeNode=KnowledgeNode;window.NodeDetailView=NodeDetailView;window.ExamReadiness=ExamReadiness;}catch(e){}';
+vm.runInContext(big, dom.getInternalVMContext(), {filename:'app.js'});
+doc.dispatchEvent(new win.Event('DOMContentLoaded')); win.dispatchEvent(new win.Event('load'));
+const W=win;
+
+setTimeout(async ()=>{
+  console.log('B) Review breaks the grind on a leech card');
+  const node = new W.KnowledgeNode({ title:'Hard Topic', subject:'Tax', processingStatus:'ready',
+    questions:[{id:'q1',type:'recall',question:'A tricky question',answer:'the answer'}] });
+  W.nodeStore.save(node);
+  // Fail it up to (threshold-1) times via the struggle log — not yet a leech.
+  for (let i=0;i<W.LeechDetector.THRESHOLD-1;i++) W.LearnerMemory.recordStruggle(node, node.questions[0], 1);
+  W.nodeStore.save(node);
+
+  // Drive a review session on this one card.
+  W.ReviewView._session = [{ node, question: node.questions[0], state: node.srsState['q1']||null }];
+  W.ReviewView._index = 0; W.ReviewView._revealed = true; W.ReviewView._stats = {again:0,hard:0,good:0,easy:0};
+  W.ReviewView._inSession = true;
+
+  // Rate "Again": this pushes the count to the threshold → leech → intervention.
+  W.ReviewView._rate(1);
+  await new Promise(r=>setTimeout(r,20));
+  const leechEl = doc.getElementById('review-leech');
+  ok('intervention appears once the card crosses the leech threshold', !!leechEl);
+  ok('it names how many times it was missed', /missed \d+/.test(leechEl.textContent));
+  ok('it offers to understand the concept', !!doc.getElementById('leech-understand'));
+  ok('it offers to keep drilling (learner stays in control)', !!doc.getElementById('leech-continue'));
+  ok('the leech card was NOT auto-re-queued behind the prompt', W.ReviewView._session.length === 1);
+
+  console.log('C) "Understand" routes to the topic, "Keep drilling" re-queues');
+  let openedNode = null;
+  W.NodeDetailView.open = (id, section) => { openedNode = { id, section }; };
+  doc.getElementById('leech-understand').click();
+  ok('Understand opens the topic to actually learn it', openedNode && openedNode.id === node.id);
+  ok('the prompt is dismissed after choosing', !doc.getElementById('review-leech'));
+
+  // Re-trigger to test the "keep drilling" path (leech already shown once, so
+  // reset the per-session shown-set to simulate a fresh session).
+  W.ReviewView._leechShown = null;
+  W.ReviewView._session = [{ node, question: node.questions[0], state: node.srsState['q1']||null }];
+  W.ReviewView._index = 0; W.ReviewView._revealed = true; W.ReviewView._stats = {again:0,hard:0,good:0,easy:0};
+  W.ReviewView._rate(1);
+  await new Promise(r=>setTimeout(r,20));
+  const before = W.ReviewView._session.length;
+  doc.getElementById('leech-continue').click();
+  ok('Keep drilling re-queues the card and continues', W.ReviewView._session.length === before + 1);
+  ok('prompt cleared after keep-drilling', !doc.getElementById('review-leech'));
+
+  console.log('D) A non-leech Again still re-queues normally (no regression)');
+  const node2 = new W.KnowledgeNode({ title:'Easy Topic', subject:'Tax', processingStatus:'ready',
+    questions:[{id:'e1',type:'recall',question:'q',answer:'a'}] });
+  W.nodeStore.save(node2);
+  W.ReviewView._leechShown = null;
+  W.ReviewView._session = [{ node: node2, question: node2.questions[0], state: null }];
+  W.ReviewView._index = 0; W.ReviewView._revealed = true; W.ReviewView._stats = {again:0,hard:0,good:0,easy:0};
+  W.ReviewView._rate(1); // first-ever miss — not a leech
+  await new Promise(r=>setTimeout(r,20));
+  ok('no intervention for a card missed once', !doc.getElementById('review-leech'));
+  ok('normal Again re-queues the card', W.ReviewView._session.length === 2);
+
+  console.log('E) Leeches surface as a high-priority Exam Readiness action');
+  const r = W.ExamReadiness.assess([node], null); // node is a leech now
+  const leechAction = r.actions.find(a => a.kind === 'leech');
+  ok('readiness lists a leech action', !!leechAction);
+  ok('…that points at the topic to understand', leechAction && leechAction.nodeId === node.id);
+  ok('…with meaningful priority (lift > a plain review)', leechAction && leechAction.lift >= 9);
+
+  console.log('\n'+(fail? 'FAIL: '+fail : 'ALL '+pass+' checks passed'));
+  process.exit(fail?1:0);
+}, 500);

--- a/knowledgenode/qa/match-group-check.js
+++ b/knowledgenode/qa/match-group-check.js
@@ -1,0 +1,64 @@
+// Match-and-Pair reassembly: the individual per-item questions an import
+// produced (each with the same shared Column B option list) are grouped back
+// into ONE interactive two-column set, and every pair is graded on-device for
+// free (a wrong match is definitively wrong — no AI). This checks the grouping
+// core; a companion jsdom test drives the actual tap-to-match UI.
+const path = require('path');
+const WWW = process.env.WWW || path.join(__dirname,'..','www');
+const MG = require(path.join(WWW, 'js/core/MatchGroup.js'));
+let pass = 0, fail = 0;
+const ok = (n, c, x = '') => { c ? (pass++, console.log('  ✓ ' + n)) : (fail++, console.error('  ✗ ' + n + (x ? '  → ' + x : ''))); };
+
+// Build a node whose questions are a matching set (shared A–E option list),
+// plus one unrelated open question that must NOT be pulled into the group.
+const OPTS = 'A — 50%\nB — Medical aid contribution paid on behalf of an employee\nC — 20%\nD — 0%\nE — Allowable retirement contributions';
+const instr = 'Match the items in COLUMN B with those in COLUMN A:';
+const mk = (id, prompt, ans) => ({ id, type: 'recall', question: instr + '\n' + prompt + '\n' + OPTS, answer: ans });
+const node = { id: 'tax1', subject: 'Tax', questions: [
+  mk('q7',  '7. Inclusion rate of travel allowance for PAYE purposes', 'A — 50%'),
+  mk('q8',  '8. Dividends withholding tax rate', 'C — 20%'),
+  mk('q9',  '9. Fringe benefit example', 'B — Medical aid contribution paid on behalf of an employee'),
+  { id: 'open1', type: 'recall', question: 'Explain the residence basis of taxation.', answer: 'worldwide income' },
+] };
+
+console.log('Match-and-Pair grouping');
+
+console.log('1) The three sibling items form ONE group; the open question is left out');
+const groups = MG.detect(node);
+ok('exactly one group detected', groups.length === 1, 'got ' + groups.length);
+const g = groups[0];
+ok('group has all three prompts', g && g.prompts.length === 3, g && g.prompts.length);
+ok('the open question is NOT in the group', g && !g.prompts.some(p => p.q.id === 'open1'));
+ok('group carries the shared five options', g && g.options.length === 5, g && g.options.length);
+
+console.log('2) The generic instruction is lifted out; each row shows only its item');
+ok('instruction captured once', g && /Match the items/.test(g.instruction), g && g.instruction);
+ok('prompt row is just the numbered item (no instruction, no options)',
+  g && g.prompts[0].prompt === '7. Inclusion rate of travel allowance for PAYE purposes', g && JSON.stringify(g.prompts[0].prompt));
+
+console.log('3) Pairs grade for free and definitively');
+ok('correctLetter(q7) → A', MG.correctLetter(g, g.prompts[0].answer) === 'A', MG.correctLetter(g, g.prompts[0].answer));
+ok('correctLetter(q8) → C', MG.correctLetter(g, g.prompts[1].answer) === 'C');
+ok('answerFor(A) → full "A — 50%"', MG.answerFor(g, 'A') === 'A — 50%', MG.answerFor(g, 'A'));
+// simulate marking: right letter is correct, wrong letter is wrong — both free
+const mark = (p, chosen) => chosen === MG.correctLetter(g, p.answer);
+ok('choosing A for q7 marks correct', mark(g.prompts[0], 'A') === true);
+ok('choosing D for q7 marks wrong (definitive, no AI)', mark(g.prompts[0], 'D') === false);
+
+console.log('4) indexByQuestion maps every set member to its group');
+const idx = MG.indexByQuestion(node);
+ok('q7,q8,q9 all map to a group', idx.get('q7') && idx.get('q8') && idx.get('q9'));
+ok('the open question maps to nothing', !idx.get('open1'));
+ok('all members map to the SAME group object', idx.get('q7') === idx.get('q8') && idx.get('q8') === idx.get('q9'));
+
+console.log('5) Conservative — a node without a matching set yields no groups');
+const plain = { id: 'n2', questions: [
+  { id: 'a', question: 'What is gross income?', answer: 'total amount received' },
+  { id: 'b', question: 'Define an asset.', answer: 'a resource controlled by the entity' },
+] };
+ok('no groups from ordinary questions', MG.detect(plain).length === 0);
+// a lone matching item (siblings not present) is not a "set"
+ok('a single lettered question alone is not grouped', MG.detect({ id: 'n3', questions: [ mk('solo', '1. only one', 'A — 50%') ] }).length === 0);
+
+console.log('\n' + (fail ? 'FAIL: ' + fail : 'ALL ' + pass + ' checks passed'));
+process.exit(fail ? 1 : 0);

--- a/knowledgenode/qa/match-group-integration-check.js
+++ b/knowledgenode/qa/match-group-integration-check.js
@@ -1,0 +1,102 @@
+// End-to-end (jsdom): a matching worksheet becomes ONE two-column table in the
+// AI Exam, tapping pairs items to options, and submitting marks every pair for
+// free (zero AI/network calls) — exactly the "like the image" experience.
+const fs=require('fs'), path=require('path'), vm=require('vm');
+const { JSDOM } = require('jsdom');
+require('fake-indexeddb/auto');
+const WWW=process.env.WWW||require('path').join(__dirname,'..','www');
+let pass=0,fail=0; const ok=(n,c,x='')=>{ c?(pass++,console.log('  ✓ '+n)):(fail++,console.error('  ✗ '+n+(x?'  → '+x:''))); };
+const dom = new JSDOM(fs.readFileSync(path.join(WWW,'index.html'),'utf8'),{ url:'https://localhost/', runScripts:'outside-only', pretendToBeVisual:true });
+const win=dom.window, doc=win.document;
+win.indexedDB=globalThis.indexedDB; win.scrollTo=()=>{};
+win.matchMedia=()=>({matches:false,addEventListener(){},removeEventListener(){},addListener(){},removeListener(){}});
+win.requestAnimationFrame=cb=>setTimeout(()=>cb(Date.now()),0); win.cancelAnimationFrame=()=>{};
+win.URL.createObjectURL=()=>'blob:fake'; win.URL.revokeObjectURL=()=>{};
+const ctx2d=new Proxy({},{get:()=>()=>({data:[]})});
+win.HTMLCanvasElement.prototype.getContext=()=>ctx2d;
+win.HTMLElement.prototype.scrollIntoView=()=>{};
+win.HTMLCanvasElement.prototype.toDataURL=()=>'data:image/jpeg;base64,AAAA';
+let fetchCalls=0; win.fetch=async()=>{ fetchCalls++; return {ok:false,status:404,json:async()=>({}),text:async()=>''}; };
+win.confirm=()=>true;
+win.console.error=()=>{}; win.console.warn=()=>{};
+let big='';
+for(const s of [...doc.querySelectorAll('script')]){
+  const src=s.getAttribute('src');
+  if(src){ if(/^https?:/.test(src))continue; big+='\n'+fs.readFileSync(path.join(WWW,src.split('?')[0]),'utf8'); }
+  else big+='\n'+s.textContent;
+}
+big+='\n;try{window.CompetencyView=CompetencyView;window.KnowledgeNode=KnowledgeNode;window.MatchGroup=MatchGroup;window.MatchOptions=MatchOptions;window.AIService=AIService;}catch(e){}';
+vm.runInContext(big, dom.getInternalVMContext(), {filename:'app.js'});
+doc.dispatchEvent(new win.Event('DOMContentLoaded')); win.dispatchEvent(new win.Event('load'));
+const W=win;
+
+const OPTS='A — 50%\nB — Medical aid contribution paid on behalf of an employee\nC — 20%\nD — 0%\nE — Allowable retirement contributions';
+const instr='Match the items in COLUMN B with those in COLUMN A:';
+const mk=(id,prompt,ans)=>({ id, type:'recall', question: instr+'\n'+prompt+'\n'+OPTS, answer: ans });
+
+const tap=(elem)=>elem.dispatchEvent(new W.Event('click',{bubbles:true}));
+
+setTimeout(async ()=>{
+  console.log('Match-and-Pair — full exam flow (jsdom)');
+  const CV=W.CompetencyView;
+  // make sure no AI path is taken even if it tried
+  W.AIService.hasApiKey=()=>false;
+
+  const node=new W.KnowledgeNode({ title:'Tax', subject:'Tax', processingStatus:'ready', questions:[
+    mk('q7','7. Inclusion rate of travel allowance for PAYE purposes','A — 50%'),
+    mk('q8','8. Dividends withholding tax rate','C — 20%'),
+    mk('q9','9. Fringe benefit example','B — Medical aid contribution paid on behalf of an employee'),
+  ] });
+
+  // 1) session build collapses the set into ONE slot
+  const sess=CV._buildSession([node],8);
+  ok('the matching set is ONE paper slot, not three', sess.length===1, 'len='+sess.length);
+  ok('that slot is a match group with all 3 prompts', sess[0].match && sess[0].match.prompts.length===3);
+
+  // 1b) the Timed Quiz keeps matching items per-item (grouping OFF)
+  const timed=CV._buildSession([node],10,false);
+  ok('Timed quiz does NOT group (3 separate items, still per-item tappable)', timed.length===3 && !timed.some(s=>s.match), 'len='+timed.length);
+
+  // 2) render the exam question — two-column table appears
+  const host=doc.getElementById('comp-content') || (()=>{ const d=doc.createElement('div'); d.id='comp-content'; doc.body.appendChild(d); return d; })();
+  CV._session=sess; CV._idx=0; CV._answers=[]; CV._started=true;
+  CV._renderAIExamQuestion();
+  const rows=host.querySelectorAll('#mp-rows .mp-row');
+  const bank=host.querySelectorAll('#mp-bank .mp-opt');
+  ok('Column A shows 3 tappable item rows', rows.length===3, 'rows='+rows.length);
+  ok('Column B shows the 5 shared options', bank.length===5, 'bank='+bank.length);
+  ok('the generic instruction shows once as a heading', /Match the items/.test(host.innerHTML));
+  ok('rows show ONLY their item text (no options blob)', !/50%/.test(rows[0].textContent) && /travel allowance/.test(rows[0].textContent));
+
+  // 3) match all three correctly by tap-item then tap-option
+  const opt=(L)=>[...bank].find(b=>b.dataset.letter===L);
+  tap(rows[0]); tap(opt('A'));   // q7 → A (correct)
+  tap(rows[1]); tap(opt('C'));   // q8 → C (correct)
+  tap(rows[2]); tap(opt('B'));   // q9 → B (correct)
+  ok('choices saved live into the answer state', JSON.stringify(CV._answers[0].letters)===JSON.stringify(['A','C','B']), JSON.stringify(CV._answers[0].letters));
+  ok('a chosen row shows its assigned letter badge', rows[0].querySelector('.mp-badge').textContent==='A');
+
+  // 4) navigation preserves the matches (re-render, re-read)
+  CV._renderAIExamQuestion();
+  ok('re-rendering the paper keeps the matches', JSON.stringify(CV._answers[0].letters)===JSON.stringify(['A','C','B']));
+  ok('badges are restored after navigation', host.querySelector('#mp-rows .mp-row .mp-badge').textContent==='A');
+
+  // 5) submit → graded for free, all correct
+  const before=fetchCalls;
+  await CV._finishAIExam();
+  ok('results screen is shown', /AI Exam Results/.test(host.innerHTML));
+  ok('all three pairs scored 100 (three 100/100 rows in the breakdown)', (host.innerHTML.match(/100\/100<\/span>/g)||[]).length===3, (host.innerHTML.match(/100\/100<\/span>/g)||[]).length+'');
+  ok('NO network/AI call was made for a pure matching paper', fetchCalls===before, 'fetchCalls delta='+(fetchCalls-before));
+  ok('feedback credits a free instant check', /No AI credits used/.test(host.innerHTML));
+
+  // 6) a wrong match is marked wrong for free (definitive)
+  CV._session=sess; CV._idx=0; CV._answers=[{ item:sess[0], match:true, letters:['D','C','B'], skipped:false }];
+  const before2=fetchCalls;
+  await CV._finishAIExam();
+  ok('one wrong + two right → two 100s and one 0', (host.innerHTML.match(/100\/100<\/span>/g)||[]).length===2 && /0\/100<\/span>/.test(host.innerHTML));
+  ok('a wrong match still costs no AI call', fetchCalls===before2);
+  ok('wrong match shows the model answer', /Not the right match/.test(host.innerHTML));
+
+  console.log('\n'+(fail? 'FAIL: '+fail : 'ALL '+pass+' checks passed'));
+  process.exit(fail?1:0);
+}, 500);

--- a/knowledgenode/qa/match-integration-check.js
+++ b/knowledgenode/qa/match-integration-check.js
@@ -1,0 +1,76 @@
+// End-to-end (jsdom): rendering a matching question in the exam produces real
+// tappable option buttons, and tapping one fills the hidden answer field with
+// the full "LETTER — text" — so the existing save + free-grading path marks it.
+// Also proves an ordinary open question still renders a normal textarea.
+const fs=require('fs'), path=require('path'), vm=require('vm');
+const { JSDOM } = require('jsdom');
+require('fake-indexeddb/auto');
+const WWW=process.env.WWW||require('path').join(__dirname,'..','www');
+let pass=0,fail=0; const ok=(n,c,x='')=>{ c?(pass++,console.log('  ✓ '+n)):(fail++,console.error('  ✗ '+n+(x?'  → '+x:''))); };
+const dom = new JSDOM(fs.readFileSync(path.join(WWW,'index.html'),'utf8'),{ url:'https://localhost/', runScripts:'outside-only', pretendToBeVisual:true });
+const win=dom.window, doc=win.document;
+win.indexedDB=globalThis.indexedDB; win.scrollTo=()=>{};
+win.matchMedia=()=>({matches:false,addEventListener(){},removeEventListener(){},addListener(){},removeListener(){}});
+win.requestAnimationFrame=cb=>setTimeout(()=>cb(Date.now()),0); win.cancelAnimationFrame=()=>{};
+win.URL.createObjectURL=()=>'blob:fake'; win.URL.revokeObjectURL=()=>{};
+const ctx2d=new Proxy({},{get:()=>()=>({data:[]})});
+win.HTMLCanvasElement.prototype.getContext=()=>ctx2d;
+win.HTMLElement.prototype.scrollIntoView=()=>{};
+win.HTMLCanvasElement.prototype.toDataURL=()=>'data:image/jpeg;base64,AAAA';
+win.fetch=async()=>({ok:false,status:404,json:async()=>({}),text:async()=>''});
+win.console.error=()=>{}; win.console.warn=()=>{};
+let big='';
+for(const s of [...doc.querySelectorAll('script')]){
+  const src=s.getAttribute('src');
+  if(src){ if(/^https?:/.test(src))continue; big+='\n'+fs.readFileSync(path.join(WWW,src.split('?')[0]),'utf8'); }
+  else big+='\n'+s.textContent;
+}
+big+='\n;try{window.CompetencyView=CompetencyView;window.MatchOptions=MatchOptions;window.LocalGrader=LocalGrader;}catch(e){}';
+vm.runInContext(big, dom.getInternalVMContext(), {filename:'app.js'});
+doc.dispatchEvent(new win.Event('DOMContentLoaded')); win.dispatchEvent(new win.Event('load'));
+const W=win;
+
+setTimeout(()=>{
+  console.log('Matching question — DOM integration');
+  const CV=W.CompetencyView;
+  const matchQ={ question:'10. Current withholding tax on dividends\nA — 50%\nB — Medical aid contributions\nC — 20%\nD — 15%\nE — 18%', answer:'C — 20%' };
+  const openQ ={ question:'Explain the difference between gross income and taxable income.', answer:'gross income is total received' };
+
+  // --- render a matching question into a container and wire taps ---
+  const host=doc.createElement('div'); host.id='comp-content'; doc.body.appendChild(host);
+  host.innerHTML = '<div class="quiz-card">'+CV._answerBlock(matchQ,'')+'</div>';
+  CV._wireMatchTaps(matchQ,'ai-answer');
+
+  const btns=host.querySelectorAll('#match-opts .match-opt');
+  ok('matching question renders tappable option buttons', btns.length===5, 'got '+btns.length);
+  ok('a hidden #ai-answer field is present', !!host.querySelector('#ai-answer') && host.querySelector('#ai-answer').style.display==='none');
+  ok('no free-text placeholder box is shown for a matching question', !host.querySelector('textarea[placeholder]'));
+  ok('the Column A stem is shown', /Current withholding tax on dividends/.test(host.querySelector('.quiz-question').innerHTML));
+
+  // --- tap option C ---
+  const cBtn=[...btns].find(b=>b.dataset.letter==='C');
+  cBtn.dispatchEvent(new W.Event('click',{bubbles:true}));
+  const hidden=host.querySelector('#ai-answer');
+  ok('tapping C fills the hidden answer with "C — 20%"', hidden.value==='C — 20%', hidden.value);
+  ok('tapped button is visually marked picked', cBtn.classList.contains('is-picked'));
+  ok('the stored answer grades CORRECT for free (no AI)', W.LocalGrader.match(hidden.value,[matchQ.answer]).verdict==='correct');
+
+  // --- change mind: tap A ---
+  const aBtn=[...btns].find(b=>b.dataset.letter==='A');
+  aBtn.dispatchEvent(new W.Event('click',{bubbles:true}));
+  ok('re-tapping moves the selection to A', aBtn.classList.contains('is-picked') && !cBtn.classList.contains('is-picked'));
+  ok('a wrong choice does NOT falsely grade correct', W.LocalGrader.match(host.querySelector('#ai-answer').value,[matchQ.answer]).verdict==='unknown');
+
+  // --- open question keeps the normal textarea ---
+  host.innerHTML='<div class="quiz-card">'+CV._answerBlock(openQ,'')+'</div>';
+  CV._wireMatchTaps(openQ,'ai-answer');
+  ok('open question still renders a free-text answer box', !!host.querySelector('textarea.config-input[placeholder]') && !host.querySelector('#match-opts'));
+
+  // --- revisit: a saved answer re-highlights its option ---
+  host.innerHTML='<div class="quiz-card">'+CV._answerBlock(matchQ,'C — 20%')+'</div>';
+  const picked=host.querySelector('#match-opts .match-opt.is-picked');
+  ok('revisiting a saved paper re-highlights the chosen option', picked && picked.dataset.letter==='C', picked && picked.dataset.letter);
+
+  console.log('\n'+(fail? 'FAIL: '+fail : 'ALL '+pass+' checks passed'));
+  process.exit(fail?1:0);
+}, 400);

--- a/knowledgenode/qa/match-options-check.js
+++ b/knowledgenode/qa/match-options-check.js
@@ -35,6 +35,24 @@ const pAQ = MO.parse(AQ);
 ok('17 consecutive options (A…Q) all captured', pAQ && pAQ.options.length === 17, pAQ && pAQ.options.length);
 ok('last letter is Q', pAQ && pAQ.options[16].letter === 'Q');
 
+
+console.log('1c) Worksheets that write options as a bare letter, no bracket or dash');
+const BARE = 'Provisional tax is payable by:\n'
+  + 'A Employees who earn salary income above R 1 million\n'
+  + 'B Sole proprietors\n'
+  + 'C Individuals (over the age of 65) who earn rental, interest or dividends of R 100 000\n'
+  + 'D All of the above';
+const pB = MO.parse(BARE);
+ok('"A Employees who…" (no separator) parses', !!pB);
+ok('all four options captured', pB && pB.options.length === 4, pB && pB.options.length);
+ok('the stem is kept separate', pB && pB.stem === 'Provisional tax is payable by:', pB && JSON.stringify(pB.stem));
+ok('the letter is not left inside the option text', pB && pB.options[0].text === 'Employees who earn salary income above R 1 million', pB && pB.options[0].text);
+ok('an option containing brackets survives intact', pB && /over the age of 65/.test(pB.options[2].text));
+ok('prose beginning with a lone capital letter is NOT mistaken for options',
+   MO.parse('A resident must pay tax.\nBecause the rule says so.\nCarry on reading.') === null);
+ok('lowercase prose after a bare letter is rejected',
+   MO.parse('Q\nA company sells goods\nB widget makers\nC traders here') === null);
+
 console.log('2) Different separators and single-line OCR blobs');
 ok('"A) x  B) y  C) z" (no newlines) still parses', (() => { const p = MO.parse('Pick one A) apple B) pear C) plum'); return p && p.options.length === 3; })());
 ok('"A. x" dotted separators parse', (() => { const p = MO.parse('Q\nA. one\nB. two\nC. three'); return p && p.options.length === 3; })());

--- a/knowledgenode/qa/match-options-check.js
+++ b/knowledgenode/qa/match-options-check.js
@@ -1,0 +1,73 @@
+// Interactive matching / lettered-option questions: a worksheet item whose
+// options (Column B) are flattened into the question text becomes structured,
+// tappable choices instead of an unusable "write a thorough answer" box. The
+// chosen option is stored as "LETTER — text" so the FREE LocalGrader marks it
+// with no AI call. This verifies the parser + that a tapped choice grades free,
+// and that ordinary open questions are left completely alone.
+const path = require('path');
+const WWW = process.env.WWW || path.join(__dirname,'..','www');
+const MO = require(path.join(WWW, 'js/core/MatchOptions.js'));
+const LG = require(path.join(WWW, 'js/core/LocalGrader.js'));
+let pass = 0, fail = 0;
+const ok = (n, c, x = '') => { c ? (pass++, console.log('  ✓ ' + n)) : (fail++, console.error('  ✗ ' + n + (x ? '  → ' + x : ''))); };
+
+console.log('Interactive matching questions');
+
+console.log('1) A real matching item (Column A prompt + many lettered options) parses');
+const q1 = `10. Current withholding tax on dividends
+A — 50%
+B — Medical aid contributions
+C — 20%
+D — 15%
+E — 18%`;
+const p1 = MO.parse(q1);
+ok('parses (not null)', !!p1);
+ok('stem is the Column A prompt', p1 && p1.stem === '10. Current withholding tax on dividends', p1 && JSON.stringify(p1.stem));
+ok('all five options captured', p1 && p1.options.length === 5, p1 && p1.options.length);
+ok('letters read A,B,C,D,E', p1 && p1.options.map(o => o.letter).join('') === 'ABCDE');
+ok('option text is clean (no letter prefix)', p1 && p1.options[2].text === '20%', p1 && p1.options[2].text);
+ok('raw is "LETTER — text"', p1 && p1.options[2].raw === 'C — 20%', p1 && p1.options[2].raw);
+
+console.log('1b) The real screenshot shape: a long A…Q matching list');
+const AQ = '10. Current withholding tax on dividends\n' +
+  'ABCDEFGHIJKLMNOPQ'.split('').map((L, i) => L + ' — value ' + i).join('\n');
+const pAQ = MO.parse(AQ);
+ok('17 consecutive options (A…Q) all captured', pAQ && pAQ.options.length === 17, pAQ && pAQ.options.length);
+ok('last letter is Q', pAQ && pAQ.options[16].letter === 'Q');
+
+console.log('2) Different separators and single-line OCR blobs');
+ok('"A) x  B) y  C) z" (no newlines) still parses', (() => { const p = MO.parse('Pick one A) apple B) pear C) plum'); return p && p.options.length === 3; })());
+ok('"A. x" dotted separators parse', (() => { const p = MO.parse('Q\nA. one\nB. two\nC. three'); return p && p.options.length === 3; })());
+ok('lowercase letters parse', (() => { const p = MO.parse('Q\na — one\nb — two\nc — three'); return p && p.options[0].letter === 'A'; })());
+
+console.log('3) Conservative — ordinary questions are NOT treated as options');
+ok('a normal open question → null', MO.parse('Explain the difference between gross income and taxable income.') === null);
+ok('two options only → null (needs ≥3 in order)', MO.parse('Q\nA — one\nB — two') === null);
+ok('out-of-order letters → null', MO.parse('Q\nB — two\nD — four\nF — six') === null);
+ok('empty/blank → null', MO.parse('') === null && MO.parse(null) === null);
+
+console.log('4) A tapped choice is stored so the FREE grader marks it correct');
+ok('answerFor(C) → "C — 20%"', MO.answerFor(p1, 'C') === 'C — 20%');
+// stored model answer shaped like the import ("C — 20%") → free correct
+ok('tap C grades correct vs "C — 20%"', LG.match(MO.answerFor(p1, 'C'), ['C — 20%']).verdict === 'correct');
+// stored model answer as a bare letter → still free correct
+ok('tap C grades correct vs bare "C"', LG.match(MO.answerFor(p1, 'C'), ['C']).verdict === 'correct');
+// stored model answer as just the value → still free correct (containment)
+ok('tap C grades correct vs value "20%"', LG.match(MO.answerFor(p1, 'C'), ['20%']).verdict === 'correct');
+// a WRONG tap must not be marked correct
+ok('tap A (wrong) does NOT match "C — 20%"', LG.match(MO.answerFor(p1, 'A'), ['C — 20%']).verdict === 'unknown');
+
+console.log('5) Re-highlighting a revisited answer');
+ok('letterOf("C — 20%") → C', MO.letterOf(p1, 'C — 20%') === 'C');
+ok('letterOf("C") → C', MO.letterOf(p1, 'C') === 'C');
+ok('letterOf("20%") → C (matches body)', MO.letterOf(p1, '20%') === 'C');
+ok('letterOf("") → null', MO.letterOf(p1, '') === null);
+ok('letterOf(unknown text) → null', MO.letterOf(p1, 'something else entirely') === null);
+
+console.log('6) Wrapped option bodies are joined, not dropped');
+const p6 = MO.parse('Q\nA — the first option that wraps\nonto a second line\nB — second\nC — third');
+ok('wrapped body is appended to option A', p6 && /wraps onto a second line/.test(p6.options[0].text), p6 && p6.options[0].text);
+ok('still three options (wrap line not counted)', p6 && p6.options.length === 3);
+
+console.log('\n' + (fail ? 'FAIL: ' + fail : 'ALL ' + pass + ' checks passed'));
+process.exit(fail ? 1 : 0);

--- a/knowledgenode/qa/package-lock.json
+++ b/knowledgenode/qa/package-lock.json
@@ -1,0 +1,528 @@
+{
+  "name": "knowledgenode-qa",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "knowledgenode-qa",
+      "version": "1.0.0",
+      "dependencies": {
+        "fake-indexeddb": "^6.2.5",
+        "jsdom": "^29.1.1"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "license": "MIT"
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
+      "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
+      "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "license": "MIT"
+    },
+    "node_modules/tldts": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
+      "integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.9"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
+      "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT"
+    }
+  }
+}

--- a/knowledgenode/qa/package.json
+++ b/knowledgenode/qa/package.json
@@ -1,0 +1,1 @@
+{"name":"knowledgenode-qa","version":"1.0.0","private":true,"scripts":{"test":"node run-all.js"},"dependencies":{"fake-indexeddb":"^6.2.5","jsdom":"^29.1.1"}}

--- a/knowledgenode/qa/question-kind-check.js
+++ b/knowledgenode/qa/question-kind-check.js
@@ -1,0 +1,65 @@
+// Full calculations were being scheduled as flashcards: a ten-minute multi-part
+// computation would surface mid-review, get skipped, rated Again, and eventually
+// be flagged as a leech on a question the student never attempted. Review is for
+// fast retrieval; calculations belong in the exam. This checks the split is
+// right — and, just as importantly, that it stays biased toward keeping cards IN
+// review, since wrongly hiding a recall card costs real practice.
+const path = require('path');
+const WWW = process.env.WWW || path.join(__dirname, '..', 'www');
+const QK = require(path.join(WWW, 'js/core/QuestionKind.js'));
+let pass = 0, fail = 0;
+const ok = (n, c, x = '') => { c ? (pass++, console.log('  ✓ ' + n)) : (fail++, console.error('  ✗ ' + n + (x ? '  → ' + x : ''))); };
+
+console.log('Telling calculations apart from recall');
+
+console.log('1) The real case that started this');
+const CHRIS = {
+  question: 'Chris, whose age next birthday will be 65, donated a usufructuary interest in a house in East London '
+    + 'valued at R 3 250 000 to his sister, Catherine (aged 57) and the bare dominium to his son Nicholas. '
+    + 'Chris made no other donations in the year.\n\nCalculate the donations tax payable by Chris.',
+  answer: 'Value of usufruct:\nAnnual Value: 12% x R 3 250 000 = R 390 000\nPresent value based on life expectancy\nDonations tax = 20% x R 3 130 000 = R 626 000',
+};
+ok('the donations tax question is a calculation', QK.of(CHRIS) === 'calculation', QK.of(CHRIS));
+ok('it is kept out of review', QK.isReviewable(CHRIS) === false);
+
+console.log('2) Short recall questions stay in review');
+[
+  { question: 'Define gross income.', answer: 'The total amount received by or accrued to a resident, excluding capital receipts.' },
+  { question: 'What is the residence basis of taxation?', answer: 'Residents are taxed on worldwide income.' },
+  { question: 'Name one exclusion from gross income.', answer: 'Receipts of a capital nature' },
+  { question: 'What rate of donations tax applies below R30 million?', answer: '20%' },
+  { question: 'Is the sale of a factory building gross income?', answer: 'No — it is capital in nature.' },
+  { question: 'What annual value percentage is used to value a usufruct?', answer: '12%' },
+].forEach(q => ok('recall: "' + q.question.slice(0, 44) + '"', QK.of(q) === 'recall', QK.of(q)));
+
+console.log('3) Multiple choice is always quick, even about amounts');
+const MCQ = {
+  question: 'Provisional tax is payable by:\nA Employees who earn salary income above R 1 million\n'
+    + 'B Sole proprietors\nC Individuals (over the age of 65) who earn rental, interest or dividends of R 100 000\nD All of the above',
+  answer: 'D All of the above',
+};
+ok('a lettered multiple-choice question stays in review', QK.of(MCQ) === 'recall', QK.of(MCQ));
+
+console.log('4) Other genuine calculations are caught');
+[
+  { question: 'Calculate the taxable income of a resident who earned a salary of R500 000 and incurred R36 000 of allowable deductions during the year of assessment.',
+    answer: 'Salary R500 000\nLess deductions R36 000\nTaxable income = R464 000' },
+  { question: 'During the current year of assessment Sipho sold shares for R1 250 000 which he had bought for R400 000. Assume that the shares were capital in nature. Determine the amount of capital gains tax payable.',
+    answer: 'Proceeds R1 250 000\nLess base cost R400 000\nCapital gain = R850 000\nInclusion rate 40% = R340 000' },
+].forEach((q, i) => ok('calculation ' + (i + 1) + ' is routed to the exam', QK.of(q) === 'calculation', QK.of(q)));
+
+console.log('5) Biased toward keeping cards in review');
+ok('a short question merely mentioning an amount stays', QK.of({ question: 'What is the annual donations tax exemption?', answer: 'R100 000' }) === 'recall');
+ok('a long theory question with no amounts stays', QK.of({
+  question: 'Explain in detail the difference between the residence basis and the source basis of taxation, '
+    + 'setting out how each determines which amounts fall into gross income and why South Africa moved between them.',
+  answer: 'Residents are taxed on worldwide income; non-residents only on South African source income.' }) === 'recall');
+ok('an empty or malformed question does not crash', QK.of({}) === 'recall' && QK.of(null) === 'recall');
+
+console.log('6) split() separates the two streams');
+const s = QK.split([CHRIS, MCQ, { question: 'Define gross income.', answer: 'total received' }]);
+ok('one calculation, two recall', s.calculation.length === 1 && s.recall.length === 2,
+   JSON.stringify({ calc: s.calculation.length, recall: s.recall.length }));
+
+console.log('\n' + (fail ? 'FAIL: ' + fail : 'ALL ' + pass + ' checks passed'));
+process.exit(fail ? 1 : 0);

--- a/knowledgenode/qa/run-all.js
+++ b/knowledgenode/qa/run-all.js
@@ -1,0 +1,36 @@
+/**
+ * run-all.js — run every KnowledgeNode check suite and summarise.
+ *
+ *   npm install && npm test                  # tests the app in ../www
+ *   WWW=/path/to/other/www npm test          # test a different build
+ *
+ * Exits non-zero if any suite fails, so it is safe to use in CI.
+ */
+const { execFileSync } = require('child_process');
+const fs = require('fs'), path = require('path');
+
+const suites = fs.readdirSync(__dirname)
+  .filter(f => /-check\.js$/.test(f))
+  .sort((a, b) => (a === 'boot-smoke-check.js' ? -1 : b === 'boot-smoke-check.js' ? 1 : a.localeCompare(b)));
+
+let failed = 0, total = 0;
+for (const s of suites) {
+  let out = '', okRun = true;
+  try {
+    out = execFileSync(process.execPath, [path.join(__dirname, s)], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+  } catch (e) {
+    okRun = false;
+    out = (e.stdout || '') + (e.stderr || '');
+  }
+  const last = out.trim().split('\n').filter(Boolean).pop() || '(no output)';
+  const n = (last.match(/ALL (\d+)/) || [])[1];
+  if (n) total += parseInt(n, 10);
+  if (!okRun) failed++;
+  console.log((okRun ? '  PASS  ' : '  FAIL  ') + s.padEnd(34) + last);
+  if (!okRun) console.log(out.split('\n').filter(l => /✗/.test(l)).map(l => '        ' + l).join('\n'));
+}
+
+console.log('\n' + (failed
+  ? failed + ' of ' + suites.length + ' suite(s) FAILED'
+  : 'All ' + suites.length + ' suites passed (' + total + ' checks)'));
+process.exit(failed ? 1 : 0);

--- a/knowledgenode/webpage-START-HERE.md
+++ b/knowledgenode/webpage-START-HERE.md
@@ -1,0 +1,21 @@
+# KnowledgeNode — phone local-server version
+
+This folder IS the whole app. No build step, no paywall — you (and anyone)
+paste an AI key in Settings once.
+
+## Run it on your phone
+1. Unzip this folder onto your phone (e.g. into Documents/knowledgenode-web)
+2. In your local-server app, set the **document root / serve folder** to this
+   folder (the one containing `index.html`)
+3. Start the server, open the address it shows (e.g. http://localhost:8080)
+   in Chrome on the phone
+
+## Turn on AI (once)
+Settings (gear) → AI setup → paste a key from openrouter.ai/keys (recommended)
+or console.anthropic.com → Save.
+
+## Good to know
+- Your notes/keys are saved in the browser you use — keep using the same one.
+- Voice input (🎤) may be blocked on plain http — everything else works.
+- Importing PDFs/photos needs internet (helper libraries load from a CDN);
+  studying already-generated content works offline.

--- a/knowledgenode/www/css/components.css
+++ b/knowledgenode/www/css/components.css
@@ -4040,6 +4040,25 @@
   scroll-padding-top: 14px;
 }
 
+/* Weak-topic pills on the exam Report Card. Without these the spans sat
+   inline with no separation and the topic names ran into each other as one
+   unreadable string ("Revision question 8Revision question 7…"). */
+.comp-weak-topics {
+  display: flex; flex-wrap: wrap; align-items: center; gap: 6px; margin-top: 8px;
+}
+.comp-topic-pill {
+  display: inline-flex; align-items: center;
+  font-family: var(--font-mono); font-size: 11px; line-height: 1.3;
+  padding: 3px 9px; border-radius: 999px;
+  border: 1px solid var(--border); background: var(--bg-raised); color: var(--text-secondary);
+  max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.comp-topic-pill.weak {
+  border-color: color-mix(in srgb, var(--red) 45%, transparent);
+  background: color-mix(in srgb, var(--red) 12%, transparent);
+  color: var(--red);
+}
+
 .coach-input-row {
   display: flex; gap: 8px; align-items: center; flex-shrink: 0;
   margin-top: 12px;

--- a/knowledgenode/www/css/components.css
+++ b/knowledgenode/www/css/components.css
@@ -1,0 +1,4965 @@
+/* ═══════════════════════════════════════════
+   KNOWLEDGE NODE v2 — COMPONENT STYLES
+═══════════════════════════════════════════ */
+
+/* ══════════════════════════════
+   UPLOAD
+══════════════════════════════ */
+
+.upload-zone {
+  border: 2px dashed var(--border-bright);
+  border-radius: var(--radius-xl);
+  padding: 56px 40px;
+  text-align: center;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  background: linear-gradient(160deg, var(--bg-surface) 0%, var(--bg-raised) 100%);
+  margin-bottom: 20px;
+  position: relative;
+  overflow: hidden;
+}
+
+.upload-zone::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(ellipse at center, var(--accent-glow) 0%, transparent 68%);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.upload-zone:hover, .upload-zone.drag-over { border-color: var(--accent); }
+
+.upload-zone:hover::before, .upload-zone.drag-over::before { opacity: 1; }
+
+.upload-inner { position: relative; z-index: 1; }
+
+.upload-icon {
+  font-size: 44px;
+  color: var(--accent);
+  margin-bottom: 16px;
+  display: block;
+  opacity: 0.75;
+}
+
+.upload-label {
+  font-family: var(--font-ui);
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  margin-bottom: 8px;
+}
+
+.upload-link { color: var(--accent); cursor: pointer; }
+
+.upload-link:hover { text-decoration: underline; }
+
+.upload-hint {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-muted);
+  line-height: 1.8;
+}
+
+.upload-preview {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
+  gap: 10px;
+  margin-bottom: 20px;
+}
+
+.preview-item img { width: 100%; height: 100%; object-fit: cover; }
+
+.upload-config {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 28px 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.processing-status {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+  padding: 60px 20px;
+  text-align: center;
+}
+
+.processing-animation { width: 72px; height: 72px; position: relative; display: flex; align-items: center; justify-content: center; }
+
+.hex-ring {
+  width: 56px; height: 56px;
+  border: 3px solid var(--accent-dim);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: spin 0.9s linear infinite;
+}
+
+@keyframes spin { to { transform: rotate(360deg); } }
+
+.processing-label { font-family: var(--font-mono); font-size: 14px; color: var(--accent); }
+
+.processing-steps { display: flex; gap: 8px; flex-wrap: wrap; justify-content: center; }
+
+.proc-step {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  padding: 5px 14px;
+  border-radius: 99px;
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  transition: all 0.3s ease;
+}
+
+.proc-step.active { border-color: var(--accent); color: var(--accent); background: var(--accent-soft); }
+
+.proc-step.done { border-color: var(--green);  color: var(--green);  background: var(--green-dim); }
+
+/* ══════════════════════════════
+   LIBRARY
+══════════════════════════════ */
+
+.library-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 16px;
+}
+
+.node-card {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 22px 22px 16px;
+  transition: all 0.22s ease;
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.node-card::after {
+  content: '';
+  position: absolute;
+  top: 0; left: 0;
+  width: 100%; height: 2px;
+  background: linear-gradient(90deg, var(--accent) 0%, var(--accent-light) 100%);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.25s ease;
+}
+
+.node-card:hover {
+  border-color: var(--border-bright);
+  background: var(--bg-raised);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-md);
+}
+
+.node-card:hover::after { transform: scaleX(1); }
+
+.node-card-body { flex: 1; cursor: pointer; }
+
+.node-card-subject {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--accent);
+  margin-bottom: 7px;
+}
+
+.node-card-title {
+  font-family: var(--font-ui);
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-bottom: 6px;
+  line-height: 1.3;
+}
+
+.node-card-meta {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-bottom: 16px;
+}
+
+.node-card-stats { display: flex; gap: 14px; align-items: center; }
+
+.mastery-bar-wrap { flex: 1; }
+
+.mastery-bar-label {
+  display: flex;
+  justify-content: space-between;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-muted);
+  margin-bottom: 5px;
+}
+
+.mastery-bar-track {
+  height: 3px;
+  background: var(--border);
+  border-radius: 99px;
+  overflow: hidden;
+}
+
+.mastery-bar-fill {
+  height: 100%;
+  background: linear-gradient(90deg, var(--accent) 0%, var(--accent-light) 100%);
+  border-radius: 99px;
+  transition: width 0.5s ease;
+}
+
+.mastery-score {
+  font-family: var(--font-mono);
+  font-size: 18px;
+  font-weight: 500;
+  color: var(--accent);
+  min-width: 42px;
+  text-align: right;
+}
+
+.node-card-actions {
+  display: flex;
+  gap: 6px;
+  padding-top: 12px;
+  margin-top: 14px;
+  border-top: 1px solid var(--border-soft);
+}
+
+.card-add-btn {
+  flex: 1;
+  padding: 7px 10px !important;
+  font-size: 11px !important;
+  justify-content: center;
+}
+
+.card-del-btn {
+  width: 34px; height: 34px;
+  padding: 0 !important;
+  display: flex; align-items: center; justify-content: center;
+  flex-shrink: 0;
+  font-size: 14px;
+}
+
+.card-del-btn:hover { border-color: var(--red) !important; color: var(--red) !important; }
+
+.node-due-badge {
+  position: absolute;
+  top: 14px; right: 14px;
+  background: var(--accent);
+  color: #060709;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  padding: 3px 8px;
+  border-radius: 99px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+/* ══════════════════════════════
+   NODE DETAIL
+══════════════════════════════ */
+
+.detail-topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 32px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-surface);
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.detail-actions { display: flex; gap: 8px; flex-wrap: wrap; }
+
+.detail-layout { display: flex; min-height: calc(100vh - 65px); }
+
+.detail-sidebar-nav {
+  width: 190px;
+  padding: 24px 12px;
+  border-right: 1px solid var(--border);
+  background: var(--bg-surface);
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  flex-shrink: 0;
+  position: sticky;
+  top: 65px;
+  height: calc(100vh - 65px);
+  overflow-y: auto;
+}
+
+.detail-nav-btn {
+  padding: 10px 14px;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text-secondary);
+  font-family: var(--font-ui);
+  font-size: 13px;
+  font-weight: 500;
+  text-align: left;
+  transition: all var(--ease);
+  cursor: pointer;
+  border: 1px solid transparent;
+}
+
+.detail-nav-btn.active { background: var(--accent-soft); color: var(--accent); border-color: var(--accent-dim); }
+
+.detail-nav-btn:hover:not(.active) { background: var(--bg-hover); color: var(--text-primary); }
+
+.detail-body { flex: 1; padding: 28px 24px 60px; overflow-y: auto; }
+
+/* ══════════════════════════════
+   NOTES RENDERER
+══════════════════════════════ */
+
+.notes-section { margin-bottom: 44px; }
+
+.notes-section-title {
+  font-family: var(--font-ui);
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--accent);
+  margin-bottom: 16px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.notes-section-title::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: linear-gradient(90deg, var(--border) 0%, transparent 100%);
+}
+
+/* Definition items — vertical stack, no gap issues */
+
+.definition-item {
+  display: block;
+  border-bottom: 1px solid var(--border-soft);
+  padding: 16px 0;
+  transition: background var(--ease);
+}
+
+.definition-item:last-child { border-bottom: none; }
+
+.definition-item:hover { background: var(--bg-raised); margin: 0 -12px; padding: 16px 12px; border-radius: var(--radius-sm); }
+
+.definition-term {
+  font-family: var(--font-mono);
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--accent);
+  margin-bottom: 5px;
+}
+
+.definition-examples {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--accent);
+  background: var(--accent-soft);
+  border-radius: var(--radius-sm);
+  padding: 3px 10px;
+  display: inline-block;
+  margin-bottom: 8px;
+  max-width: 100%;
+  word-break: break-word;
+}
+
+.definition-desc {
+  font-family: var(--font-body);
+  font-size: 14px;
+  color: var(--text-primary);
+  line-height: 1.65;
+}
+
+.formula-block {
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent);
+  border-radius: var(--radius-md);
+  padding: 16px 20px;
+  margin-bottom: 10px;
+  transition: border-color var(--ease);
+}
+
+.formula-block:hover { border-color: var(--accent-dim); border-left-color: var(--accent-light); }
+
+.formula-expr {
+  font-family: var(--font-mono);
+  font-size: 15px;
+  color: var(--text-primary);
+  margin-bottom: 6px;
+  letter-spacing: 0.02em;
+}
+
+.formula-desc {
+  font-family: var(--font-body);
+  font-size: 13px;
+  color: var(--text-secondary);
+  font-style: italic;
+  margin-bottom: 4px;
+}
+
+.formula-constraints {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-top: 6px;
+  padding-top: 6px;
+  border-top: 1px solid var(--border-soft);
+}
+
+.procedure-step {
+  display: flex;
+  gap: 18px;
+  padding: 18px 0;
+  border-bottom: 1px solid var(--border-soft);
+}
+
+.procedure-num {
+  width: 30px; height: 30px;
+  border-radius: 50%;
+  border: 1.5px solid var(--accent-dim);
+  color: var(--accent);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  display: flex; align-items: center; justify-content: center;
+  flex-shrink: 0;
+  margin-top: 2px;
+  font-weight: 700;
+}
+
+.procedure-text {
+  font-family: var(--font-body);
+  font-size: 15px;
+  color: var(--text-primary);
+  line-height: 1.75;
+}
+
+.mistake-item {
+  background: var(--red-dim);
+  border: 1px solid rgba(240,97,90,0.18);
+  border-radius: var(--radius-md);
+  padding: 12px 16px 12px 14px;
+  margin-bottom: 8px;
+  font-family: var(--font-body);
+  font-size: 13.5px;
+  color: var(--text-primary);
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+}
+
+.mistake-item::before { content: '⚠'; color: var(--red); flex-shrink: 0; font-size: 13px; margin-top: 1px; }
+
+.summary-block {
+  background: var(--bg-raised);
+  border-radius: var(--radius-md);
+  padding: 22px 24px;
+  font-family: var(--font-body);
+  font-size: 15px;
+  line-height: 1.8;
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--purple);
+}
+
+/* ── Questions ── */
+
+/* ══════════════════════════════
+   REVIEW / FLASHCARD
+══════════════════════════════ */
+
+.review-container { max-width: 640px; margin: 0 auto; }
+
+.review-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.review-counter { font-family: var(--font-mono); font-size: 12px; color: var(--text-muted); }
+
+.review-node-tag {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--accent);
+  background: var(--accent-soft);
+  border: 1px solid var(--accent-dim);
+  border-radius: 99px;
+  padding: 3px 12px;
+  max-width: 280px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.flashcard {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-bright);
+  border-radius: var(--radius-xl);
+  padding: 48px 40px;
+  min-height: 300px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  box-shadow: var(--shadow-md);
+  position: relative;
+  overflow: hidden;
+}
+
+.flashcard::before {
+  content: '';
+  position: absolute;
+  top: -60px; left: 50%;
+  transform: translateX(-50%);
+  width: 200px; height: 200px;
+  background: var(--accent-glow);
+  border-radius: 50%;
+  filter: blur(48px);
+  pointer-events: none;
+}
+
+.flashcard-inner { width: 100%; position: relative; z-index: 1; }
+
+.card-type-label { font-family: var(--font-mono); font-size: 10px; text-transform: uppercase; letter-spacing: 0.12em; color: var(--text-muted); margin-bottom: 18px; }
+
+.card-question { font-family: var(--font-ui); font-size: 19px; font-weight: 600; color: var(--text-primary); line-height: 1.45; margin-bottom: 28px; white-space: pre-wrap; text-align: left; }
+
+.card-answer { font-family: var(--font-body); font-size: 15px; color: var(--text-secondary); line-height: 1.7; margin-bottom: 28px; font-style: italic; white-space: pre-wrap; text-align: left; }
+
+.flashcard-back { animation: fade-in 0.3s ease; }
+
+.rating-prompt { font-family: var(--font-mono); font-size: 11px; color: var(--text-muted); margin-bottom: 12px; }
+
+.rating-btns { display: flex; gap: 8px; justify-content: center; flex-wrap: wrap; }
+
+.rating-btn:hover { transform: translateY(-2px); }
+
+.rating-1:hover { border-color: var(--red);    color: var(--red);    background: var(--red-dim); }
+
+.rating-2:hover { border-color: #e09a4a;        color: #e09a4a;        background: rgba(224,154,74,0.1); }
+
+.rating-3:hover { border-color: var(--blue);   color: var(--blue);   background: var(--blue-dim); }
+
+.rating-4:hover { border-color: var(--green);  color: var(--green);  background: var(--green-dim); }
+
+.review-complete { text-align: center; padding: 80px 40px; }
+
+.complete-icon { font-size: 60px; color: var(--green); margin-bottom: 20px; }
+
+.review-complete h2 { font-family: var(--font-ui); font-size: 26px; font-weight: 800; margin-bottom: 10px; }
+
+.review-complete p { font-family: var(--font-mono); font-size: 13px; color: var(--text-muted); margin-bottom: 28px; }
+
+/* ── Review Filter ── */
+
+#review-filter-panel {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 24px 28px;
+  margin-bottom: 28px;
+  max-width: 680px;
+}
+
+/* ══════════════════════════════
+   MASTERY
+══════════════════════════════ */
+
+.mastery-overview {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 12px;
+  margin-bottom: 28px;
+}
+
+.mastery-stat-card {
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 18px;
+  text-align: center;
+  transition: border-color var(--ease);
+}
+
+.mastery-stat-card:hover { border-color: var(--border-bright); }
+
+.mastery-stat-value { display: block; font-family: var(--font-mono); font-size: 26px; color: var(--accent); font-weight: 500; margin-bottom: 6px; }
+
+.mastery-stat-label { font-family: var(--font-ui); font-size: 10px; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text-muted); }
+
+/* ══════════════════════════════
+   EDIT MODE
+══════════════════════════════ */
+
+.edit-section {
+  margin-bottom: 28px;
+  padding-bottom: 24px;
+  border-bottom: 1px solid var(--border-soft);
+}
+
+.edit-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.edit-del-btn {
+  width: 30px; height: 30px;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  font-size: 13px;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: all var(--ease);
+  display: flex; align-items: center; justify-content: center;
+}
+
+.edit-del-btn:hover { border-color: var(--red); color: var(--red); background: var(--red-dim); }
+
+/* ══════════════════════════════
+   LECTURE MODE
+══════════════════════════════ */
+
+/* ══════════════════════════════
+   AI SETTINGS MODAL
+══════════════════════════════ */
+
+.provider-btn .provider-icon { font-size: 22px; }
+
+.provider-btn .provider-name { font-size: 11px; }
+
+/* ══════════════════════════════
+   EXPORT FORMAT PICKER
+══════════════════════════════ */
+
+.export-format-btn {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  width: 100%;
+  padding: 16px 18px;
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  text-align: left;
+}
+
+.export-format-btn:hover {
+  border-color: var(--accent);
+  background: var(--bg-hover);
+  transform: translateX(3px);
+}
+
+.export-format-btn .exp-icon {
+  font-size: 26px;
+  flex-shrink: 0;
+  width: 36px;
+  text-align: center;
+}
+
+.export-format-btn .exp-title {
+  font-family: var(--font-ui);
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-bottom: 3px;
+}
+
+.export-format-btn .exp-desc {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+/* ══════════════════════════════
+   STUDY PLAN
+══════════════════════════════ */
+
+/* Wizard */
+
+.wizard-steps {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  margin-bottom: 4px;
+}
+
+.wizard-step {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  flex: 1;
+}
+
+.wizard-step-dot {
+  width: 28px; height: 28px;
+  border-radius: 50%;
+  border: 2px solid var(--border);
+  display: flex; align-items: center; justify-content: center;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-muted);
+  background: var(--bg-raised);
+  transition: all 0.2s;
+}
+
+.wizard-step.active .wizard-step-dot { border-color: var(--accent); color: var(--accent); background: var(--accent-soft); }
+
+.wizard-step.done   .wizard-step-dot { border-color: var(--green);  color: var(--green);  background: var(--green-dim); }
+
+.wizard-step span { font-family: var(--font-ui); font-size: 10px; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.06em; }
+
+.wizard-step.active span { color: var(--accent); }
+
+.wizard-step-line { flex: 1; height: 2px; background: var(--border); margin: 0 4px; margin-bottom: 16px; }
+
+/* Plan task rows */
+
+.plan-task {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--border-soft);
+  transition: opacity 0.2s;
+}
+
+.plan-task.done { opacity: 0.5; }
+
+.priority-dot {
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.priority-dot.priority-1 { background: var(--border-bright); }
+
+.priority-dot.priority-2 { background: var(--accent); }
+
+.priority-dot.priority-3 { background: var(--red); }
+
+/* Plan day card */
+
+.plan-day-card[open] summary { border-bottom: 1px solid var(--border-soft); }
+
+/* Subject toggles in wizard */
+
+.subject-toggle input { cursor: pointer; }
+
+/* Competency test grade */
+
+/* ══════════════════════════════
+   ONBOARDING
+══════════════════════════════ */
+
+.onboarding-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(4,5,8,0.96);
+  z-index: 99999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  backdrop-filter: blur(8px);
+}
+
+.onboarding-card {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-bright);
+  border-radius: var(--radius-2xl);
+  padding: 40px 36px;
+  max-width: 520px;
+  width: 100%;
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: var(--shadow-lg);
+  position: relative;
+}
+
+.onboarding-logo {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 20px;
+}
+
+.onboarding-title {
+  font-family: var(--font-ui);
+  font-size: 28px;
+  font-weight: 800;
+  color: var(--text-primary);
+  text-align: center;
+  margin-bottom: 12px;
+  line-height: 1.2;
+}
+
+.onboarding-subtitle {
+  font-family: var(--font-body);
+  font-size: 15px;
+  color: var(--text-secondary);
+  text-align: center;
+  line-height: 1.65;
+  margin-bottom: 28px;
+  font-style: italic;
+}
+
+.welcome-loop {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  margin-bottom: 32px;
+  flex-wrap: wrap;
+}
+
+.loop-step {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 10px 14px;
+}
+
+.loop-icon { font-size: 20px; }
+
+.loop-step span:last-child { font-family: var(--font-ui); font-size: 11px; color: var(--text-muted); font-weight: 600; }
+
+.loop-arrow { font-size: 16px; color: var(--accent); }
+
+.welcome-choices { display: flex; flex-direction: column; gap: 10px; }
+
+.welcome-btn-main { justify-content: center; padding: 14px; font-size: 15px; }
+
+.welcome-btn-skip { justify-content: center; }
+
+/* Slide card */
+
+.ob-skip-link:hover { color: var(--text-primary); }
+
+.ob-progress-track {
+  height: 3px;
+  background: var(--border);
+  border-radius: 99px;
+  overflow: hidden;
+  margin-bottom: 28px;
+}
+
+.ob-progress-fill {
+  height: 100%;
+  background: linear-gradient(90deg, var(--accent), var(--accent-light));
+  border-radius: 99px;
+  transition: width 0.4s ease;
+}
+
+.ob-slide-body {
+  font-family: var(--font-body);
+  font-size: 14px;
+  color: var(--text-secondary);
+  line-height: 1.7;
+  text-align: center;
+  margin-bottom: 0;
+}
+
+/* Slide visuals */
+
+.slide-visual {
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 16px;
+  margin: 16px 0;
+}
+
+.nodes-visual { display: flex; flex-direction: column; align-items: center; gap: 6px; font-family: var(--font-mono); font-size: 12px; }
+
+.snode { background: var(--bg-surface); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 8px 16px; color: var(--text-secondary); }
+
+.snode-arrow { color: var(--accent); font-weight: 700; }
+
+.snode-out { display: flex; gap: 8px; flex-wrap: wrap; justify-content: center; background: var(--accent-soft); border-color: var(--accent-dim); color: var(--accent); }
+
+.snode-out div { padding: 4px 10px; background: var(--bg-raised); border-radius: var(--radius-sm); }
+
+.steps-visual { display: flex; align-items: center; gap: 0; justify-content: center; }
+
+.sstep { padding: 8px 12px; border-radius: var(--radius-sm); font-family: var(--font-mono); font-size: 11px; border: 1px solid var(--border); background: var(--bg-surface); color: var(--text-muted); }
+
+.sstep.done { border-color: var(--green); color: var(--green); background: var(--green-dim); }
+
+.sstep.active { border-color: var(--accent); color: var(--accent); background: var(--accent-soft); }
+
+.sstep.locked { opacity: 0.4; }
+
+.sstep-line { width: 16px; height: 2px; background: var(--border); }
+
+.plan-visual { display: flex; flex-direction: column; gap: 6px; }
+
+.splan-row { display: flex; align-items: center; gap: 8px; font-family: var(--font-mono); font-size: 11px; color: var(--text-muted); }
+
+.splan-row span { min-width: 30px; }
+
+.splan-bar { background: var(--accent-soft); border: 1px solid var(--accent-dim); border-radius: var(--radius-sm); padding: 5px 10px; color: var(--accent); font-size: 11px; }
+
+/* ══════════════════════════════
+   NOTE TEMPLATES
+══════════════════════════════ */
+
+.template-picker { display: flex; flex-direction: column; gap: 8px; margin-top: 8px; }
+
+.template-option {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px 14px;
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: all var(--ease);
+}
+
+.template-option:hover { border-color: var(--border-bright); background: var(--bg-hover); }
+
+.template-option.selected { border-color: var(--accent); background: var(--accent-soft); }
+
+.template-icon { font-size: 20px; flex-shrink: 0; margin-top: 1px; }
+
+.template-name { font-family: var(--font-ui); font-size: 13px; font-weight: 700; color: var(--text-primary); margin-bottom: 2px; }
+
+.template-desc { font-family: var(--font-mono); font-size: 11px; color: var(--text-muted); line-height: 1.5; }
+
+/* Cornell */
+
+.cornell-layout { display: flex; flex-direction: column; gap: 0; border: 1px solid var(--border); border-radius: var(--radius-md); overflow: hidden; }
+
+.cornell-header { padding: 16px 20px; background: var(--bg-raised); border-bottom: 1px solid var(--border); }
+
+.cornell-title { font-family: var(--font-ui); font-size: 18px; font-weight: 800; margin-bottom: 4px; }
+
+.cornell-meta { font-family: var(--font-mono); font-size: 11px; color: var(--text-muted); }
+
+.cornell-body { display: grid; grid-template-columns: 200px 1fr; min-height: 200px; }
+
+.cornell-cues { border-right: 1px solid var(--border); padding: 16px; background: var(--bg-raised); }
+
+.cornell-notes { padding: 16px; }
+
+.cornell-col-label { font-family: var(--font-ui); font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.1em; color: var(--accent); margin-bottom: 12px; }
+
+.cornell-cue-item { font-family: var(--font-mono); font-size: 12px; color: var(--text-secondary); padding: 6px 0; border-bottom: 1px solid var(--border-soft); }
+
+.cornell-note-item { font-family: var(--font-body); font-size: 13px; color: var(--text-primary); padding: 6px 0; border-bottom: 1px solid var(--border-soft); display: flex; gap: 8px; }
+
+.cn-section-title { font-family: var(--font-ui); font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-muted); margin: 12px 0 6px; }
+
+.cornell-summary { border-top: 2px solid var(--border); padding: 16px; background: var(--bg-raised); }
+
+.cornell-summary-body { font-family: var(--font-body); font-size: 14px; color: var(--text-primary); line-height: 1.7; }
+
+/* Outline */
+
+.outline-layout { padding: 4px 0; }
+
+.outline-title { font-family: var(--font-ui); font-size: 20px; font-weight: 800; margin-bottom: 4px; }
+
+.outline-meta { font-family: var(--font-mono); font-size: 11px; color: var(--text-muted); margin-bottom: 20px; }
+
+.outline-section { margin-bottom: 20px; }
+
+.outline-h1 { font-family: var(--font-ui); font-size: 14px; font-weight: 700; color: var(--text-primary); margin-bottom: 8px; padding: 8px 12px; background: var(--bg-raised); border-left: 3px solid var(--accent); border-radius: var(--radius-sm); }
+
+.outline-h2 { font-family: var(--font-body); font-size: 13px; color: var(--text-primary); padding: 5px 12px 5px 24px; margin-bottom: 2px; }
+
+.outline-h3 { font-family: var(--font-body); font-size: 13px; color: var(--text-secondary); padding: 4px 12px 4px 40px; font-style: italic; }
+
+.outline-h4 { font-family: var(--font-mono); font-size: 11px; color: var(--text-muted); padding: 3px 12px 3px 52px; }
+
+.outline-mistake { color: var(--red); }
+
+/* Feynman */
+
+.feynman-layout { display: flex; flex-direction: column; gap: 0; }
+
+.feynman-title { font-family: var(--font-ui); font-size: 20px; font-weight: 800; margin-bottom: 4px; }
+
+.feynman-meta { font-family: var(--font-mono); font-size: 11px; color: var(--text-muted); margin-bottom: 24px; }
+
+.feynman-step { display: flex; gap: 16px; margin-bottom: 20px; padding-bottom: 20px; border-bottom: 1px solid var(--border-soft); }
+
+.feynman-step:last-child { border-bottom: none; }
+
+.feynman-step-num {
+  width: 32px; height: 32px; border-radius: 50%;
+  background: var(--accent); color: #000;
+  font-family: var(--font-ui); font-size: 14px; font-weight: 800;
+  display: flex; align-items: center; justify-content: center; flex-shrink: 0;
+}
+
+.feynman-step-content { flex: 1; min-width: 0; }
+
+.feynman-step-title { font-family: var(--font-ui); font-size: 14px; font-weight: 700; color: var(--text-primary); margin-bottom: 4px; }
+
+.feynman-step-desc { font-family: var(--font-mono); font-size: 11px; color: var(--text-muted); margin-bottom: 10px; }
+
+.feynman-box { background: var(--bg-raised); border: 1px solid var(--border); border-radius: var(--radius-md); padding: 14px 16px; font-family: var(--font-body); font-size: 14px; color: var(--text-primary); line-height: 1.7; white-space: pre-wrap; min-height: 60px; }
+
+.feynman-empty { border-style: dashed; }
+
+.feynman-gaps { display: flex; flex-direction: column; gap: 6px; }
+
+.feynman-gap-item { background: var(--red-dim); border: 1px solid rgba(240,97,90,0.2); border-radius: var(--radius-sm); padding: 8px 12px; font-family: var(--font-body); font-size: 13px; color: var(--text-primary); }
+
+/* ══════════════════════════════
+   GUIDED FLOW — NEW STEPS
+══════════════════════════════ */
+
+/* Tab bar — single scrollable row, never wraps */
+
+.step-tabs {
+  display: flex;
+  align-items: flex-start;
+  background: transparent;
+  border-bottom: none;
+  overflow: visible;            /* fits to width now — no clipping */
+  padding: 6px 2px 2px;
+  margin-bottom: 4px;
+}
+
+.step-tab {
+  flex: 1 1 0;
+  min-width: 0;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 7px;
+  background: transparent;
+  border: none;
+  padding: 6px 2px 4px;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+
+/* Connecting rail sits behind the node circles; the segment leading into a
+   reached step (done or active) is filled, upcoming segments stay muted. */
+.step-tab::before {
+  content: '';
+  position: absolute;
+  top: 21px;
+  right: 50%;
+  width: 100%;
+  height: 2px;
+  background: var(--border);
+  z-index: 0;
+}
+.step-tab:first-child::before { display: none; }
+.step-tab.done::before,
+.step-tab.active::before { background: var(--green); }
+
+.step-tab-icon {
+  position: relative;
+  z-index: 1;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  font-size: 14px;
+  line-height: 1;
+  background: var(--bg-raised);
+  border: 1.5px solid var(--border-bright);
+  color: var(--text-muted);
+  transition: background var(--ease), border-color var(--ease), box-shadow var(--ease), color var(--ease);
+}
+
+.step-tab-label {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  white-space: nowrap;
+  transition: color var(--ease);
+}
+
+/* States */
+.step-tab.done .step-tab-icon {
+  background: var(--green-dim);
+  border-color: var(--green);
+  color: var(--green);
+  font-size: 15px;
+}
+.step-tab.done .step-tab-label { color: var(--text-secondary); }
+
+.step-tab.active .step-tab-icon {
+  background: var(--accent-soft);
+  border: 2px solid var(--accent);
+  box-shadow: 0 0 0 4px var(--accent-glow);
+  color: var(--accent);
+}
+.step-tab.active .step-tab-label { color: var(--accent); font-weight: 700; }
+
+.step-tab.locked { cursor: not-allowed; }
+.step-tab.locked .step-tab-icon { opacity: 0.5; }
+.step-tab.locked .step-tab-label { opacity: 0.5; }
+
+.step-tab:not(.locked):not(.active):hover .step-tab-icon {
+  border-color: var(--text-secondary);
+  color: var(--text-secondary);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .step-tab-icon, .step-tab-label { transition: none; }
+}
+
+.guided-read-step { }
+
+.read-step-header { text-align: center; margin-bottom: 24px; }
+
+.read-step-icon { font-size: 36px; margin-bottom: 8px; }
+
+.read-step-title { font-family: var(--font-ui); font-size: 18px; font-weight: 800; margin-bottom: 8px; }
+
+.read-step-desc { font-family: var(--font-body); font-size: 14px; color: var(--text-secondary); }
+
+.read-checklist { background: var(--bg-raised); border: 1px solid var(--border); border-radius: var(--radius-md); padding: 16px 20px; margin-bottom: 16px; display: flex; flex-direction: column; gap: 10px; }
+
+.read-check-label { font-family: var(--font-ui); font-size: 12px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-muted); margin-bottom: 4px; }
+
+.read-check-item { display: flex; align-items: center; gap: 10px; font-family: var(--font-body); font-size: 14px; color: var(--text-primary); cursor: pointer; }
+
+.read-check-item input { accent-color: var(--accent); width: 16px; height: 16px; }
+
+.read-rule { background: var(--accent-soft); border: 1px solid var(--accent-dim); border-radius: var(--radius-md); padding: 12px 16px; font-family: var(--font-mono); font-size: 12px; color: var(--accent); }
+
+/* Understanding Check */
+
+.uc-icon { font-size: 36px; margin-bottom: 8px; }
+
+.uc-desc { font-family: var(--font-body); font-size: 14px; color: var(--text-secondary); margin-bottom: 8px; line-height: 1.6; }
+
+.uc-hint { font-family: var(--font-mono); font-size: 12px; color: var(--accent); }
+
+.uc-q { display: flex; flex-direction: column; gap: 7px; }
+
+/* Blank Recall */
+
+.recall-intro { text-align: center; margin-bottom: 24px; }
+
+.recall-intro-icon { font-size: 36px; margin-bottom: 8px; }
+
+.recall-intro-title { font-family: var(--font-ui); font-size: 18px; font-weight: 800; margin-bottom: 8px; }
+
+.recall-intro-desc { font-family: var(--font-body); font-size: 14px; color: var(--text-secondary); margin-bottom: 6px; line-height: 1.6; }
+
+.recall-intro-hint { font-family: var(--font-mono); font-size: 12px; color: var(--accent); font-style: italic; }
+
+.recall-sections { display: flex; flex-direction: column; gap: 16px; }
+
+.recall-section { display: flex; flex-direction: column; gap: 7px; }
+
+.recall-section-label { font-family: var(--font-ui); font-size: 13px; font-weight: 600; color: var(--text-primary); }
+
+.recall-textarea { resize: vertical; min-height: 80px; }
+
+.recall-compare-header { margin-bottom: 16px; }
+
+.recall-compare-section {
+  border: 2px solid var(--border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  margin-bottom: 12px;
+  transition: border-color 0.2s;
+}
+
+.recall-compare-section.border-red { border-color: var(--red); }
+
+.recall-compare-section.border-orange { border-color: var(--accent); }
+
+.recall-compare-section.border-green { border-color: var(--green); }
+
+.recall-compare-label { font-family: var(--font-ui); font-size: 12px; font-weight: 700; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.08em; padding: 10px 14px; background: var(--bg-raised); border-bottom: 1px solid var(--border); }
+
+.recall-compare-cols { display: grid; grid-template-columns: 1fr 1fr; }
+
+.recall-col { padding: 12px 14px; }
+
+.recall-col-user { border-right: 1px solid var(--border); background: var(--bg-raised); }
+
+.recall-col-actual { background: var(--bg-surface); }
+
+.recall-col-header { font-family: var(--font-mono); font-size: 10px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-muted); margin-bottom: 8px; }
+
+.recall-col-body { font-family: var(--font-body); font-size: 13px; color: var(--text-primary); line-height: 1.6; white-space: pre-wrap; }
+
+.recall-gap-rating { display: flex; align-items: center; gap: 12px; padding: 10px 14px; background: var(--bg-raised); border-top: 1px solid var(--border); flex-wrap: wrap; }
+
+.gap-btns { display: flex; gap: 6px; }
+
+.gap-btn { padding: 6px 14px; border: 1px solid var(--border); border-radius: var(--radius-sm); background: transparent; font-family: var(--font-ui); font-size: 12px; font-weight: 600; cursor: pointer; transition: all var(--ease); color: var(--text-secondary); }
+
+.gap-btn.selected { font-weight: 800; }
+
+.gap-red.selected { background: var(--red-dim);   border-color: var(--red);   color: var(--red); }
+
+.gap-orange.selected { background: var(--accent-soft); border-color: var(--accent); color: var(--accent); }
+
+.gap-green.selected { background: var(--green-dim); border-color: var(--green); color: var(--green); }
+
+.gap-btn:hover { background: var(--bg-hover); }
+
+.recall-gap-summary { background: var(--bg-raised); border: 1px solid var(--border); border-radius: var(--radius-md); padding: 14px 16px; margin-top: 16px; }
+
+.gap-summary-row { display: flex; gap: 10px; flex-wrap: wrap; align-items: center; }
+
+.gap-pill { font-family: var(--font-mono); font-size: 11px; padding: 4px 10px; border-radius: 99px; font-weight: 600; }
+
+.gap-pill.red { background: var(--red-dim);    color: var(--red);    border: 1px solid rgba(240,97,90,0.2); }
+
+.gap-pill.orange { background: var(--accent-soft); color: var(--accent); border: 1px solid var(--accent-dim); }
+
+.gap-pill.green { background: var(--green-dim);  color: var(--green);  border: 1px solid rgba(62,207,130,0.2); }
+
+/* Completed step tab */
+
+.step-tab.completed { color: var(--green); border-bottom-color: var(--green); opacity: 1; }
+
+/* ══════════════════════════════
+   ONBOARDING
+══════════════════════════════ */
+
+.ob-overlay {
+  position: fixed;
+  inset: 0;
+  background: var(--bg-base);
+  z-index: 99999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  /* honour device safe-areas (gesture bar / notch) so nothing hides under them */
+  padding: max(24px, env(safe-area-inset-top, 0px))
+           max(24px, env(safe-area-inset-right, 0px))
+           max(24px, env(safe-area-inset-bottom, 0px))
+           max(24px, env(safe-area-inset-left, 0px));
+  /* fallback scroll if a slide is taller than the screen */
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  animation: fade-in 0.3s ease;
+}
+
+.ob-welcome {
+  max-width: 480px;
+  width: 100%;
+  text-align: center;
+  max-height: calc(100dvh - max(48px, env(safe-area-inset-top, 0px) + env(safe-area-inset-bottom, 0px)));
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.ob-logo { display:flex; align-items:center; justify-content:center; gap:12px; margin-bottom:32px; }
+
+.ob-logo-mark {
+  width:44px; height:44px; background:var(--accent); border-radius:10px;
+  font-family:var(--font-ui); font-size:22px; font-weight:900; color:#000;
+  display:flex; align-items:center; justify-content:center;
+  box-shadow: 0 4px 16px rgba(240,165,0,0.4);
+}
+
+.ob-logo-text { font-family:var(--font-ui); font-size:20px; font-weight:800; color:var(--text-primary); }
+
+.ob-welcome-title {
+  font-family:var(--font-ui); font-size:32px; font-weight:800;
+  color:var(--text-primary); line-height:1.15; margin-bottom:12px;
+}
+
+.ob-welcome-sub { font-family:var(--font-body); font-size:15px; color:var(--text-secondary); margin-bottom:36px; }
+
+.ob-choice-btns { display:flex; flex-direction:column; gap:12px; margin-bottom:20px; }
+
+.ob-btn-primary {
+  padding:16px 24px; background:var(--accent); color:#000; border:none;
+  border-radius:var(--radius-lg); font-family:var(--font-ui); font-size:15px;
+  font-weight:700; cursor:pointer; transition:all 0.2s;
+  box-shadow: 0 4px 20px rgba(240,165,0,0.35);
+}
+
+.ob-btn-primary:hover { background:var(--accent-light); transform:translateY(-1px); }
+
+.ob-btn-secondary {
+  padding:14px 24px; background:var(--bg-raised); color:var(--text-secondary);
+  border:1px solid var(--border); border-radius:var(--radius-lg);
+  font-family:var(--font-ui); font-size:14px; font-weight:600; cursor:pointer;
+  transition:all 0.2s;
+}
+
+.ob-btn-secondary:hover { border-color:var(--border-bright); color:var(--text-primary); }
+
+.ob-btn-ghost {
+  background:transparent; border:none; color:var(--text-muted);
+  font-family:var(--font-ui); font-size:13px; cursor:pointer; padding:8px 12px;
+}
+
+.ob-small { font-family:var(--font-mono); font-size:11px; color:var(--text-muted); }
+
+/* Slide */
+
+.ob-slide {
+  max-width: 520px;
+  width: 100%;
+  /* never taller than the viewport (minus the overlay's safe-area padding) */
+  max-height: calc(100dvh - max(48px, env(safe-area-inset-top, 0px) + env(safe-area-inset-bottom, 0px)));
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+/* header bits never shrink — only the content area scrolls */
+.ob-skip-link,
+.ob-slide-icon,
+.ob-slide-title,
+.ob-slide-sub,
+.ob-dots,
+.ob-slide-nav { flex-shrink: 0; }
+
+.ob-skip-link {
+  display:block; text-align:right; background:transparent; border:none;
+  color:var(--text-muted); font-family:var(--font-mono); font-size:12px;
+  cursor:pointer; margin-bottom:24px;
+}
+
+.ob-slide-icon { font-size:40px; margin-bottom:12px; }
+
+.ob-slide-title { font-family:var(--font-ui); font-size:24px; font-weight:800; color:var(--text-primary); margin-bottom:6px; }
+
+.ob-slide-sub { font-family:var(--font-body); font-size:14px; color:var(--text-secondary); font-style:italic; margin-bottom:24px; }
+
+.ob-slide-content {
+  margin-bottom: 20px;
+  /* this is the part that scrolls when content is tall */
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.ob-dots { display:flex; gap:8px; justify-content:center; margin-bottom:24px; }
+
+.ob-dot { width:8px; height:8px; border-radius:50%; background:var(--border); transition:background 0.2s; }
+
+.ob-dot.active { background:var(--accent); width:20px; border-radius:4px; }
+
+.ob-slide-nav { display:flex; justify-content:space-between; align-items:center; }
+
+/* Loop graphic */
+
+.ob-loop { display:flex; align-items:center; justify-content:center; gap:6px; flex-wrap:wrap; margin-bottom:20px; }
+
+.ob-loop-step { display:flex; flex-direction:column; align-items:center; gap:4px; }
+
+.ob-loop-icon { font-size:22px; }
+
+.ob-loop-step span:last-child { font-family:var(--font-mono); font-size:10px; color:var(--text-muted); }
+
+.ob-loop-step.accent .ob-loop-icon { color:var(--accent); }
+
+.ob-loop-arrow { color:var(--text-muted); font-size:14px; }
+
+.ob-body { font-family:var(--font-body); font-size:14px; color:var(--text-secondary); line-height:1.7; }
+
+/* Features list */
+
+.ob-features { display:flex; flex-direction:column; gap:14px; margin-bottom:16px; }
+
+.ob-feature { display:flex; align-items:flex-start; gap:14px; text-align:left; }
+
+.ob-feature-icon { font-size:20px; width:32px; text-align:center; flex-shrink:0; margin-top:2px; }
+
+.ob-feature-title { font-family:var(--font-ui); font-size:14px; font-weight:700; color:var(--text-primary); margin-bottom:2px; }
+
+.ob-feature-desc { font-family:var(--font-body); font-size:13px; color:var(--text-secondary); }
+
+.ob-tip { background:var(--accent-soft); border:1px solid var(--accent-dim); border-radius:var(--radius-md); padding:12px 16px; font-family:var(--font-mono); font-size:12px; color:var(--accent); margin-top:12px; }
+
+/* Pulse animation for upload button after onboarding */
+
+@keyframes pulse-accent {
+  0%,100% { box-shadow:none; }
+  50% { box-shadow:0 0 0 4px var(--accent-glow); }
+}
+
+/* ══════════════════════════════
+   UNDERSTANDING CHECK
+══════════════════════════════ */
+
+.uc-wrapper { max-width:680px; }
+
+.uc-header { margin-bottom:24px; }
+
+.uc-badge {
+  display:inline-block; background:var(--accent-soft); border:1px solid var(--accent-dim);
+  color:var(--accent); font-family:var(--font-mono); font-size:11px; font-weight:500;
+  padding:4px 12px; border-radius:99px; margin-bottom:10px; letter-spacing:0.05em;
+}
+
+.uc-title { font-family:var(--font-ui); font-size:20px; font-weight:800; color:var(--text-primary); margin-bottom:8px; }
+
+.uc-subtitle { font-family:var(--font-body); font-size:14px; color:var(--text-secondary); line-height:1.65; }
+
+.uc-questions { display:flex; flex-direction:column; gap:20px; margin-bottom:20px; }
+
+.uc-question { display:flex; flex-direction:column; gap:8px; }
+
+.uc-textarea { font-family:var(--font-body); font-size:14px; resize:vertical; }
+
+.uc-source { background:var(--bg-raised); border:1px solid var(--border); border-radius:var(--radius-md); padding:12px 16px; margin-bottom:20px; }
+
+.uc-source summary { font-family:var(--font-mono); font-size:12px; color:var(--text-muted); cursor:pointer; list-style:none; }
+
+.uc-source-text { font-family:var(--font-mono); font-size:12px; color:var(--text-secondary); white-space:pre-wrap; margin-top:12px; max-height:200px; overflow-y:auto; }
+
+.uc-actions { display:flex; gap:10px; flex-wrap:wrap; margin-bottom:16px; }
+
+.uc-tip { background:var(--blue-dim); border:1px solid rgba(90,156,245,0.2); border-radius:var(--radius-md); padding:12px 16px; font-family:var(--font-body); font-size:13px; color:var(--text-secondary); }
+
+/* Comparison */
+
+.uc-compare { display:flex; flex-direction:column; gap:0; margin-bottom:20px; border:1px solid var(--border); border-radius:var(--radius-md); overflow:hidden; }
+
+.uc-compare-row { border-bottom:1px solid var(--border-soft); }
+
+.uc-compare-row:last-child { border-bottom:none; }
+
+.uc-compare-q { display:flex; align-items:center; gap:10px; padding:10px 16px; background:var(--bg-raised); border-bottom:1px solid var(--border-soft); }
+
+.uc-compare-cols { display:grid; grid-template-columns:1fr 1fr; gap:0; }
+
+.uc-compare-col { padding:14px 16px; }
+
+.uc-compare-col.notes { border-left:1px solid var(--border-soft); background:var(--accent-soft); }
+
+.uc-col-label { font-family:var(--font-mono); font-size:11px; text-transform:uppercase; letter-spacing:0.08em; color:var(--text-muted); margin-bottom:8px; }
+
+.uc-col-text { font-family:var(--font-body); font-size:13px; color:var(--text-primary); line-height:1.6; }
+
+.uc-gap-tip { background:var(--accent-soft); border:1px solid var(--accent-dim); border-radius:var(--radius-md); padding:14px 18px; font-family:var(--font-body); font-size:13px; color:var(--text-primary); }
+
+/* ══════════════════════════════
+   BLANK RECALL
+══════════════════════════════ */
+
+.br-wrapper { max-width:720px; }
+
+.br-header { margin-bottom:20px; }
+
+.br-badge {
+  display:inline-block; background:var(--blue-dim); border:1px solid rgba(90,156,245,0.3);
+  color:var(--blue); font-family:var(--font-mono); font-size:11px;
+  padding:4px 12px; border-radius:99px; margin-bottom:10px;
+}
+
+.br-title { font-family:var(--font-ui); font-size:20px; font-weight:800; color:var(--text-primary); margin-bottom:6px; }
+
+.br-subtitle { font-family:var(--font-body); font-size:14px; color:var(--text-secondary); line-height:1.6; }
+
+.br-timer-row { display:flex; align-items:center; gap:16px; margin-bottom:14px; flex-wrap:wrap; }
+
+.br-timer { background:var(--bg-raised); border:1px solid var(--border); border-radius:var(--radius-md); padding:8px 16px; font-family:var(--font-mono); font-size:16px; color:var(--accent); }
+
+.br-struggle-tip { font-family:var(--font-body); font-size:13px; color:var(--text-muted); font-style:italic; flex:1; }
+
+.br-canvas {
+  width:100%; min-height:220px; padding:16px; background:var(--bg-raised);
+  border:2px solid var(--border); border-radius:var(--radius-md);
+  font-family:var(--font-body); font-size:15px; color:var(--text-primary);
+  line-height:1.7; resize:vertical; outline:none; transition:border-color 0.2s;
+}
+
+.br-canvas:focus { border-color:var(--blue); box-shadow:0 0 0 3px rgba(90,156,245,0.12); }
+
+.br-meta-row { display:flex; justify-content:space-between; align-items:center; padding:6px 2px; margin-bottom:16px; }
+
+.br-word-count { font-family:var(--font-mono); font-size:11px; color:var(--text-muted); }
+
+.br-hint { font-family:var(--font-mono); font-size:11px; color:var(--text-muted); }
+
+.br-actions { display:flex; gap:10px; flex-wrap:wrap; margin-bottom:0; }
+
+/* Comparison */
+
+.br-score-row { display:flex; align-items:center; gap:20px; background:var(--bg-raised); border:1px solid var(--border); border-radius:var(--radius-md); padding:18px 20px; margin-bottom:20px; }
+
+.br-score-circle { width:70px; height:70px; border-radius:50%; border:3px solid; display:flex; flex-direction:column; align-items:center; justify-content:center; flex-shrink:0; }
+
+.br-compare { display:grid; grid-template-columns:1fr 1fr; gap:14px; margin-bottom:20px; }
+
+.br-compare-col { background:var(--bg-raised); border:1px solid var(--border); border-radius:var(--radius-md); padding:16px; }
+
+.br-col-label { font-family:var(--font-mono); font-size:11px; text-transform:uppercase; letter-spacing:0.08em; color:var(--text-muted); margin-bottom:10px; }
+
+.br-col-body { font-family:var(--font-body); font-size:13px; color:var(--text-primary); line-height:1.65; white-space:pre-wrap; word-break:break-word; }
+
+.br-ref-section { margin-bottom:12px; }
+
+.br-ref-section strong { font-family:var(--font-ui); font-size:11px; text-transform:uppercase; letter-spacing:0.08em; color:var(--text-muted); }
+
+.br-ref-item { font-family:var(--font-body); font-size:13px; color:var(--text-secondary); padding:3px 0; }
+
+.br-ref-item code { font-family:var(--font-mono); font-size:12px; }
+
+.br-selfmark { background:var(--bg-raised); border:1px solid var(--border); border-radius:var(--radius-md); padding:16px 20px; }
+
+.br-selfmark-title { font-family:var(--font-ui); font-size:12px; font-weight:700; color:var(--text-muted); text-transform:uppercase; letter-spacing:0.08em; margin-bottom:12px; }
+
+.br-selfmark-btns { display:flex; gap:8px; flex-wrap:wrap; }
+
+.br-mark-btn { flex:1; padding:10px 12px; border-radius:var(--radius-md); font-family:var(--font-ui); font-size:13px; font-weight:600; cursor:pointer; border:1px solid var(--border); background:transparent; color:var(--text-secondary); transition:all 0.2s; }
+
+.br-mark-btn.red:hover { background:var(--red-dim);   border-color:var(--red);   color:var(--red); }
+
+.br-mark-btn.amber:hover { background:var(--accent-soft);border-color:var(--accent);color:var(--accent); }
+
+.br-mark-btn.green:hover { background:var(--green-dim);  border-color:var(--green); color:var(--green); }
+
+/* ══════════════════════════════
+   NOTE TEMPLATES
+══════════════════════════════ */
+
+.nt-picker { display:flex; flex-direction:column; gap:8px; }
+
+.nt-option {
+  display:flex; align-items:flex-start; gap:14px; padding:14px 16px;
+  background:var(--bg-raised); border:1px solid var(--border); border-radius:var(--radius-md);
+  cursor:pointer; transition:all 0.2s; text-align:left; width:100%;
+}
+
+.nt-option:hover { border-color:var(--border-bright); background:var(--bg-hover); }
+
+.nt-option.active { border-color:var(--accent); background:var(--accent-soft); }
+
+.nt-icon { font-size:22px; flex-shrink:0; }
+
+.nt-name { font-family:var(--font-ui); font-size:14px; font-weight:700; color:var(--text-primary); margin-bottom:2px; }
+
+.nt-desc { font-family:var(--font-mono); font-size:11px; color:var(--text-muted); }
+
+/* Cornell */
+
+.cornell-editor { display:flex; flex-direction:column; gap:14px; }
+
+.cornell-top { display:grid; grid-template-columns:1fr 2fr; gap:14px; }
+
+.cornell-cues, .cornell-notes, .cornell-summary { display:flex; flex-direction:column; gap:8px; }
+
+.cornell-label { font-family:var(--font-ui); font-size:11px; font-weight:700; text-transform:uppercase; letter-spacing:0.1em; color:var(--text-muted); }
+
+.cornell-display { border:1px solid var(--border); border-radius:var(--radius-md); overflow:hidden; }
+
+/* Header row — labels */
+
+.cn-header-row {
+  display: grid;
+  grid-template-columns: 38% 1fr;
+  border-bottom: 2px solid var(--accent-dim);
+  background: var(--bg-raised);
+}
+
+.cn-label-cue { padding: 10px 16px; border-right: 1px solid var(--border); }
+
+.cn-label-note { padding: 10px 16px; }
+
+/* Body */
+
+.cn-body { display: flex; flex-direction: column; }
+
+/* Each paired cue + note row */
+
+.cn-row {
+  display: grid;
+  grid-template-columns: 38% 1fr;
+  border-bottom: 1px solid var(--border-soft);
+  min-height: 60px;
+}
+
+.cn-row-last { border-bottom: none; }
+
+.cn-cue {
+  padding: 16px 14px;
+  border-right: 1px solid var(--border);
+  background: var(--bg-raised);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--accent);
+  line-height: 1.6;
+  word-break: break-word;
+}
+
+.cn-note {
+  padding: 16px 16px;
+  font-family: var(--font-body);
+  font-size: 14.5px;
+  color: var(--text-primary);
+  line-height: 1.75;
+  word-break: break-word;
+}
+
+.cornell-summary-display { border-top: 2px solid var(--border); padding: 18px 18px; background: var(--accent-soft); }
+
+/* Mobile — stack columns */
+
+/* Outline */
+
+.outline-editor { display:flex; flex-direction:column; gap:4px; }
+
+.outline-item { display:flex; align-items:center; gap:8px; }
+
+.outline-bullet { font-family:var(--font-mono); font-size:12px; color:var(--accent); min-width:24px; }
+
+.outline-input { flex:1; }
+
+.outline-display { display:flex; flex-direction:column; gap:4px; }
+
+.outline-display-item { display:flex; align-items:center; gap:8px; font-family:var(--font-body); font-size:14px; color:var(--text-primary); padding:4px 0; }
+
+/* Feynman */
+
+.feynman-phase { display:flex; flex-direction:column; gap:8px; }
+
+.feynman-phase-label { display:flex; align-items:center; gap:10px; font-family:var(--font-ui); font-size:13px; font-weight:700; color:var(--text-primary); }
+
+.feynman-num { width:24px; height:24px; border-radius:50%; background:var(--accent); color:#000; font-family:var(--font-mono); font-size:11px; font-weight:700; display:flex; align-items:center; justify-content:center; flex-shrink:0; }
+
+.feynman-display { display:flex; flex-direction:column; gap:16px; }
+
+.feynman-display-section { background:var(--bg-raised); border:1px solid var(--border); border-radius:var(--radius-md); padding:16px; }
+
+.feynman-display-text { font-family:var(--font-body); font-size:14px; color:var(--text-primary); white-space:pre-wrap; line-height:1.65; margin-top:10px; }
+
+/* Mobile adjustments */
+
+/* ══════════════════════════════
+   FIX: UC question label — no more column splitting
+══════════════════════════════ */
+
+.uc-q-label {
+  display: flex !important;
+  align-items: flex-start !important;
+  gap: 10px !important;
+  font-family: var(--font-ui) !important;
+  font-size: 14px !important;
+  font-weight: 600 !important;
+  color: var(--text-primary) !important;
+  line-height: 1.55 !important;
+  margin-bottom: 8px !important;
+}
+
+.uc-q-label span:last-child {
+  flex: 1;
+  min-width: 0;
+}
+
+.uc-q-num {
+  width: 26px !important;
+  height: 26px !important;
+  border-radius: 50% !important;
+  background: var(--accent) !important;
+  color: #000 !important;
+  font-family: var(--font-mono) !important;
+  font-size: 12px !important;
+  font-weight: 700 !important;
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  flex-shrink: 0 !important;
+  margin-top: 1px !important;
+}
+
+/* ══════════════════════════════
+   LECTURE MODE — polished
+══════════════════════════════ */
+
+.lecture-tab {
+  padding: 9px 18px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text-muted);
+  font-family: var(--font-ui);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--ease);
+}
+
+.lecture-tab.active { background: var(--accent-soft); border-color: var(--accent-dim); color: var(--accent); }
+
+.lecture-tab:hover:not(.active) { background: var(--bg-hover); color: var(--text-primary); }
+
+.voice-opt {
+  padding: 7px 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  cursor: pointer;
+  transition: all var(--ease);
+}
+
+.voice-opt.active { background: var(--accent-soft); border-color: var(--accent-dim); color: var(--accent); }
+
+/* Lecture read-along: the chunk currently being spoken */
+
+.lm-chunk { transition: background-color .2s ease, color .2s ease; border-radius: 4px; }
+
+.lm-chunk.active {
+  background: var(--accent);
+  color: #060709;
+  box-shadow: 0 0 0 3px var(--accent);
+  font-weight: 600;
+}
+
+/* ══════════════════════════════
+   REVIEW VIEW — premium cards
+══════════════════════════════ */
+
+.review-filter-card {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 24px 22px;
+  margin-bottom: 24px;
+}
+
+.review-stats-row {
+  display: flex;
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  margin-bottom: 20px;
+}
+
+.review-stat {
+  flex: 1;
+  padding: 16px 10px;
+  text-align: center;
+  border-right: 1px solid var(--border-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.review-stat:last-child { border-right: none; }
+
+.review-stat.accent { background: var(--accent-soft); }
+
+.review-stat-val {
+  font-family: var(--font-mono);
+  font-size: 24px;
+  font-weight: 500;
+  color: var(--accent);
+  line-height: 1;
+}
+
+.review-stat-key {
+  font-family: var(--font-ui);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-muted);
+}
+
+.review-mode-toggle {
+  display: flex;
+  gap: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  margin-top: 8px;
+}
+
+.mode-btn {
+  flex: 1;
+  padding: 11px 12px;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  font-family: var(--font-ui);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--ease);
+  border-right: 1px solid var(--border);
+}
+
+.mode-btn:last-child { border-right: none; }
+
+.mode-btn.active { background: var(--accent-soft); color: var(--accent); }
+
+.mode-btn:hover:not(.active) { background: var(--bg-hover); color: var(--text-primary); }
+
+/* ══════════════════════════════
+   STUDY SESSION TIMER
+══════════════════════════════ */
+
+.session-presets {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 8px;
+  margin-bottom: 0;
+}
+
+.session-preset {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+  padding: 12px 6px;
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  font-family: var(--font-ui);
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text-primary);
+  transition: all var(--ease);
+}
+
+.session-preset span { font-size: 10px; font-weight: 400; color: var(--text-muted); }
+
+.session-preset.active { border-color: var(--accent); background: var(--accent-soft); color: var(--accent); }
+
+.session-preset.active span { color: var(--accent); }
+
+.session-preset:hover:not(.active) { border-color: var(--border-bright); background: var(--bg-hover); }
+
+/* ══════════════════════════════
+   SETTINGS PANEL
+══════════════════════════════ */
+
+.settings-section {
+  padding: 18px 0;
+  border-bottom: 1px solid var(--border-soft);
+  margin-bottom: 4px;
+}
+
+.settings-section:last-of-type { border-bottom: none; }
+
+.settings-section-title {
+  font-family: var(--font-ui);
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-muted);
+  margin-bottom: 12px;
+}
+
+/* ══════════════════════════════
+   STUDY PLAN — IMPROVED LAYOUT
+══════════════════════════════ */
+
+/* Day card */
+
+.plan-day-card {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  margin-bottom: 10px;
+  overflow: hidden;
+  transition: border-color 0.2s;
+  background: var(--bg-surface);
+}
+
+.plan-day-card[open] { border-color: var(--border-bright); }
+
+.plan-day-card summary { list-style: none; }
+
+.plan-day-card summary::-webkit-details-marker { display: none; }
+
+.plan-day-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px;
+  cursor: pointer;
+  user-select: none;
+  gap: 10px;
+  background: var(--bg-raised);
+  transition: background 0.15s;
+}
+
+.plan-day-summary:hover { background: var(--bg-hover); }
+
+.plan-day-card[open] .plan-day-summary { border-bottom: 1px solid var(--border-soft); }
+
+.plan-day-left { display: flex; align-items: center; gap: 8px; flex-shrink: 0; }
+
+.plan-day-right { display: flex; align-items: center; gap: 8px; min-width: 0; }
+
+.plan-day-stats { font-family: var(--font-mono); font-size: 11px; color: var(--text-muted); white-space: nowrap; }
+
+.plan-day-progress-text { font-family: var(--font-mono); font-size: 11px; color: var(--accent); }
+
+.sp-day-label { font-family: var(--font-mono); font-size: 12px; color: var(--text-secondary); }
+
+.sp-day-label.today { color: var(--accent); font-weight: 700; }
+
+.sp-day-label.past { color: var(--text-muted); }
+
+.sp-today-badge { background: var(--accent); color: #000; font-family: var(--font-mono); font-size: 9px; font-weight: 700; padding: 2px 7px; border-radius: 99px; text-transform: uppercase; letter-spacing: 0.06em; }
+
+.sp-done-badge { color: var(--green); font-size: 15px; }
+
+.sp-chevron { font-size: 14px; color: var(--text-muted); transition: transform 0.2s; flex-shrink: 0; }
+
+.plan-day-card[open] .sp-chevron { transform: rotate(90deg); }
+
+/* Task rows */
+
+.sp-day-body { padding: 10px 14px 14px; display: flex; flex-direction: column; gap: 0; }
+
+.sp-task-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 11px 0;
+  border-bottom: 1px solid var(--border-soft);
+  transition: opacity 0.2s;
+}
+
+.sp-task-row:last-of-type { border-bottom: none; }
+
+.sp-task-row.done { opacity: 0.5; }
+
+.sp-task-icon { font-size: 16px; flex-shrink: 0; margin-top: 1px; }
+
+.sp-task-info { flex: 1; min-width: 0; }
+
+.sp-task-title {
+  font-family: var(--font-ui);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  line-height: 1.4;
+  word-break: break-word;
+}
+
+.sp-task-title.done-text { text-decoration: line-through; color: var(--text-muted); }
+
+.sp-task-meta { font-family: var(--font-mono); font-size: 10px; color: var(--text-muted); margin-top: 2px; text-transform: lowercase; }
+
+.sp-task-actions { display: flex; align-items: center; gap: 6px; flex-shrink: 0; }
+
+.sp-open-btn, .sp-test-btn {
+  padding: 5px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-muted);
+  font-family: var(--font-ui);
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: all 0.15s;
+}
+
+.sp-open-btn:hover { border-color: var(--accent); color: var(--accent); background: var(--accent-soft); }
+
+.sp-test-btn { border-color: var(--purple-dim); color: var(--purple); background: var(--purple-dim); }
+
+/* Break separator */
+
+.sp-break-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 0;
+}
+
+.sp-break-line { flex: 1; height: 1px; background: var(--border-soft); }
+
+.sp-break-badge {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--green);
+  background: var(--green-dim);
+  border: 1px solid rgba(52,199,123,0.2);
+  border-radius: 99px;
+  padding: 3px 12px;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+/* Add task button */
+
+.sp-add-task-btn {
+  width: 100%;
+  margin-top: 10px;
+  padding: 9px;
+  background: transparent;
+  border: 1px dashed var(--border-bright);
+  border-radius: var(--radius-md);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  cursor: pointer;
+  transition: all var(--ease);
+  text-align: center;
+}
+
+.sp-add-task-btn:hover { border-color: var(--accent); color: var(--accent); }
+
+/* Override old styles */
+
+.sp-header-actions { display: flex; gap: 6px; flex-wrap: wrap; }
+
+/* ══════════════════════════════
+   SESSION OVERLAY — Final
+══════════════════════════════ */
+
+#session-overlay {
+  position: fixed;
+  bottom: 80px;
+  right: 16px;
+  z-index: 8000;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-bright);
+  border-radius: var(--radius-lg);
+  padding: 16px 18px;
+  min-width: 220px;
+  max-width: 260px;
+  box-shadow: var(--shadow-lg);
+  animation: slide-up 0.2s ease;
+  transition: all 0.25s ease;
+}
+
+#session-overlay.minimised {
+  min-width: 0;
+  padding: 8px 12px;
+  border-radius: 99px;
+}
+
+.so-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.so-phase {
+  font-family: var(--font-ui);
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--accent);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.so-icon-btn {
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 13px;
+  padding: 3px 6px;
+  border-radius: var(--radius-sm);
+  transition: color var(--ease);
+}
+
+.so-icon-btn:hover { color: var(--text-primary); }
+
+.so-timer {
+  font-family: var(--font-mono);
+  font-size: 32px;
+  font-weight: 500;
+  color: var(--text-primary);
+  text-align: center;
+  margin-bottom: 4px;
+  line-height: 1;
+}
+
+.so-controls {
+  display: flex;
+  gap: 6px;
+  margin-top: 0;
+}
+
+.so-ctrl-btn {
+  flex: 1;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text-secondary);
+  font-family: var(--font-ui);
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--ease);
+  white-space: nowrap;
+}
+
+.so-ctrl-btn.primary { background: var(--accent-soft); border-color: var(--accent-dim); color: var(--accent); }
+
+.so-ctrl-btn:hover { background: var(--bg-hover); color: var(--text-primary); }
+
+/* Mini pill */
+
+#session-mini {
+  display: none;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-mono);
+  font-size: 14px;
+  color: var(--accent);
+  white-space: nowrap;
+}
+
+#mini-timer { font-weight: 500; }
+
+#mini-phase-icon { font-size: 16px; }
+
+/* ══════════════════════════════
+   MODULE OUTCOMES
+══════════════════════════════ */
+
+.outcomes-summary::-webkit-details-marker { display: none; }
+
+.outcomes-panel[open] .outcomes-summary { border-bottom: 1px solid var(--border-soft); }
+
+.outcomes-count { font-family: var(--font-mono); font-size: 11px; color: var(--text-muted); font-weight: 400; }
+
+.outcome-row:last-of-type { border-bottom: none; }
+
+.outcome-text {
+  font-family: var(--font-body);
+  font-size: 13px;
+  color: var(--text-primary);
+  flex: 1;
+  line-height: 1.55;
+}
+
+/* ══════════════════════════════
+   EDIT DEFINITION ROWS
+══════════════════════════════ */
+
+.edit-def-row {
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 12px 14px;
+}
+
+/* ══════════════════════════════
+   AI STUDY ASSISTANT FLOATER
+══════════════════════════════ */
+
+/* ══════════════════════════════
+   AI STUDY FLOATER — Full Redesign
+══════════════════════════════ */
+
+#ai-floater {
+  position: fixed;
+  bottom: 88px;
+  right: 16px;
+  z-index: 7000;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 10px;
+}
+
+/* Toggle button */
+
+#ai-floater-btn {
+  width: 54px;
+  height: 54px;
+  border-radius: 50%;
+  background: var(--bg-surface);
+  border: 2px solid var(--accent);
+  color: var(--accent);
+  font-size: 22px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 4px 24px rgba(240,165,0,0.35);
+  transition: all 0.2s;
+  flex-shrink: 0;
+}
+
+#ai-floater-btn:hover,
+#ai-floater-btn.active { background: var(--accent); color: #000; transform: scale(1.06); }
+
+/* Panel — taller, wider, scrollable */
+
+#ai-floater-panel {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-bright);
+  border-radius: var(--radius-lg);
+  width: 310px;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: var(--shadow-lg);
+  animation: floater-in 0.2s ease;
+  overflow: hidden;
+}
+
+@keyframes floater-in {
+  from { opacity:0; transform:scale(0.94) translateY(10px); }
+  to   { opacity:1; transform:scale(1) translateY(0); }
+}
+
+/* Header */
+
+.aif-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border-soft);
+  background: var(--accent-soft);
+  flex-shrink: 0;
+}
+
+.aif-title {
+  font-family: var(--font-ui);
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.aif-close-btn {
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 16px;
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+  transition: color 0.15s;
+  line-height: 1;
+}
+
+.aif-close-btn:hover { color: var(--text-primary); }
+
+/* Home screen */
+
+#aif-home {
+  overflow-y: auto;
+  padding: 10px;
+  flex: 1;
+}
+
+.aif-section-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-muted);
+  padding: 8px 4px 5px;
+}
+
+/* Card grid — 3 per row */
+
+.aif-card-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 6px;
+  margin-bottom: 4px;
+}
+
+.aif-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 10px 6px 8px;
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: all 0.15s;
+  text-align: center;
+}
+
+.aif-card:hover { border-color: var(--accent-dim); background: var(--accent-soft); transform: translateY(-1px); }
+
+.aif-card-icon { font-size: 20px; line-height: 1; }
+
+.aif-card-text {
+  font-family: var(--font-ui);
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-primary);
+  line-height: 1.3;
+}
+
+.aif-card-text small {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  color: var(--text-muted);
+  font-weight: 400;
+  margin-top: 1px;
+}
+
+/* Ask anything input row */
+
+.aif-ask-row {
+  display: flex;
+  gap: 6px;
+  padding: 8px 4px 4px;
+}
+
+.aif-custom-input {
+  flex: 1;
+  padding: 9px 12px;
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-family: var(--font-body);
+  font-size: 13px;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.aif-custom-input:focus { border-color: var(--accent); }
+
+.aif-send-btn {
+  width: 36px;
+  height: 36px;
+  border-radius: var(--radius-md);
+  background: var(--accent);
+  border: none;
+  color: #000;
+  font-size: 16px;
+  font-weight: 700;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: opacity 0.15s;
+}
+
+.aif-send-btn:hover { opacity: 0.85; }
+
+/* Result screen — full height, scrollable */
+
+#aif-result-screen {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  overflow: hidden;
+}
+
+.aif-result-label {
+  font-family: var(--font-ui);
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  padding: 10px 14px 6px;
+  border-bottom: 1px solid var(--border-soft);
+  flex-shrink: 0;
+}
+
+/* Full scrollable text — no max-height cap */
+
+.ai-floater-text {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px 14px;
+  font-family: var(--font-body);
+  font-size: 13px;
+  color: var(--text-primary);
+  line-height: 1.7;
+}
+
+.ai-floater-text p { margin: 0 0 10px; }
+
+.ai-floater-text p:last-child { margin-bottom: 0; }
+
+.aif-back-btn {
+  flex-shrink: 0;
+  margin: 8px 10px 10px;
+  padding: 8px 14px;
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  font-family: var(--font-ui);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.aif-back-btn:hover { border-color: var(--border-bright); color: var(--text-primary); }
+
+/* Animated loading dots */
+
+.aif-loading {
+  display: flex;
+  gap: 5px;
+  padding: 8px 2px;
+  align-items: center;
+}
+
+.aif-dot {
+  width: 7px; height: 7px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: aif-bounce 1.2s infinite ease-in-out;
+}
+
+.aif-dot:nth-child(2) { animation-delay: 0.2s; }
+
+.aif-dot:nth-child(3) { animation-delay: 0.4s; }
+
+@keyframes aif-bounce {
+  0%,80%,100% { transform: scale(0.6); opacity: 0.4; }
+  40%         { transform: scale(1);   opacity: 1; }
+}
+
+/* ══════════════════════════════
+   LIBRARY SEARCH — larger
+══════════════════════════════ */
+
+.library-toolbar {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  margin-bottom: 22px;
+  flex-wrap: wrap;
+}
+
+.library-toolbar .search-input {
+  flex: 1;
+  min-width: 200px;
+  max-width: 100%;
+  padding: 12px 16px;
+  font-size: 15px;
+  border-radius: var(--radius-md);
+}
+
+@media (max-width: 768px) {
+  #ai-floater { bottom: 76px; right: 12px; }
+  #ai-floater-panel { width: calc(100vw - 32px); max-width: 320px; }
+  .library-toolbar .search-input { min-width: 0; }
+}
+
+/* ══════════════════════════════
+   OCR REVIEW MODAL
+══════════════════════════════ */
+
+#ocr-review-modal { min-height: 0; }
+
+/* ══════════════════════════════
+   STRUCTURED PROCEDURES
+══════════════════════════════ */
+
+.proc-card {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  margin-bottom: 10px;
+  background: var(--bg-surface);
+}
+
+.proc-card[open] { border-color: var(--border-bright); }
+
+.proc-card-summary {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 16px;
+  cursor: pointer;
+  list-style: none;
+  background: var(--bg-raised);
+  user-select: none;
+}
+
+.proc-card-summary::-webkit-details-marker { display: none; }
+
+.proc-card[open] .proc-card-summary { border-bottom: 1px solid var(--border-soft); }
+
+.proc-card-num {
+  width: 24px; height: 24px;
+  background: var(--accent); color: #000;
+  border-radius: 50%;
+  font-family: var(--font-mono); font-size: 11px; font-weight: 700;
+  display: flex; align-items: center; justify-content: center;
+  flex-shrink: 0;
+}
+
+.proc-card-title { font-family: var(--font-ui); font-size: 14px; font-weight: 700; color: var(--text-primary); flex: 1; }
+
+.proc-card-applies { font-family: var(--font-mono); font-size: 11px; color: var(--text-muted); }
+
+.proc-card-body { padding: 14px 16px; }
+
+/* Procedure notes section */
+
+.proc-notes-section {
+  margin-top: 14px;
+  background: var(--bg-raised);
+  border: 1px solid var(--border-soft);
+  border-left: 3px solid var(--accent);
+  border-radius: var(--radius-sm);
+  padding: 12px 14px;
+}
+
+.proc-notes-title { font-family: var(--font-ui); font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-muted); margin-bottom: 6px; }
+
+.proc-notes-text { font-family: var(--font-body); font-size: 13px; color: var(--text-secondary); line-height: 1.65; white-space: pre-wrap; }
+
+/* Procedure edit group */
+
+.proc-edit-group {
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 14px 16px;
+}
+
+/* ══════════════════════════════
+   NODE TABLES
+══════════════════════════════ */
+
+.node-table-wrap {
+  overflow-x: auto;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+}
+
+.node-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--font-body);
+  font-size: 14px;
+}
+
+.node-table th {
+  background: var(--bg-raised);
+  padding: 10px 14px;
+  text-align: left;
+  font-family: var(--font-ui);
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  border-bottom: 2px solid var(--border);
+  white-space: nowrap;
+}
+
+.node-table td {
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border-soft);
+  color: var(--text-primary);
+  vertical-align: top;
+  line-height: 1.55;
+}
+
+.node-table tr:last-child td { border-bottom: none; }
+
+.node-table tr:hover td { background: var(--bg-hover); }
+
+/* Table edit group */
+
+.table-edit-group {
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 14px 16px;
+}
+
+/* Definition styles consolidated above */
+
+/* ══════════════════════════════
+   MULTI-IMAGE PREVIEW GRID
+══════════════════════════════ */
+
+.preview-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
+  gap: 10px;
+}
+
+.preview-item {
+  position: relative;
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  cursor: grab;
+  transition: box-shadow 0.2s, transform 0.15s;
+}
+
+.preview-item:hover { box-shadow: var(--shadow-md); transform: translateY(-1px); }
+
+.preview-item[draggable]:active { cursor: grabbing; }
+
+.preview-order-badge {
+  position: absolute;
+  top: 6px; left: 6px;
+  background: var(--accent); color: #000;
+  font-family: var(--font-mono); font-size: 10px; font-weight: 700;
+  width: 20px; height: 20px; border-radius: 50%;
+  display: flex; align-items: center; justify-content: center;
+  z-index: 2;
+}
+
+.preview-filename {
+  padding: 6px 8px;
+  font-family: var(--font-mono); font-size: 10px; color: var(--text-muted);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  background: var(--bg-surface); border-top: 1px solid var(--border-soft);
+}
+
+.preview-remove {
+  position: absolute; top: 4px; right: 4px;
+  width: 20px; height: 20px; border-radius: 50%;
+  background: rgba(0,0,0,0.6); border: none; color: #fff;
+  font-size: 11px; cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  transition: background 0.15s; z-index: 3;
+}
+
+.preview-remove:hover { background: var(--red); }
+
+/* ══════════════════════════════
+   IMAGE RESPONSE BLOCKS
+══════════════════════════════ */
+
+.img-with-response { width: 100% !important; max-width: 100%; }
+
+.img-response-block {
+  border-top: 2px solid var(--accent-dim);
+  padding: 14px;
+  background: var(--bg-raised);
+  border-radius: 0 0 var(--radius-md) var(--radius-md);
+}
+
+.irb-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.irb-label {
+  font-family: var(--font-ui);
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--accent);
+}
+
+.irb-remove-btn {
+  background: transparent; border: none;
+  color: var(--text-muted); cursor: pointer;
+  font-family: var(--font-mono); font-size: 11px;
+  padding: 2px 6px; border-radius: var(--radius-sm);
+  transition: color 0.2s;
+}
+
+.irb-remove-btn:hover { color: var(--red); }
+
+.irb-add-row {
+  padding: 8px 0;
+}
+
+.irb-type-btn {
+  padding: 7px 12px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  font-family: var(--font-ui);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all var(--ease);
+}
+
+.irb-type-btn:hover { border-color: var(--accent); color: var(--accent); background: var(--accent-soft); }
+
+.irb-model-answer {
+  margin-top: 12px;
+  background: var(--green-dim);
+  border: 1px solid rgba(52,199,123,0.2);
+  border-radius: var(--radius-sm);
+  padding: 10px 14px;
+}
+
+.irb-model-answer summary {
+  font-family: var(--font-mono); font-size: 12px; color: var(--green); cursor: pointer; list-style: none;
+}
+
+.irb-model-answer summary::-webkit-details-marker { display: none; }
+
+.irb-model-text { font-family: var(--font-body); font-size: 13px; color: var(--text-primary); line-height: 1.65; margin-top: 8px; white-space: pre-wrap; }
+
+/* ══════════════════════════════
+   AI SETTINGS MODAL
+══════════════════════════════ */
+
+.provider-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.provider-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 5px;
+  padding: 12px 8px;
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: all var(--ease);
+  font-family: var(--font-ui);
+}
+
+.provider-btn:hover { border-color: var(--border-bright); background: var(--bg-hover); }
+
+.provider-btn.selected { border-color: var(--accent); background: var(--accent-soft); }
+
+.provider-icon { font-size: 22px; }
+
+.provider-name { font-size: 11px; font-weight: 600; color: var(--text-secondary); text-align: center; line-height: 1.3; }
+
+.provider-btn.selected .provider-name { color: var(--accent); }
+
+/* Tab bar */
+
+.ai-tab-bar {
+  display: flex;
+  gap: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  margin-bottom: 4px;
+}
+
+.ai-tab {
+  flex: 1;
+  padding: 10px 14px;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  font-family: var(--font-ui);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--ease);
+  border-right: 1px solid var(--border);
+}
+
+.ai-tab:last-child { border-right: none; }
+
+.ai-tab.active { background: var(--accent-soft); color: var(--accent); }
+
+.ai-tab:hover:not(.active) { background: var(--bg-hover); color: var(--text-primary); }
+
+/* OpenRouter preset grid */
+
+.or-preset-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.or-preset-btn {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px 10px;
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: all var(--ease);
+  text-align: center;
+}
+
+.or-preset-btn:hover { border-color: var(--border-bright); background: var(--bg-hover); }
+
+.or-preset-btn.active { border-color: var(--accent); background: var(--accent-soft); }
+
+.or-preset-label { font-family: var(--font-ui); font-size: 13px; font-weight: 700; color: var(--text-primary); }
+
+.or-preset-desc { font-family: var(--font-mono); font-size: 10px; color: var(--text-muted); }
+
+/* Function model rows */
+
+.fn-model-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 16px;
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  flex-wrap: wrap;
+}
+
+.fn-model-info { flex: 1; min-width: 160px; }
+
+.fn-model-label { font-family: var(--font-ui); font-size: 13px; font-weight: 600; color: var(--text-primary); }
+
+.fn-model-desc { font-family: var(--font-mono); font-size: 11px; color: var(--text-muted); margin-top: 2px; }
+
+@media (max-width: 500px) {
+  .or-preset-grid { grid-template-columns: 1fr; }
+  .provider-grid  { grid-template-columns: repeat(2,1fr); }
+  .fn-model-row   { flex-direction: column; align-items: flex-start; }
+  .fn-model-row select { width: 100%; }
+}
+
+/* ══════════════════════════════
+   REVIEW — AI Study Toolbar
+══════════════════════════════ */
+
+.rai-btn {
+  padding: 7px 12px;
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  font-family: var(--font-ui);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s;
+  white-space: nowrap;
+}
+
+.rai-btn:hover:not(:disabled) {
+  border-color: var(--accent-dim);
+  color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.rai-btn:disabled { cursor: not-allowed; }
+
+/* ══════════════════════════════
+   GUIDED FLOW — Full Redesign
+══════════════════════════════ */
+
+.gf-card {
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 28px 24px;
+  margin-bottom: 20px;
+}
+
+.gf-prime { border-top: 3px solid var(--accent); }
+
+.gf-reflect { border-top: 3px solid var(--green); }
+
+.gf-question-card { border-top: 3px solid var(--blue); }
+
+.gf-step-badge {
+  display: inline-block;
+  padding: 4px 14px;
+  background: var(--accent-soft);
+  border: 1px solid var(--accent-dim);
+  border-radius: 99px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--accent);
+  margin-bottom: 14px;
+  letter-spacing: 0.04em;
+}
+
+.gf-title {
+  font-family: var(--font-ui);
+  font-size: 22px;
+  font-weight: 800;
+  color: var(--text-primary);
+  margin-bottom: 10px;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+}
+
+.gf-title em { font-style: normal; color: var(--accent); }
+
+.gf-subtitle {
+  font-family: var(--font-body);
+  font-size: 14px;
+  color: var(--text-secondary);
+  line-height: 1.7;
+  margin-bottom: 20px;
+}
+
+/* Coach tip bar */
+
+.gf-coach-tip {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-soft);
+  border-left: 3px solid var(--accent);
+  border-radius: var(--radius-sm);
+  padding: 10px 14px;
+  font-family: var(--font-body);
+  font-size: 13px;
+  color: var(--text-secondary);
+  line-height: 1.6;
+  margin-bottom: 20px;
+}
+
+/* Prime rows */
+
+.gf-prime-block {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  margin-bottom: 20px;
+}
+
+.gf-prime-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  padding: 14px 16px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-md);
+}
+
+.gf-prime-icon { font-size: 22px; flex-shrink: 0; padding-top: 1px; }
+
+.gf-prime-row strong { font-family: var(--font-ui); font-size: 13px; font-weight: 700; color: var(--text-primary); display: block; margin-bottom: 3px; }
+
+.gf-prime-row p { font-family: var(--font-body); font-size: 13px; color: var(--text-secondary); margin: 0; line-height: 1.6; }
+
+/* AI block */
+
+.gf-ai-block {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 16px 18px;
+  margin-bottom: 20px;
+}
+
+.gf-ai-offline { border-left: 3px solid var(--border-bright); }
+
+.gf-ai-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--accent);
+  margin-bottom: 10px;
+}
+
+.gf-ai-text {
+  font-family: var(--font-body);
+  font-size: 14px;
+  color: var(--text-primary);
+  line-height: 1.7;
+}
+
+/* Continue button */
+
+.gf-continue-btn {
+  width: 100%;
+  padding: 14px;
+  background: var(--accent);
+  border: none;
+  border-radius: var(--radius-md);
+  color: #000;
+  font-family: var(--font-ui);
+  font-size: 15px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: opacity 0.15s;
+  margin-top: 4px;
+}
+
+.gf-continue-btn:hover { opacity: 0.88; }
+
+.gf-action-row { margin-top: 4px; }
+
+/* Notes step footer */
+
+.gf-notes-header { margin-bottom: 24px; }
+
+.gf-notes-footer { margin-top: 28px; padding-top: 20px; border-top: 1px solid var(--border-soft); }
+
+.gf-speak-btn[data-playing="1"] { background: var(--accent-soft); border-color: var(--accent-dim); color: var(--accent); }
+
+.gf-speak-btn[data-playing="1"]:hover { opacity: 0.85; }
+
+.gf-section-complete-prompt {
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 18px 20px;
+}
+
+.gf-section-complete-prompt p {
+  font-family: var(--font-body);
+  font-size: 14px;
+  color: var(--text-secondary);
+  line-height: 1.65;
+  margin-bottom: 14px;
+}
+
+/* Question step */
+
+.gf-q-text {
+  font-family: var(--font-body);
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text-primary);
+  line-height: 1.65;
+  margin-bottom: 14px;
+  padding: 16px;
+  background: var(--bg-surface);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+}
+
+.gf-answer-area {
+  width: 100%;
+  margin-bottom: 12px;
+  font-size: 14px;
+  line-height: 1.65;
+}
+
+.gf-q-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+  margin-top: 4px;
+}
+
+.gf-q-actions .btn-primary { margin-left: auto; }
+
+/* Reflect step */
+
+.gf-reflect-section {
+  margin-bottom: 20px;
+  padding-bottom: 20px;
+  border-bottom: 1px solid var(--border-soft);
+}
+
+.gf-reflect-section:last-child { border-bottom: none; padding-bottom: 0; margin-bottom: 0; }
+
+.gf-reflect-label {
+  font-family: var(--font-ui);
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-bottom: 8px;
+}
+
+.gf-reflect-desc {
+  font-family: var(--font-body);
+  font-size: 13px;
+  color: var(--text-secondary);
+  line-height: 1.65;
+}
+
+.gf-confidence-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 10px;
+}
+
+.gf-confidence-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-family: var(--font-body);
+  font-size: 13px;
+  color: var(--text-primary);
+  cursor: pointer;
+  padding: 8px 12px;
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  transition: border-color 0.15s;
+}
+
+.gf-confidence-row:has(input:checked) {
+  border-color: var(--green);
+  background: var(--green-dim);
+  color: var(--green);
+}
+
+/* Step tab redesign */
+
+.step-tab { transition: all 0.15s; }
+
+.step-tab.done .step-tab-icon { color: var(--green); }
+
+/* ══════════════════════════════
+   QUESTION CARDS — Redesigned
+══════════════════════════════ */
+
+.question-card {
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 16px 18px;
+  margin-bottom: 10px;
+  transition: border-color 0.15s;
+}
+
+.question-card:hover { border-color: var(--border-bright); }
+
+.question-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.question-card-actions {
+  display: flex;
+  gap: 4px;
+}
+
+.qc-action-btn {
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 13px;
+  padding: 4px 9px;
+  transition: all 0.15s;
+  font-family: var(--font-ui);
+}
+
+.qc-action-btn:hover { border-color: var(--accent-dim); color: var(--accent); background: var(--accent-soft); }
+
+.qc-action-btn.danger:hover { border-color: rgba(240,86,74,0.4); color: var(--red); background: var(--red-dim); }
+
+.question-text {
+  font-family: var(--font-body);
+  font-size: 15px;
+  color: var(--text-primary);
+  line-height: 1.65;
+  margin-bottom: 12px;
+}
+
+.question-answer-toggle {
+  padding: 6px 14px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  font-family: var(--font-ui);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s;
+  margin-bottom: 8px;
+}
+
+.question-answer-toggle:hover { border-color: var(--accent-dim); color: var(--accent); }
+
+.question-answer {
+  background: var(--green-dim);
+  border: 1px solid rgba(52,199,123,0.2);
+  border-radius: var(--radius-sm);
+  padding: 12px 14px;
+  font-family: var(--font-body);
+  font-size: 14px;
+  color: var(--text-primary);
+  line-height: 1.65;
+  margin-top: 4px;
+}
+
+.question-answer.hidden { display: none; }
+
+.question-edit-form {
+  margin-top: 14px;
+  padding-top: 14px;
+  border-top: 1px solid var(--border-soft);
+}
+
+.question-edit-form.hidden { display: none; }
+
+.question-label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  padding: 3px 8px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: 99px;
+}
+
+/* ═══════════════════════════════════════════════════════
+   BLOCK CANVAS (BlockEngine.js)
+═══════════════════════════════════════════════════════ */
+
+.kn-block {position:relative;margin-bottom:28px;animation:knRise .35s ease both}
+
+@keyframes knRise {from{opacity:0;transform:translateY(8px)}to{opacity:1;transform:none}}
+
+.kn-block-controls {position:absolute;top:8px;right:8px;display:flex;gap:3px;opacity:0;transition:.15s;z-index:2}
+
+.kn-block:hover .kn-block-controls {opacity:1}
+
+.kn-bc {width:24px;height:24px;border-radius:5px;border:1px solid var(--border);background:var(--bg-card);color:var(--text-muted);font-size:10px;cursor:pointer;display:grid;place-items:center}
+
+.kn-bc:hover {border-color:var(--accent-dim);color:var(--accent)}
+
+.kn-blk-inner {--blk-accent:var(--accent);background:var(--bg-surface);border:1px solid var(--border);border-radius:var(--radius-md);overflow:hidden}
+
+.kn-blk-head {display:flex;align-items:center;gap:8px;padding:13px 18px;border-bottom:1px solid var(--border-soft);background:var(--bg-raised)}
+
+.kn-blk-kind {font-family:var(--font-mono);font-size:10px;text-transform:uppercase;letter-spacing:.08em;color:var(--blk-accent);font-weight:600}
+
+.kn-blk-title {font-size:14px;font-weight:700}
+
+.kn-blk-body {padding:20px 20px 22px}
+
+/* prose / definition / formula / procedure */
+
+.kn-prose {font-family:var(--font-body);font-size:15px;color:var(--text-secondary);line-height:1.85}
+
+.kn-prose code {font-family:var(--font-mono);font-size:.9em;background:var(--bg-raised);padding:1px 5px;border-radius:4px;color:var(--accent-light)}
+
+.kn-callout {border-left:4px solid var(--accent);padding:14px 18px;background:var(--accent-soft);border-radius:0 var(--radius-md) var(--radius-md) 0;font-size:14.5px;color:var(--text-secondary);line-height:1.7}
+
+.kn-callout ul {margin:0;padding-left:18px}
+
+.kn-callout ul li {margin-bottom:8px}
+
+.kn-def {margin-bottom:22px;padding-bottom:18px;border-bottom:1px solid var(--border-soft)}
+
+.kn-def-term {font-weight:700;color:var(--text-primary);font-size:15px;margin-bottom:4px}
+
+.kn-def-ex {font-size:12px;color:var(--accent-light);font-style:italic;margin:2px 0}
+
+.kn-def-desc {font-family:var(--font-body);font-size:14.5px;color:var(--text-secondary);line-height:1.7;margin-top:4px}
+
+.kn-formula {margin-bottom:18px;padding:16px 18px;background:var(--bg-raised);border-radius:var(--radius-md)}
+
+.kn-formula-expr {font-family:var(--font-mono);font-size:17px;color:var(--accent);font-weight:600;letter-spacing:0.02em}
+
+.kn-formula-desc {font-size:14px;color:var(--text-secondary);margin-top:8px;line-height:1.6}
+
+.kn-formula-con {font-size:11px;color:var(--text-muted);margin-top:4px;font-family:var(--font-mono)}
+
+.kn-applies {font-size:12.5px;color:var(--text-muted);margin-bottom:12px;font-style:italic}
+
+.kn-steps {padding-left:24px;font-size:15px;color:var(--text-secondary);line-height:1.9}
+
+.kn-steps li {margin-bottom:12px;padding-left:4px}
+
+.kn-proc-notes {margin-top:14px;font-size:13px;color:var(--text-muted);border-left:2px solid var(--border);padding-left:12px;line-height:1.7}
+
+.kn-table-wrap {overflow-x:auto}
+
+.kn-table {border-collapse:collapse;width:100%;font-size:13px}
+
+.kn-table th,.kn-table td {border:1px solid var(--border);padding:11px 14px;text-align:left}
+
+.kn-table th {background:var(--bg-raised);color:var(--accent);font-weight:600;font-size:12px}
+
+.kn-table td {color:var(--text-secondary)}
+
+/* code runner */
+
+.kn-editor {font-family:var(--font-mono);font-size:13px;width:100%;background:#0a0c10;color:#e6e6e6;border:1px solid var(--border);border-radius:var(--radius-sm);padding:12px;resize:vertical;min-height:90px;line-height:1.55;tab-size:2}
+
+.kn-editor:focus {outline:none;border-color:var(--accent-dim)}
+
+.kn-run-row {display:flex;gap:8px;margin-top:10px;align-items:center;flex-wrap:wrap}
+
+.kn-btn {padding:8px 16px;border-radius:var(--radius-sm);font-size:12px;font-weight:700;cursor:pointer;border:none;transition:.15s;font-family:var(--font-ui)}
+
+.kn-btn-go {background:var(--accent);color:#000}
+
+.kn-btn-go:hover {background:var(--accent-light)}
+
+.kn-btn-ghost {background:transparent;border:1px solid var(--border);color:var(--text-secondary)}
+
+.kn-btn-ghost:hover {border-color:var(--accent-dim);color:var(--accent)}
+
+.kn-run-hint {font-family:var(--font-mono);font-size:11px;color:var(--text-muted)}
+
+.kn-out {margin-top:12px;border-radius:var(--radius-sm);overflow:hidden;border:1px solid var(--border-soft)}
+
+.kn-out-label {font-family:var(--font-mono);font-size:10px;color:var(--text-muted);padding:6px 12px;background:var(--bg-raised);text-transform:uppercase;letter-spacing:.08em}
+
+.kn-out-body {padding:12px;font-family:var(--font-mono);font-size:12.5px;background:#0a0c10;color:var(--green);white-space:pre-wrap;max-height:260px;overflow:auto}
+
+.kn-out-body.err {color:var(--red)}
+
+.kn-res {border-collapse:collapse;width:100%;font-size:12px}
+
+.kn-res th,.kn-res td {border:1px solid var(--border);padding:5px 9px;text-align:left;font-family:var(--font-mono)}
+
+.kn-res th {background:var(--bg-raised);color:var(--accent);font-weight:600}
+
+.kn-res td {color:var(--text-secondary)}
+
+.kn-spin {display:inline-block;width:13px;height:13px;border:2px solid var(--accent-dim);border-top-color:var(--accent);border-radius:50%;animation:knspin .7s linear infinite;vertical-align:-2px}
+
+@keyframes knspin {to{transform:rotate(360deg)}}
+
+/* calculator */
+
+.kn-calc-grid {display:grid;gap:10px}
+
+.kn-calc-row {display:flex;align-items:center;gap:12px}
+
+.kn-calc-row label {font-size:13px;flex:1;color:var(--text-secondary)}
+
+.kn-calc-row input {width:150px;background:#0a0c10;border:1px solid var(--border);border-radius:var(--radius-sm);color:var(--text-primary);padding:8px 12px;font-family:var(--font-mono);font-size:13px;text-align:right}
+
+.kn-calc-row input:focus {outline:none;border-color:var(--accent-dim)}
+
+.kn-calc-result {margin-top:12px;padding:14px 16px;border-radius:var(--radius-sm);background:linear-gradient(135deg,var(--accent-soft),transparent);border:1px solid var(--accent-dim)}
+
+.kn-calc-lab {font-size:11px;text-transform:uppercase;letter-spacing:.08em;color:var(--text-muted)}
+
+.kn-calc-val {font-family:var(--font-mono);font-size:26px;font-weight:600;color:var(--accent);margin-top:2px}
+
+.kn-calc-break {font-family:var(--font-mono);font-size:12px;color:var(--text-secondary);margin-top:8px}
+
+.kn-calc-step {display:flex;justify-content:space-between;border-bottom:1px dashed var(--border-soft);padding:2px 0}
+
+/* live web preview */
+
+.kn-split {display:grid;grid-template-columns:1fr 1fr;border-radius:var(--radius-sm);overflow:hidden;border:1px solid var(--border)}
+
+.kn-split .kn-editor {border-radius:0;border:none;border-right:1px solid var(--border);min-height:200px}
+
+.kn-frame {background:#fff;min-height:200px;border:none;width:100%}
+
+@media(max-width:620px) {.kn-split{grid-template-columns:1fr}.kn-split .kn-editor{border-right:none;border-bottom:1px solid var(--border)}}
+
+/* quiz */
+
+.kn-quiz-q {font-size:16px;font-weight:700;margin-bottom:18px;line-height:1.55;color:var(--text-primary)}
+
+.kn-quiz-opt {display:block;width:100%;text-align:left;padding:15px 18px;border-radius:var(--radius-md);border:1px solid var(--border);background:var(--bg-raised);color:var(--text-secondary);font-size:14.5px;cursor:pointer;margin-bottom:12px;transition:.12s;font-family:var(--font-ui);line-height:1.55}
+
+.kn-quiz-opt:hover {border-color:var(--accent-dim);color:var(--text-primary)}
+
+.kn-quiz-opt.correct {border-color:var(--green);background:var(--green-soft);color:var(--green)}
+
+.kn-quiz-opt.wrong {border-color:var(--red);background:rgba(229,72,77,.1);color:var(--red)}
+
+.kn-quiz-fb {font-size:13.5px;margin-top:10px;padding:14px 16px;border-radius:var(--radius-md);background:var(--bg-raised);color:var(--text-secondary);font-family:var(--font-body);line-height:1.65}
+
+/* cloze / fill-in-the-blank */
+
+.kn-cloze-text {font-family:var(--font-body);font-size:15px;line-height:2.1;color:var(--text-primary)}
+
+.kn-cloze-input {display:inline-block;min-width:90px;width:auto;padding:2px 8px;margin:0 2px;border:none;border-bottom:2px solid var(--accent-dim);background:var(--bg-raised);color:var(--text-primary);font-family:var(--font-ui);font-size:14.5px;text-align:center;border-radius:6px 6px 0 0;transition:.15s}
+
+.kn-cloze-input:focus {outline:none;border-bottom-color:var(--accent);background:var(--accent-soft)}
+
+.kn-cloze-input.correct {border-bottom-color:var(--green);background:var(--green-soft);color:var(--green)}
+
+.kn-cloze-input.wrong {border-bottom-color:var(--red);background:rgba(229,72,77,.1);color:var(--red)}
+
+.kn-cloze-input.revealed {border-bottom-color:var(--accent);background:var(--accent-soft);color:var(--accent);font-style:italic}
+
+.kn-cloze-actions {display:flex;gap:10px;margin-top:16px}
+
+.kn-cloze-fb {margin-top:12px;font-family:var(--font-mono);font-size:13px}
+
+.kn-cloze-win {color:var(--green);font-weight:700}
+
+.kn-cloze-partial {color:var(--text-muted)}
+
+/* match game */
+
+.kn-match-wrap {display:grid;grid-template-columns:1fr 1fr;gap:10px}
+
+.kn-match-col {display:flex;flex-direction:column;gap:8px}
+
+.kn-match-item {padding:14px;border-radius:var(--radius-md);border:2px solid var(--border);background:var(--bg-raised);text-align:center;font-size:15px;font-weight:600;cursor:pointer;transition:.15s}
+
+.kn-match-item:hover {transform:scale(1.03)}
+
+.kn-match-item.sel {border-color:var(--accent);background:var(--accent-soft)}
+
+.kn-match-item.wrong {border-color:var(--red);background:rgba(229,72,77,.1)}
+
+.kn-match-item.done {border-color:var(--green);background:var(--green-soft);color:var(--green);cursor:default;opacity:.7}
+
+/* diagram */
+
+.kn-flowbox {display:flex;flex-wrap:wrap;align-items:center;gap:8px;justify-content:center;padding:6px 0}
+
+.kn-flownode {padding:10px 16px;border-radius:var(--radius-md);background:var(--bg-raised);border:1px solid var(--accent-dim);font-size:13px;font-weight:600}
+
+.kn-flowarrow {color:var(--accent);font-size:18px}
+
+/* flashcards */
+
+.kn-card {min-height:120px;border-radius:var(--radius-md);background:var(--bg-raised);border:1px solid var(--border);display:grid;place-items:center;padding:20px;cursor:pointer;text-align:center;transition:.15s}
+
+.kn-card:hover {border-color:var(--accent-dim)}
+
+.kn-card-face {font-size:16px;color:var(--text-primary);font-weight:500}
+
+.kn-card-hint {font-family:var(--font-mono);font-size:10px;color:var(--text-muted);margin-top:10px;text-transform:uppercase;letter-spacing:.08em}
+
+/* kid profile = bigger, friendlier */
+
+.kn-kid .kn-blk-body {font-size:16px}
+
+.kn-kid .kn-prose {font-size:17px;line-height:1.85;color:var(--text-primary)}
+
+.kn-kid .kn-match-item {font-size:17px;padding:16px}
+
+/* learner profile selector in node detail */
+
+.kn-profile-bar {display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin:0 0 18px}
+
+.kn-profile-bar .pl {font-size:10px;text-transform:uppercase;letter-spacing:.1em;color:var(--text-muted);font-weight:600;margin-right:4px}
+
+.kn-pchip {padding:6px 12px;border-radius:20px;border:1px solid var(--border);background:var(--bg-raised);color:var(--text-secondary);font-size:12px;font-weight:500;cursor:pointer;transition:.15s}
+
+.kn-pchip:hover {border-color:var(--accent-dim);color:var(--text-primary)}
+
+.kn-pchip.active {background:var(--accent-soft);border-color:var(--accent-dim);color:var(--accent)}
+
+/* add-block menu */
+
+.kn-add-block {margin-top:8px}
+
+.kn-add-btn {width:100%;padding:12px;border-radius:var(--radius-md);border:1px dashed var(--border);background:transparent;color:var(--text-muted);font-size:13px;font-weight:600;cursor:pointer;transition:.15s}
+
+.kn-add-btn:hover {border-color:var(--accent-dim);color:var(--accent);background:var(--accent-soft)}
+
+.kn-add-palette {display:none;grid-template-columns:repeat(auto-fill,minmax(120px,1fr));gap:8px;margin-top:8px}
+
+.kn-add-palette.open {display:grid}
+
+.kn-pal-item {padding:10px;border-radius:var(--radius-sm);border:1px solid var(--border);background:var(--bg-raised);color:var(--text-secondary);font-size:12px;cursor:pointer;text-align:center;transition:.15s}
+
+.kn-pal-item:hover {border-color:var(--accent-dim);color:var(--accent)}
+
+/* ═══════════════════════════════════════════════════════
+   REACTIVE RESHAPING BAR (ReactiveReshaper.js)
+═══════════════════════════════════════════════════════ */
+
+.reshaping-bar {position:fixed;left:50%;bottom:78px;transform:translateX(-50%);z-index:9000;
+  display:flex;align-items:center;gap:10px;padding:10px 18px;border-radius:24px;
+  background:linear-gradient(90deg,rgba(240,165,0,0.18),rgba(240,165,0,0.06));
+  border:1px solid var(--accent-dim);color:var(--accent);font-family:var(--font-ui);
+  font-size:13px;font-weight:600;box-shadow:0 8px 30px rgba(0,0,0,0.4);
+  backdrop-filter:blur(8px);animation:reshapePulse 1.6s ease-in-out infinite;
+  max-width:90vw;}
+
+.reshaping-bar.hidden {display:none}
+
+.reshaping-orb {display:inline-block;animation:reshapeSpin 1.2s linear infinite;font-size:15px}
+
+.reshaping-msg {white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:78vw}
+
+@keyframes reshapePulse {0%,100%{opacity:0.92}50%{opacity:0.66}}
+
+@keyframes reshapeSpin {to{transform:rotate(360deg)}}
+
+@media(min-width:900px) {.reshaping-bar{bottom:28px}}
+
+/* ═══════════════════════════════════════════════════════
+   AI DIRECTOR (AIDirector.js)
+═══════════════════════════════════════════════════════ */
+
+.ai-director-btn {width:100%;display:flex;align-items:center;justify-content:center;gap:8px;
+  padding:11px 14px;margin-bottom:12px;border-radius:var(--radius-md);cursor:pointer;
+  background:linear-gradient(135deg,var(--accent),var(--accent-light));color:#060709;
+  border:none;font-family:var(--font-ui);font-size:13px;font-weight:800;letter-spacing:-0.01em;
+  box-shadow:0 4px 16px var(--accent-glow);transition:transform .15s,box-shadow .15s;}
+
+.ai-director-btn:hover {transform:translateY(-1px);box-shadow:0 6px 22px var(--accent-glow);}
+
+.ai-director-btn:active {transform:translateY(0);}
+
+.aidir-btn-orb {font-size:15px;animation:reshapeSpin 4s linear infinite;}
+
+.aidir {max-width:540px;}
+
+.aidir-head {display:flex;align-items:center;gap:12px;margin-bottom:8px;}
+
+.aidir-head h2 {font-family:var(--font-ui);font-size:19px;font-weight:800;letter-spacing:-0.02em;margin:0;}
+
+.aidir-orb {font-size:24px;color:var(--accent);animation:reshapeSpin 1.4s linear infinite;}
+
+.aidir-sub {font-size:13.5px;color:var(--text-secondary);line-height:1.6;margin:6px 0 14px;}
+
+.aidir-assessment {font-family:var(--font-body);font-size:15px;color:var(--text-primary);line-height:1.7;
+  padding:14px 16px;border-radius:var(--radius-md);background:var(--accent-soft);border:1px solid var(--accent-dim);margin-bottom:16px;}
+
+.aidir-loading {display:flex;gap:6px;justify-content:center;padding:24px 0;}
+
+.aidir-method-card {padding:14px 16px;border-radius:var(--radius-md);background:var(--bg-raised);border:1px solid var(--border);margin-bottom:16px;}
+
+.aidir-method-label {font-size:10.5px;text-transform:uppercase;letter-spacing:.09em;color:var(--text-muted);font-weight:600;}
+
+.aidir-method-name {font-size:17px;font-weight:800;color:var(--accent);margin:3px 0 4px;letter-spacing:-0.01em;}
+
+.aidir-section-label {font-size:11px;text-transform:uppercase;letter-spacing:.08em;color:var(--text-muted);font-weight:600;margin:14px 0 8px;}
+
+.aidir-rows {display:flex;flex-direction:column;gap:8px;max-height:280px;overflow-y:auto;}
+
+.aidir-row {padding:11px 13px;border-radius:var(--radius-sm);border:1px solid var(--border);background:var(--bg-surface);}
+
+.aidir-row.urgent {border-color:var(--accent-dim);background:var(--accent-soft);}
+
+.aidir-node-title {font-size:13.5px;font-weight:700;display:flex;align-items:center;gap:7px;}
+
+.aidir-urgent-dot {width:7px;height:7px;border-radius:50%;background:var(--accent);box-shadow:0 0 8px var(--accent);flex-shrink:0;}
+
+.aidir-change {display:flex;align-items:center;gap:6px;flex-wrap:wrap;margin:6px 0;}
+
+.aidir-pill {font-family:var(--font-mono);font-size:10.5px;padding:2px 8px;border-radius:20px;background:var(--bg-hover);color:var(--text-muted);}
+
+.aidir-pill.new {background:var(--accent-soft);color:var(--accent);border:1px solid var(--accent-dim);}
+
+.aidir-arrow {color:var(--text-muted);font-size:12px;}
+
+.aidir-why {font-size:12px;color:var(--text-secondary);line-height:1.5;}
+
+.aidir-firstaction {margin-top:14px;padding:11px 14px;border-radius:var(--radius-sm);background:var(--bg-raised);
+  border-left:3px solid var(--accent);font-size:13.5px;font-weight:600;color:var(--text-primary);}
+
+.aidir-method-meta {font-family:var(--font-mono);font-size:11.5px;color:var(--text-muted);margin-top:5px;}
+
+.aidir-details {margin-top:14px;border:1px solid var(--border);border-radius:var(--radius-md);background:var(--bg-surface);overflow:hidden;}
+.aidir-details > summary {list-style:none;cursor:pointer;padding:11px 14px;font-size:12.5px;font-weight:600;
+  color:var(--text-secondary);display:flex;align-items:center;justify-content:space-between;}
+.aidir-details > summary::-webkit-details-marker {display:none;}
+.aidir-details > summary::after {content:'▾';color:var(--text-muted);font-size:12px;transition:transform var(--ease);}
+.aidir-details[open] > summary::after {transform:rotate(180deg);}
+.aidir-details[open] > summary {border-bottom:1px solid var(--border);}
+.aidir-details-body {padding:6px 14px 14px;}
+.aidir-details-body .aidir-assessment {font-size:13.5px;line-height:1.65;margin:10px 0 4px;}
+.aidir-details-body .aidir-rows {max-height:240px;}
+
+.aidir-btns {display:flex;gap:10px;margin-top:18px;}
+
+.aidir-btns .btn-primary,.aidir-btns .btn-secondary {flex:1;justify-content:center;}
+
+/* ── Outcome rows — module-aware ─────────────────────── */
+
+.outcome-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 12px 14px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-soft);
+  background: var(--bg-raised);
+  margin-bottom: 8px;
+  transition: border-color .15s;
+}
+
+.outcome-row:hover { border-color: var(--accent-dim); }
+
+.outcome-row.achieved { opacity: .6; }
+
+.outcome-row.achieved .outcome-text { text-decoration: line-through; color: var(--text-muted); }
+
+.outcome-goto-btn:hover { border-color: var(--accent); color: var(--accent); }
+
+/* Current node outcome highlight */
+
+.current-node-outcome {
+  border-color: var(--accent-dim) !important;
+  background: var(--accent-soft) !important;
+}
+
+/* ══════════════════════════════════════════════════════
+   TABLE OF CONTENTS — Premium redesign
+══════════════════════════════════════════════════════ */
+
+/* Panel */
+
+.outcomes-panel {
+  background: var(--bg-card, var(--bg-raised));
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  margin-bottom: 22px;
+  overflow: hidden;
+}
+
+/* Header */
+
+.outcomes-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 18px;
+  user-select: none;
+  background: var(--bg-raised);
+}
+
+/* Body */
+
+.outcomes-body {
+  padding: 0;
+}
+
+/* ── Individual ToC Row ────────────────────────────── */
+
+.toc-row {
+  border-bottom: 1px solid var(--border-soft);
+  transition: background .12s;
+}
+
+.toc-row:last-child { border-bottom: none; }
+
+.toc-row:hover { background: rgba(255,255,255,.02); }
+
+.toc-row.achieved { opacity: .5; }
+
+.toc-row.achieved .toc-row__title { text-decoration: line-through; color: var(--text-muted); }
+
+.toc-row--current { background: var(--accent-soft) !important; }
+
+/* Row header */
+
+.toc-row__header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 13px 16px;
+  cursor: default;
+}
+
+/* Checkbox */
+
+.toc-row__check {
+  accent-color: var(--green);
+  width: 15px; height: 15px;
+  flex-shrink: 0;
+  cursor: pointer;
+}
+
+/* Module badge */
+
+.toc-row__badge {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: .07em;
+  color: var(--accent);
+  background: var(--accent-soft);
+  border: 1px solid var(--accent-dim);
+  padding: 2px 8px;
+  border-radius: 20px;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.toc-row__badge--current {
+  color: var(--text-primary);
+  background: var(--bg-elevated, var(--bg-raised));
+  border-color: var(--border);
+}
+
+/* Title */
+
+.toc-row__title {
+  font-family: var(--font-body);
+  font-size: 14px;
+  color: var(--text-primary);
+  flex: 1;
+  line-height: 1.45;
+}
+
+.toc-row__title--current {
+  font-weight: 700;
+  color: var(--accent);
+}
+
+/* Action icons cluster */
+
+.toc-row__actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex-shrink: 0;
+  opacity: 1;
+}
+
+.toc-row__chevron,
+.toc-row__icon {
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 12px;
+  padding: 4px 6px;
+  border-radius: 6px;
+  transition: background .1s, color .1s;
+  line-height: 1;
+}
+
+.toc-row__chevron:hover,
+.toc-row__icon:hover { background: var(--bg-elevated, var(--bg-raised)); color: var(--text-primary); }
+
+.toc-row__delete:hover { color: var(--red, #e5484d); }
+
+/* Always show chevron (main affordance) */
+
+.toc-row__chevron { opacity: 1 !important; }
+
+/* ── Expandable area ───────────────────────────────── */
+
+.toc-expandable {
+  display: none;
+  flex-direction: column;
+  border-top: 1px solid var(--border-soft);
+  background: var(--bg-elevated, var(--bg-raised));
+}
+
+/* Action row (Go to / You are here / Create node) */
+
+.toc-action {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px 10px 44px;
+}
+
+/* Achieved badge */
+
+.toc-achieved-badge {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--green);
+}
+
+/* Sub-outcomes */
+
+.toc-suboutcomes {
+  padding: 10px 16px 14px 44px;
+  border-top: 1px solid var(--border-soft);
+}
+
+.toc-suboutcomes__label {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .08em;
+  color: var(--text-muted);
+  margin-bottom: 10px;
+}
+
+.toc-suboutcome-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 6px 0;
+  border-bottom: 1px solid var(--border-soft);
+}
+
+.toc-suboutcome-item:last-child { border-bottom: none; }
+
+.toc-suboutcome-num {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--accent);
+  flex-shrink: 0;
+  margin-top: 3px;
+  min-width: 16px;
+}
+
+.toc-suboutcome-text {
+  font-family: var(--font-body);
+  font-size: 13.5px;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+/* ── Add panel ─────────────────────────────────────── */
+
+.toc-add-panel {
+  padding: 14px 16px 16px;
+  border-top: 1px solid var(--border);
+  background: var(--bg-raised);
+}
+
+.toc-add-panel__label {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .08em;
+  color: var(--text-muted);
+  margin-bottom: 10px;
+}
+
+.toc-add-panel__inputs {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.toc-add-panel__mod {
+  width: 96px !important;
+  flex-shrink: 0;
+  font-size: 12px !important;
+}
+
+.toc-add-panel__text { flex: 1; }
+
+.toc-add-panel__btn {
+  width: 100%;
+  justify-content: center;
+  font-size: 13px;
+}
+
+/* ── Activity heatmap (dashboard This Week) ── */
+
+.heatmap-grid {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  grid-auto-flow: column;
+  grid-template-rows: repeat(7, 1fr);
+  gap: 3px;
+  max-width: 100%;
+}
+
+.heatmap-cell {
+  aspect-ratio: 1;
+  border-radius: 3px;
+  background: var(--bg-elevated, #1a1a1a);
+  min-width: 8px;
+}
+
+.heatmap-cell.level-1 { background: rgba(245, 178, 64, 0.35); }
+
+.heatmap-cell.level-2 { background: rgba(245, 178, 64, 0.65); }
+
+.heatmap-cell.level-3 { background: var(--accent, #f5b240); }
+
+/* ── Existing-modules hint (upload config) ── */
+
+.existing-modules-hint {
+  background: var(--bg-raised, #14141a);
+  border: 1px solid var(--border-soft, #2a2a33);
+  border-left: 3px solid var(--accent, #f5b240);
+  border-radius: 8px;
+  padding: 12px 14px;
+  margin-bottom: 14px;
+}
+
+.existing-modules-hint .emh-title {
+  font-family: var(--font-ui);
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--accent, #f5b240);
+  margin-bottom: 8px;
+}
+
+.existing-modules-hint .emh-row {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  padding: 3px 0;
+  flex-wrap: wrap;
+}
+
+.existing-modules-hint .emh-chapter {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--text-primary);
+  min-width: 78px;
+}
+
+.existing-modules-hint .emh-nodes {
+  font-family: var(--font-body);
+  font-size: 12px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  flex: 1;
+}
+
+.existing-modules-hint .emh-foot {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-muted);
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border-soft, #2a2a33);
+}
+
+/* ─── StudyFitCheck — AI formatting suggestions in the Study step ─── */
+
+.sfc-card { background: var(--accent-soft); border: 1px solid var(--accent-dim); border-radius: var(--radius-md); padding: 14px 16px; margin: 0 0 18px; }
+
+.sfc-thinking { display: flex; align-items: center; gap: 10px; }
+
+.sfc-thinking-text { font-family: var(--font-body); font-size: 13px; color: var(--text-secondary); }
+
+.sfc-orb { color: var(--accent); font-size: 14px; display: inline-block; animation: sfc-pulse 1.6s ease-in-out infinite; }
+
+@keyframes sfc-pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.4; } }
+
+.sfc-head { display: flex; align-items: center; gap: 8px; margin-bottom: 10px; }
+
+.sfc-title { font-family: var(--font-mono); font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; color: var(--accent); }
+
+.sfc-dismiss { margin-left: auto; width: 24px; height: 24px; background: transparent; border: 1px solid var(--border); border-radius: 50%; color: var(--text-muted); font-size: 11px; cursor: pointer; display: flex; align-items: center; justify-content: center; transition: all var(--ease); }
+
+.sfc-dismiss:hover { border-color: var(--red); color: var(--red); }
+
+.sfc-row { display: flex; flex-direction: column; gap: 10px; padding: 10px 0; border-top: 1px solid var(--accent-dim); }
+
+.sfc-row:first-of-type { border-top: none; padding-top: 2px; }
+
+.sfc-row-q { font-family: var(--font-body); font-size: 14px; line-height: 1.55; color: var(--text-primary); }
+
+.sfc-row-why { font-family: var(--font-body); font-size: 12px; line-height: 1.5; color: var(--text-muted); margin-top: 3px; }
+
+.sfc-row-btns { display: flex; gap: 8px; flex-wrap: wrap; }
+
+.sfc-btn { font-family: var(--font-ui); font-size: 13px; font-weight: 600; padding: 8px 14px; border-radius: var(--radius-sm); cursor: pointer; border: 1px solid var(--border); transition: all var(--ease); }
+
+.sfc-yes { background: var(--accent); color: #060709; border-color: var(--accent); }
+
+.sfc-yes:hover { filter: brightness(1.08); }
+
+.sfc-no { background: transparent; color: var(--text-secondary); }
+
+.sfc-no:hover { border-color: var(--text-secondary); color: var(--text-primary); }
+
+.sfc-working { display: flex; align-items: center; gap: 8px; font-family: var(--font-body); font-size: 13px; color: var(--text-secondary); padding: 4px 0; }
+
+.sfc-error { font-family: var(--font-body); font-size: 13px; color: var(--red); display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+
+/* ─── Study Coach ───────────────────────────────────── */
+
+.coach-cta {
+  display: flex; align-items: center; gap: 12px; width: 100%;
+  margin-bottom: 18px; padding: 14px 16px; cursor: pointer; text-align: left;
+  background: var(--accent-soft); border: 1px solid var(--accent-dim);
+  border-radius: var(--radius-md); transition: all .2s;
+}
+
+.coach-cta:hover { background: var(--accent-dim); transform: translateY(-1px); }
+
+.coach-cta-orb {
+  font-size: 20px; color: var(--accent); flex-shrink: 0;
+  width: 38px; height: 38px; display: flex; align-items: center; justify-content: center;
+  background: var(--bg-base); border-radius: 50%; border: 1px solid var(--accent-dim);
+}
+
+.coach-cta-text { display: flex; flex-direction: column; gap: 2px; flex: 1; min-width: 0; }
+
+.coach-cta-text strong { font-family: var(--font-ui); font-size: 14px; color: var(--text-primary); }
+
+.coach-cta-text span { font-family: var(--font-mono); font-size: 10px; color: var(--text-muted); }
+
+.coach-cta-arrow { font-family: var(--font-mono); font-size: 18px; color: var(--accent); flex-shrink: 0; }
+
+.coach { display: flex; flex-direction: column; height: 100%; max-height: 100%; overflow: hidden; position: relative; }
+
+.coach-head { display: flex; align-items: center; gap: 12px; margin-bottom: 14px; flex-shrink: 0; padding-right: 40px; }
+
+.coach-orb {
+  font-size: 20px; color: var(--accent);
+  width: 40px; height: 40px; display: flex; align-items: center; justify-content: center;
+  background: var(--accent-soft); border-radius: 50%; border: 1px solid var(--accent-dim); flex-shrink: 0;
+}
+
+.coach-log {
+  flex: 1 1 auto; overflow-y: auto; min-height: 0;
+  padding: 14px 4px 24px;
+  -webkit-overflow-scrolling: touch;
+  scroll-padding-top: 14px;
+}
+
+.coach-input-row {
+  display: flex; gap: 8px; align-items: center; flex-shrink: 0;
+  margin-top: 12px;
+  padding-bottom: calc(16px + env(safe-area-inset-bottom, 0px));
+}
+
+.coach-msg:last-child { margin-bottom: 0; }
+
+.coach-empty {
+  font-family: var(--font-body); font-size: 13px; color: var(--text-muted);
+  line-height: 1.6; padding: 18px 14px; text-align: center;
+}
+
+.coach-msg {
+  font-family: var(--font-body); font-size: 13.5px; line-height: 1.65;
+  padding: 10px 14px; border-radius: var(--radius-md); max-width: 88%;
+  height: auto; box-sizing: border-box; width: fit-content;
+  overflow-wrap: break-word; word-break: break-word; white-space: normal;
+  margin-bottom: 14px;
+}
+
+.coach-msg p { overflow-wrap: break-word; word-break: break-word; }
+
+.coach-msg.user {
+  margin-left: auto; background: var(--accent-soft);
+  border: 1px solid var(--accent-dim); color: var(--text-primary);
+}
+
+.coach-msg.coach {
+  margin-right: auto; background: var(--bg-raised);
+  border: 1px solid var(--border-soft); color: var(--text-primary);
+}
+
+.coach-msg.coach strong { font-weight: 700; color: var(--text-primary); }
+
+.coach-suggest { display: flex; flex-wrap: wrap; gap: 6px; margin: 10px 0 4px; flex-shrink: 0; }
+
+.coach-suggest:empty { display: none; margin: 0; }
+
+.coach-chip {
+  font-family: var(--font-mono); font-size: 11px; padding: 6px 11px; cursor: pointer;
+  background: var(--bg-raised); border: 1px solid var(--border); border-radius: 20px;
+  color: var(--text-secondary); transition: all .2s;
+}
+
+.coach-chip:hover { border-color: var(--accent); color: var(--accent); }
+
+/* Coach action confirm button (Phase 3) */
+
+.coach-action {
+  display: inline-flex; align-items: center; gap: 6px; margin-top: 4px;
+  font-family: var(--font-ui); font-size: 12.5px; font-weight: 700; cursor: pointer;
+  padding: 9px 15px; background: var(--accent); color: #1a1a1a;
+  border: none; border-radius: var(--radius-md); transition: all .2s;
+}
+
+.coach-action:hover { filter: brightness(1.08); transform: translateY(-1px); }
+
+/* Coach thinking bubble — keep it small, don't stretch */
+
+.coach-msg.coach:has(.aif-loading) { padding: 12px 16px; }
+
+.coach-log .aif-loading { display: flex; gap: 5px; align-items: center; }
+
+.coach-log .aif-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--accent); opacity: .7; animation: aif-bounce 1.2s infinite; }
+
+.coach-log .aif-dot:nth-child(2) { animation-delay: .15s; }
+
+.coach-log .aif-dot:nth-child(3) { animation-delay: .3s; }
+
+/* Coach modal: fixed height, non-scrolling — only .coach-log scrolls inside.
+   Prevents the modal and the log from being two competing scroll layers. */
+
+.modal.modal-coach {
+  overflow: hidden;
+  height: 88vh;
+  height: 88dvh;
+  max-height: 88dvh;
+  display: flex;
+  flex-direction: column;
+  padding: 20px 18px 0;   /* override base modal padding; input row adds its own bottom space */
+  box-sizing: border-box;
+}
+
+.modal.modal-coach #modal-content {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+@media (max-width: 600px) {
+  .modal.modal-coach { height: 90vh; height: 90dvh; max-height: 90dvh; }
+}
+
+/* Coach message reader — full-screen, simple, reliable scroll.
+   Tap any coach message to read the whole thing here without bubble scrolling. */
+
+.coach-expand {
+  display: inline-flex; align-items: center; gap: 5px; margin-bottom: 10px;
+  font-family: var(--font-mono); font-size: 11px; font-weight: 700;
+  letter-spacing: .03em;
+  color: var(--accent); background: var(--accent-soft);
+  border: 1px solid var(--accent-dim); border-radius: 14px; cursor: pointer;
+  padding: 5px 12px;
+}
+
+.coach-expand:active { filter: brightness(1.1); }
+
+/* Long messages are clamped to a preview height with a fade; the expand pill
+   (rendered at the top, so it stays visible above the clamp) opens the full
+   reader. Whether a message overflows is detected locally on the element. */
+.coach-msg.coach.cclamp {
+  max-height: 50vh;
+  max-height: 50dvh;
+  overflow: hidden;
+  position: relative;
+}
+.coach-msg.coach.cclamp::after {
+  content: '';
+  position: absolute; left: 0; right: 0; bottom: 0; height: 56px;
+  background: linear-gradient(to bottom, rgba(19,23,32,0), var(--bg-raised));
+  pointer-events: none;
+}
+.coach-msg.coach.cclamp .coach-expand { position: relative; z-index: 1; }
+
+.coach-reader-hint {
+  font-family: var(--font-mono); font-size: 10px; color: var(--text-muted);
+  text-transform: uppercase; letter-spacing: .05em;
+}
+
+.coach-reader {
+  position: absolute;
+  top: 0; left: 0; right: 0;
+  bottom: 76px;            /* sit above the input row */
+  z-index: 50;
+  background: var(--bg-surface);
+  border-radius: var(--radius-md);
+  display: flex; flex-direction: column;
+  animation: fade-in .15s ease;
+  box-shadow: 0 -4px 20px rgba(0,0,0,.4);
+}
+
+@keyframes fade-in { from { opacity: 0; } to { opacity: 1; } }
+
+.coach-reader-who { font-family: var(--font-ui); font-size: 15px; font-weight: 800; color: var(--text-primary); }
+
+.coach-reader-close {
+  font-family: var(--font-ui); font-size: 13px; font-weight: 700; cursor: pointer;
+  background: var(--bg-raised); border: 1px solid var(--border); border-radius: 18px;
+  color: var(--text-secondary); padding: 7px 14px;
+}
+
+.coach-reader-body {
+  flex: 1 1 auto; overflow-y: auto; -webkit-overflow-scrolling: touch;
+  padding: 20px 20px calc(40px + env(safe-area-inset-bottom, 0px));
+  font-family: var(--font-body); font-size: 16px; line-height: 1.7; color: var(--text-primary);
+}
+
+.coach-reader-body p { margin: 0 0 14px; }
+
+.coach-reader-body strong { font-weight: 700; }
+
+/* Reader: "go back to chat" footer tap target */
+
+.coach-reader-done {
+  margin-top: 20px; padding: 16px; text-align: center;
+  font-family: var(--font-mono); font-size: 12px; font-weight: 700;
+  color: var(--accent); background: var(--accent-soft);
+  border: 1px dashed var(--accent-dim); border-radius: var(--radius-md);
+  cursor: pointer; letter-spacing: .03em;
+}
+
+.coach-reader-done:active { filter: brightness(1.1); }
+
+.coach-reader-bar { cursor: pointer; }
+
+/* Ensure the modal X stays tappable above the coach header content */
+
+.modal.modal-coach .modal-close,
+#modal-overlay .modal-close { z-index: 60; }
+
+/* ─── Slide Lecture (LectureMode → Slides tab) ─── */
+
+.lm-slide { padding: 22px 22px 26px; animation: lm-slide-in 0.28s ease; }
+
+@keyframes lm-slide-in { from { opacity: 0; transform: translateX(10px); } to { opacity: 1; transform: translateX(0); } }
+
+/* ─── Presentation-style slide deck ─── */
+
+.lm-deck {
+  display: flex; flex-direction: column; min-height: 340px;
+  background: var(--bg-raised);
+  background: linear-gradient(165deg, var(--bg-raised), var(--bg-base));
+  background:
+    radial-gradient(120% 80% at 100% 0%, color-mix(in srgb, var(--accent) 9%, transparent), transparent 60%),
+    linear-gradient(165deg, var(--bg-raised), var(--bg-base));
+  border: 1px solid var(--border); border-radius: 14px; overflow: hidden;
+  position: relative; box-shadow: 0 18px 40px -28px rgba(0,0,0,0.9), inset 0 1px 0 rgba(255,255,255,0.03);
+  animation: lm-deck-in 0.34s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+@keyframes lm-deck-in { from { opacity: 0; transform: translateY(10px) scale(0.985); } to { opacity: 1; transform: none; } }
+
+.lm-deck::before { content: ''; position: absolute; top: 0; left: 0; right: 0; height: 5px;
+  background: var(--accent);
+  background: linear-gradient(90deg, var(--accent), color-mix(in srgb, var(--accent) 35%, transparent)); }
+
+.lm-deck-progress { position: absolute; top: 0; left: 0; right: 0; height: 5px; z-index: 2; background: transparent; }
+
+.lm-deck-progress-fill { height: 100%; background: rgba(255,255,255,0.85); mix-blend-mode: overlay; transition: width 0.35s ease; }
+
+.lm-deck-body { flex: 1; padding: 30px 26px 18px; display: flex; flex-direction: column; }
+
+.lm-deck-kicker { font-family: var(--font-mono); font-size: 10px; font-weight: 700; letter-spacing: 0.14em; color: var(--accent); margin-bottom: 12px; }
+
+.lm-deck-title { font-family: var(--font-ui); font-size: 25px; font-weight: 800; line-height: 1.18; color: var(--text-primary); margin: 0 0 18px; padding-bottom: 14px; position: relative; }
+
+.lm-deck-title::after { content: ''; position: absolute; bottom: 0; left: 0; width: 48px; height: 3px; border-radius: 3px; background: var(--accent); }
+
+.lm-deck-bullets { list-style: none; margin: 4px 0 0; padding: 0; }
+
+.lm-deck-bullets li { position: relative; padding-left: 24px; font-family: var(--font-body); font-size: 16px; line-height: 1.5; color: var(--text-primary); margin-bottom: 14px;
+  opacity: 0; animation: lm-bullet-in 0.4s ease forwards; }
+
+.lm-deck-bullets li::before { content: '▸'; position: absolute; left: 2px; top: 0; color: var(--accent); font-size: 15px; }
+
+@keyframes lm-bullet-in { from { opacity: 0; transform: translateX(-6px); } to { opacity: 1; transform: none; } }
+
+.lm-deck-titleslide { text-align: center; }
+
+.lm-deck-titleslide .lm-deck-body { justify-content: center; align-items: center; }
+
+.lm-deck-titleslide .lm-deck-title { font-size: 30px; }
+
+.lm-deck-titleslide .lm-deck-title::after { left: 50%; transform: translateX(-50%); width: 64px; }
+
+.lm-deck-notes { background: rgba(0,0,0,0.22); border-top: 1px solid var(--border-soft); padding: 13px 26px 14px;
+  font-family: var(--font-body); font-size: 12.5px; line-height: 1.65; color: var(--text-muted); }
+
+.lm-deck-footer { display: flex; align-items: center; justify-content: space-between; gap: 12px;
+  padding: 11px 18px 11px 26px; border-top: 1px solid var(--border-soft); background: rgba(0,0,0,0.15); }
+
+.lm-deck-topic { font-family: var(--font-mono); font-size: 10px; color: var(--text-muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 70%; }
+
+.lm-deck-num { font-family: var(--font-mono); font-size: 11px; font-weight: 700; color: var(--text-secondary); background: var(--bg-base); border: 1px solid var(--border); border-radius: 999px; padding: 3px 10px; }
+
+/* ─── Slide Lecture: activity (break-point) slides ─── */
+
+.lm-deck-activity { background: var(--bg-raised);
+  background: linear-gradient(165deg, var(--bg-raised), var(--bg-base));
+  background:
+  radial-gradient(130% 80% at 0% 0%, color-mix(in srgb, var(--accent) 16%, transparent), transparent 55%),
+  linear-gradient(165deg, var(--bg-raised), var(--bg-base)); }
+
+.lm-deck-activity::before { background: var(--accent);
+  background: linear-gradient(90deg, var(--accent), color-mix(in srgb, var(--accent) 20%, transparent)); }
+
+.lm-activity-badge { display: inline-block; font-family: var(--font-mono); font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; color: var(--accent); background: var(--bg-base); border: 1px solid var(--accent-dim); border-radius: 999px; padding: 4px 10px; margin-bottom: 12px; }
+
+.lm-activity-prompt { font-family: var(--font-body); font-size: 16px; line-height: 1.55; color: var(--text-primary); margin: 0 0 14px; }
+
+.lm-activity-input { width: 100%; box-sizing: border-box; background: var(--bg-base); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 11px 13px; font-family: var(--font-body); font-size: 14px; line-height: 1.5; color: var(--text-primary); resize: vertical; margin-bottom: 12px; touch-action: pan-y; }
+
+.lm-activity-input:focus { outline: none; border-color: var(--accent-dim); }
+
+.lm-activity-actions { display: flex; gap: 8px; flex-wrap: wrap; }
+
+.lm-activity-feedback { margin-top: 14px; }
+
+/* ─── Full-screen presentation mode ─── */
+
+.lm-present { position: fixed; inset: 0; z-index: 9500; display: flex; flex-direction: column;
+  overscroll-behavior: none; touch-action: none;
+  background: var(--bg-base);
+  background: radial-gradient(120% 70% at 100% 0%, color-mix(in srgb, var(--accent) 12%, transparent), transparent 55%), linear-gradient(165deg, var(--bg-raised), var(--bg-base));
+  animation: lm-deck-in 0.28s ease; }
+
+.lm-present-top { flex: 0 0 auto; display: flex; align-items: center; justify-content: space-between; padding: 14px 16px; border-bottom: 1px solid var(--border-soft); }
+
+.lm-present-kicker { font-family: var(--font-mono); font-size: 12px; font-weight: 700; color: var(--text-secondary); }
+
+.lm-present-iconbtn { width: 40px; height: 40px; border-radius: 50%; background: var(--bg-raised); border: 1px solid var(--border); color: var(--text-secondary); font-size: 15px; display: flex; align-items: center; justify-content: center; cursor: pointer; }
+
+.lm-present-iconbtn:active { transform: scale(0.94); }
+
+.lm-present-stage { flex: 1 1 auto; min-height: 0; overflow: hidden; display: flex; }
+
+.lm-present-slide { flex: 1; display: flex; flex-direction: column; justify-content: flex-start; padding: 12px 20px 14px; overflow: hidden; }
+
+.lm-present-activity { justify-content: flex-start; padding-top: 20px; }
+
+.lm-present-kicker2 { font-family: var(--font-mono); font-size: 9px; font-weight: 700; letter-spacing: 0.14em; color: var(--accent); margin-bottom: 8px; }
+
+.lm-present-title { font-family: var(--font-ui); font-size: 22px; font-weight: 800; line-height: 1.18; color: var(--text-primary); margin: 0 0 12px; padding-bottom: 10px; position: relative; }
+
+.lm-present-title::after { content: ''; position: absolute; bottom: 0; left: 0; width: 40px; height: 3px; border-radius: 4px; background: var(--accent); }
+
+.lm-present-bullets { list-style: none; margin: 0; padding: 0; }
+
+.lm-present-bullets li { position: relative; padding-left: 22px; font-family: var(--font-body); font-size: 15px; line-height: 1.38; color: var(--text-primary); margin-bottom: 10px; opacity: 0; animation: lm-bullet-in 0.4s ease forwards; }
+
+.lm-present-bullets li::before { content: '▸'; position: absolute; left: 4px; top: 1px; color: var(--accent); }
+
+.lm-present-narration { margin-top: 14px; padding-top: 12px; border-top: 1px solid var(--border-soft); font-family: var(--font-body); font-size: 12px; line-height: 1.6; color: var(--text-secondary); opacity: 0; animation: lm-bullet-in 0.5s ease 0.4s forwards; overflow: hidden; }
+
+.lm-present-bar { flex: 0 0 auto; display: flex; gap: 10px; padding: 14px 16px 18px; border-top: 1px solid var(--border-soft); background: rgba(0,0,0,0.28); }
+
+@supports (padding: env(safe-area-inset-bottom)) { .lm-present-bar { padding-bottom: calc(16px + env(safe-area-inset-bottom)); } }
+
+.lm-present-bar .btn-secondary, .lm-present-bar .btn-primary { flex: 1; justify-content: center; padding: 14px 10px; font-size: 15px; }
+
+.lm-present-notes-sheet { position: absolute; left: 0; right: 0; bottom: 78px; max-height: 42%; overflow-y: auto; touch-action: pan-y; background: var(--bg-raised); border-top: 1px solid var(--border); padding: 16px 22px 20px; font-family: var(--font-body); font-size: 14px; line-height: 1.7; color: var(--text-secondary); box-shadow: 0 -12px 32px rgba(0,0,0,0.5); }
+
+/* Applied to body during present mode — locks scroll without position:fixed page-jump */
+
+body.lm-presenting {
+  overflow: hidden;
+  position: fixed;
+  width: 100%;
+}
+
+/* Ensure narration label and text are separated */
+
+.lm-deck-notes-label { display: block; margin-bottom: 4px; }
+
+.lm-deck-notes-text { display: block; }
+
+/* ════════════════════════════════════════════════════════
+   UTILITY CLASSES — replaces inline styles in Dashboard/Library
+   Use these to eliminate the inline style strings throughout
+════════════════════════════════════════════════════════ */
+
+.dash-title { font-family: var(--font-ui); font-size: 14px; font-weight: 700; color: var(--text-primary); }
+
+.dash-title-lg { font-family: var(--font-ui); font-size: 15px; font-weight: 800; color: var(--text-primary); }
+
+.dash-meta { font-family: var(--font-mono); font-size: 11px; color: var(--text-muted); }
+
+.dash-row { display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 8px; }
+
+.dash-row--base { align-items: baseline; }
+
+.text-accent { color: var(--accent); font-weight: 700; }
+
+.text-green { color: var(--green); }
+
+.text-red { color: var(--red); }
+
+.fw-700 { font-weight: 700; }
+
+.fw-800 { font-weight: 800; }
+
+.mt-6 { margin-top: 6px; }
+
+.mt-10 { margin-top: 10px; }
+
+.mb-10 { margin-bottom: 10px; }
+
+.mb-12 { margin-bottom: 12px; }
+
+.mb-14 { margin-bottom: 14px; }
+
+/* ════════════════════════════════════════════════════════
+   EMPTY STATES V2 — actionable, not just an error message
+════════════════════════════════════════════════════════ */
+
+.empty-state-v2 {
+  display: flex; flex-direction: column; align-items: center; justify-content: center;
+  gap: 14px; min-height: 320px; text-align: center; padding: 40px 28px;
+}
+
+.empty-state-icon { font-size: 52px; opacity: 0.3; line-height: 1; }
+
+.empty-state-title {
+  font-family: var(--font-ui); font-size: 18px; font-weight: 700;
+  color: var(--text-primary); line-height: 1.3;
+}
+
+.empty-state-body {
+  font-family: var(--font-body); font-size: 14px; color: var(--text-secondary);
+  line-height: 1.65; max-width: 320px;
+}
+
+.empty-state-cta { margin-top: 4px; }
+
+/* ════════════════════════════════════════════════════════
+   REVIEW — rating buttons with scheduling hints
+════════════════════════════════════════════════════════ */
+
+.rating-btn { display: flex; flex-direction: column; align-items: center;
+                    gap: 3px; padding: 10px 8px; }
+
+.rating-label { font-family: var(--font-ui); font-size: 13px; font-weight: 700; }
+
+.rating-hint { font-family: var(--font-mono); font-size: 9px; letter-spacing: .03em;
+                    text-transform: uppercase; opacity: 0.6; }
+
+/* ════════════════════════════════════════════════════════
+   LIBRARY — cleaned card with single mastery display
+════════════════════════════════════════════════════════ */
+
+.node-badge { font-family: var(--font-mono); font-size: 10px; font-weight: 700;
+                      padding: 2px 8px; border-radius: 99px; letter-spacing: .04em;
+                      white-space: nowrap; }
+
+.node-badge--due { background: var(--accent-soft); color: var(--accent);
+                      border: 1px solid var(--accent-dim); }
+
+.node-badge--new { background: var(--bg-raised); color: var(--text-muted);
+                      border: 1px solid var(--border); }
+
+.node-card-header { display: flex; align-items: center; justify-content: space-between;
+                      gap: 8px; margin-bottom: 6px; }
+
+.node-mastery { display: flex; align-items: center; gap: 8px; margin-top: 10px; }
+
+.node-mastery-pct { font-family: var(--font-mono); font-size: 11px; color: var(--accent);
+                      min-width: 32px; text-align: right; flex-shrink: 0; }
+
+.btn-ghost-danger { padding: 7px 12px; background: transparent;
+                      border: 1px solid var(--border); border-radius: var(--radius-md);
+                      color: var(--text-muted); font-size: 12px; cursor: pointer;
+                      transition: border-color var(--ease), color var(--ease); }
+
+.btn-ghost-danger:hover { border-color: var(--red); color: var(--red); }
+
+/* ════════════════════════════════════════════════════════
+   GUIDED STUDY — session completion screen
+════════════════════════════════════════════════════════ */
+
+.guided-session-complete {
+  display: flex; flex-direction: column; align-items: center;
+  text-align: center; padding: 32px 20px; gap: 20px;
+  animation: fade-in 0.4s ease;
+}
+
+.gsc-trophy { font-size: 56px; line-height: 1; animation: gsc-pop 0.5s cubic-bezier(0.34,1.56,0.64,1); }
+
+@keyframes gsc-pop { from { transform: scale(0.5); opacity:0; } to { transform: scale(1); opacity:1; } }
+
+.gsc-title { font-family: var(--font-ui); font-size: 24px; font-weight: 800;
+                    color: var(--text-primary); }
+
+.gsc-stats { display: flex; gap: 20px; justify-content: center; flex-wrap: wrap; }
+
+.gsc-stat { display: flex; flex-direction: column; align-items: center; gap: 4px; }
+
+.gsc-stat-val { font-family: var(--font-mono); font-size: 28px; font-weight: 700;
+                    color: var(--accent); line-height: 1; }
+
+.gsc-stat-lbl { font-family: var(--font-mono); font-size: 10px; color: var(--text-muted);
+                    text-transform: uppercase; letter-spacing: .06em; }
+
+.gsc-stat--due .gsc-stat-val { color: var(--blue); }
+
+.gsc-topics { width: 100%; max-width: 400px; display: flex; flex-direction: column; gap: 6px; }
+
+.gsc-topic { display: flex; justify-content: space-between; align-items: center;
+                    padding: 8px 14px; background: var(--bg-raised);
+                    border: 1px solid var(--border-soft); border-radius: var(--radius-md);
+                    font-family: var(--font-ui); font-size: 13px; color: var(--text-primary); }
+
+.gsc-mastery { font-family: var(--font-mono); font-size: 12px; color: var(--accent);
+                    font-weight: 700; }
+
+.gsc-next-msg { font-family: var(--font-body); font-size: 14px; color: var(--text-secondary);
+                    line-height: 1.65; max-width: 340px; }
+
+.gsc-actions { display: flex; gap: 10px; flex-wrap: wrap; justify-content: center; }
+
+/* ════════════════════════════════════════════════════════
+   COACH — Director context panel (shown when no history)
+════════════════════════════════════════════════════════ */
+.coach-director-context {
+  background: var(--bg-raised);
+  border: 1px solid var(--accent-dim);
+  border-left: 3px solid var(--accent);
+  border-radius: var(--radius-md);
+  padding: 12px 16px;
+  margin-bottom: 14px;
+  display: flex; flex-direction: column; gap: 6px;
+}
+.coach-dir-badge {
+  font-family: var(--font-mono); font-size: 10px;
+  font-weight: 700; color: var(--accent);
+  text-transform: uppercase; letter-spacing: .06em;
+}
+.coach-director-context p {
+  font-family: var(--font-body); font-size: 13px;
+  color: var(--text-secondary); line-height: 1.6; margin: 0;
+}
+.coach-director-context strong { color: var(--text-primary); }
+.coach-dir-plan {
+  font-family: var(--font-mono) !important;
+  font-size: 12px !important; color: var(--text-muted) !important;
+  font-style: italic;
+}
+
+/* ════════════════════════════════
+   COACH — stale Director context
+════════════════════════════════ */
+.coach-dir-stale {
+  border-color: var(--border) !important;
+  border-left-color: var(--text-muted) !important;
+  opacity: 0.75;
+}
+.coach-dir-action {
+  font-family: var(--font-mono) !important;
+  font-size: 11px !important;
+  color: var(--accent) !important;
+  font-weight: 700;
+  margin-top: 4px !important;
+}
+/* Director review — urgent-only pill (no method change) */
+.aidir-pill.urgent-only {
+  background: var(--red-dim);
+  color: var(--red);
+  border-color: transparent;
+  font-style: italic;
+}
+
+/* ═══════════════════════════════════════════════════════════
+   COMPETENCY TEST — premium redesign (v63-9 styling pass)
+   Identity: near-black surfaces, amber accent, hexagon motif.
+   The mode selector reads as a segmented control; the active
+   mode glows amber. Quiz cards float on raised surfaces with a
+   progress rail and a live timer pill.
+═══════════════════════════════════════════════════════════ */
+
+/* ── Mode selector: segmented control ───────────────────── */
+.competency-modes {
+  display: inline-flex;
+  gap: 4px;
+  padding: 4px;
+  margin-bottom: 18px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-lg);
+  box-shadow: inset 0 1px 2px rgba(0,0,0,0.4);
+  flex-wrap: wrap;
+}
+.comp-mode-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 10px 18px;
+  border: none;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text-secondary);
+  font-family: var(--font-ui);
+  font-size: 13.5px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  cursor: pointer;
+  transition: color .18s ease, background .18s ease, box-shadow .18s ease;
+  white-space: nowrap;
+}
+.comp-mode-btn:hover { color: var(--text-primary); }
+.comp-mode-btn.active {
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-light) 100%);
+  color: #1a1206;
+  font-weight: 700;
+  box-shadow: 0 2px 14px var(--accent-glow), 0 1px 0 rgba(255,255,255,0.25) inset;
+}
+
+/* ── Toolbar: subject + start ───────────────────────────── */
+.competency-toolbar {
+  display: flex;
+  align-items: stretch;
+  gap: 10px;
+  margin-bottom: 28px;
+  flex-wrap: wrap;
+}
+.competency-toolbar .config-select {
+  flex: 1;
+  min-width: 180px;
+  font-family: var(--font-mono);
+  font-size: 13.5px;
+  letter-spacing: 0.01em;
+}
+.competency-toolbar .btn-primary {
+  flex-shrink: 0;
+  padding: 0 22px;
+  font-size: 14px;
+  white-space: nowrap;
+}
+
+/* ── Quiz shell: the question container ─────────────────── */
+.quiz-shell {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  padding: 22px;
+  box-shadow: var(--shadow-md);
+  position: relative;
+  overflow: hidden;
+}
+/* subtle amber top edge — the signature line */
+.quiz-shell::before {
+  content: '';
+  position: absolute;
+  top: 0; left: 0; right: 0;
+  height: 2px;
+  background: linear-gradient(90deg, transparent, var(--accent) 45%, var(--accent-light) 55%, transparent);
+  opacity: 0.7;
+}
+
+.quiz-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+.quiz-counter {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.quiz-timer {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  background: var(--accent-soft);
+  border: 1px solid var(--accent-dim);
+  border-radius: 99px;
+  font-family: var(--font-mono);
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--accent-light);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.02em;
+}
+/* timer turns red under 30s — set via inline style override or .low class */
+.quiz-timer.low {
+  background: var(--red-dim);
+  border-color: var(--red);
+  color: var(--red);
+  animation: timer-pulse 1s ease-in-out infinite;
+}
+@keyframes timer-pulse { 50% { opacity: 0.55; } }
+
+/* ── Progress rail ──────────────────────────────────────── */
+.quiz-progress-track {
+  height: 5px;
+  background: var(--bg-raised);
+  border-radius: 99px;
+  overflow: hidden;
+  margin-bottom: 22px;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,0.5);
+}
+.quiz-progress-fill {
+  height: 100%;
+  background: linear-gradient(90deg, var(--accent) 0%, var(--accent-light) 100%);
+  border-radius: 99px;
+  transition: width .45s cubic-bezier(0.4, 0, 0.2, 1);
+  box-shadow: 0 0 10px var(--accent-glow);
+}
+
+/* ── Question card ──────────────────────────────────────── */
+.quiz-card {
+  /* lives inside quiz-shell; no extra border, just spacing */
+}
+.quiz-node-tag {
+  display: inline-block;
+  padding: 5px 12px;
+  margin-bottom: 14px;
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: 99px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--accent);
+  letter-spacing: 0.02em;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.quiz-question {
+  font-family: var(--font-body);
+  font-size: 17px;
+  line-height: 1.6;
+  color: var(--text-primary);
+  margin-bottom: 20px;
+  letter-spacing: -0.01em;
+}
+/* the answer textarea inside a quiz card */
+.quiz-card .config-input,
+#timed-answer, #ai-answer {
+  width: 100%;
+  background: var(--bg-base);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 16px 18px;
+  font-family: var(--font-body);
+  font-size: 15px;
+  line-height: 1.6;
+  color: var(--text-primary);
+  min-height: 130px;
+  resize: vertical;
+  transition: border-color .18s, box-shadow .18s;
+}
+.quiz-card .config-input:focus,
+#timed-answer:focus, #ai-answer:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-glow);
+  outline: none;
+}
+
+/* ── Action buttons row in a quiz ───────────────────────── */
+.quiz-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 16px;
+}
+.quiz-actions .btn-primary { flex: 1; justify-content: center; }
+
+/* ═══════════════════════════════════════════════════════════
+   REPORT CARD — subject grade cards
+═══════════════════════════════════════════════════════════ */
+.comp-subject-card {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 18px 20px;
+  margin-bottom: 14px;
+  transition: border-color .18s, transform .18s;
+}
+.comp-subject-card:hover {
+  border-color: var(--border-bright);
+  transform: translateY(-1px);
+}
+.comp-subject-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+.comp-subject-name {
+  font-family: var(--font-ui);
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--text-primary);
+  letter-spacing: -0.01em;
+}
+.comp-subject-meta {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-top: 2px;
+  letter-spacing: 0.02em;
+}
+
+/* Grade badge — circular, color reflects performance */
+.comp-grade {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 52px;
+  height: 52px;
+  border-radius: var(--radius-md);
+  font-family: var(--font-ui);
+  font-size: 22px;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  flex-shrink: 0;
+}
+.comp-grade.grade-a { background: var(--green-dim); color: var(--green); border: 1px solid rgba(52,199,123,0.3); }
+.comp-grade.grade-b { background: var(--accent-soft); color: var(--accent-light); border: 1px solid var(--accent-dim); }
+.comp-grade.grade-c { background: var(--blue-dim); color: var(--blue); border: 1px solid rgba(78,142,247,0.3); }
+.comp-grade.grade-d,
+.comp-grade.grade-f { background: var(--red-dim); color: var(--red); border: 1px solid rgba(240,86,74,0.3); }
+
+
+/* ── Report: overall hero card ──────────────────────────── */
+.comp-overall-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  background: linear-gradient(135deg, var(--bg-surface) 0%, var(--bg-card) 100%);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  padding: 24px 26px;
+  margin-bottom: 18px;
+  box-shadow: var(--shadow-md);
+  position: relative;
+  overflow: hidden;
+}
+.comp-overall-card::before {
+  content: '';
+  position: absolute;
+  top: 0; left: 0; right: 0; height: 2px;
+  background: linear-gradient(90deg, transparent, var(--accent) 50%, transparent);
+  opacity: 0.6;
+}
+.comp-overall-left {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  min-width: 0;
+}
+.comp-overall-grade {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 72px; height: 72px;
+  border-radius: var(--radius-lg);
+  font-family: var(--font-ui);
+  font-size: 32px;
+  font-weight: 800;
+  letter-spacing: -0.04em;
+  flex-shrink: 0;
+}
+.comp-grade-lg { width: 72px; height: 72px; font-size: 32px; }
+/* grade colour map (shared by .comp-grade and .comp-overall-grade) */
+.grade-a-plus, .comp-overall-grade.grade-a-plus { background: var(--green-dim); color: var(--green); border: 1px solid rgba(52,199,123,0.35); }
+.grade-a,  .comp-overall-grade.grade-a  { background: var(--green-dim); color: var(--green); border: 1px solid rgba(52,199,123,0.3); }
+.grade-b,  .comp-overall-grade.grade-b  { background: var(--accent-soft); color: var(--accent-light); border: 1px solid var(--accent-dim); }
+.grade-c,  .comp-overall-grade.grade-c  { background: var(--blue-dim); color: var(--blue); border: 1px solid rgba(78,142,247,0.3); }
+.grade-d,  .comp-overall-grade.grade-d  { background: var(--red-dim); color: var(--red); border: 1px solid rgba(240,86,74,0.3); }
+.grade-f,  .comp-overall-grade.grade-f  { background: var(--red-dim); color: var(--red); border: 1px solid rgba(240,86,74,0.3); }
+
+.comp-recommendation {
+  background: var(--accent-soft);
+  border: 1px solid var(--accent-dim);
+  border-left: 3px solid var(--accent);
+  border-radius: var(--radius-md);
+  padding: 14px 18px;
+  margin-bottom: 22px;
+  font-family: var(--font-body);
+  font-size: 14px;
+  line-height: 1.65;
+  color: var(--text-secondary);
+}
+.comp-recommendation strong { color: var(--accent-light); }
+
+.comp-subjects-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 14px;
+}
+
+/* ── Graded results ─────────────────────────────────────── */
+.comp-result-item {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 18px 20px;
+  margin-bottom: 12px;
+}
+.comp-result-score {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 2px;
+  font-family: var(--font-mono);
+  font-weight: 700;
+}
+.comp-result-score .pct { font-size: 22px; }
+.comp-result-score .of  { font-size: 12px; color: var(--text-muted); }
+
+/* ═══════════════════════════════════════════════════════════
+   MOBILE — safe-area top padding so the title is never clipped
+   behind the status bar / browser chrome.
+═══════════════════════════════════════════════════════════ */
+@media (max-width: 768px) {
+  /* Safe-area top padding so the view title is never clipped behind the
+     status bar or browser URL chrome. Full shorthand to beat main.css. */
+  .view {
+    padding: calc(18px + env(safe-area-inset-top, 0px)) 16px 80px;
+  }
+  .competency-modes { width: 100%; justify-content: space-between; }
+  .comp-mode-btn { flex: 1; justify-content: center; padding: 10px 8px; font-size: 12.5px; }
+  /* Stack subject + start vertically and make both full-width so the
+     Start button matches the All Subjects dropdown above it. */
+  .competency-toolbar { flex-direction: column; }
+  .competency-toolbar .config-select { width: 100%; max-width: none; }
+  .competency-toolbar .btn-primary { width: 100%; justify-content: center; padding: 14px 22px; }
+  .comp-overall-card { flex-direction: column; align-items: flex-start; }
+  .comp-overall-card canvas { align-self: center; }
+  .comp-subjects-grid { grid-template-columns: 1fr; }
+  .quiz-question { font-size: 16px; }
+}
+
+/* ── Dashboard (Progress view) — base styles. The markup shipped before its
+   stylesheet did; only two phone media-tweaks existed. Both themes. ── */
+.dash-section { background: var(--bg-surface); border: 1px solid var(--border); border-radius: var(--radius-lg); padding: 18px 20px; margin-bottom: 16px; }
+.dash-section-title { font-family: var(--font-ui); font-size: 12px; font-weight: 700; letter-spacing: .05em; text-transform: uppercase; color: var(--text-secondary); margin-bottom: 12px; }
+.dash-stats-row { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
+.dash-stat-card { background: var(--bg-raised); border: 1px solid var(--border-soft); border-radius: var(--radius-md); padding: 14px 10px; text-align: center; }
+.dash-stat-card.accent { border-color: var(--accent-dim); background: var(--accent-soft); }
+.dash-stat-card.warn { border-color: var(--accent-dim); }
+.dash-stat-val { font-family: var(--font-mono); font-size: 26px; font-weight: 800; color: var(--accent); line-height: 1.1; }
+.dash-stat-label { font-family: var(--font-ui); font-size: 11px; color: var(--text-muted); margin-top: 4px; text-transform: uppercase; letter-spacing: .05em; }
+.dash-subject-row { padding: 12px 0; border-bottom: 1px solid var(--border-soft); }
+.dash-subject-row:last-child { border-bottom: none; }
+.dash-subject-name { font-family: var(--font-ui); font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 6px; }
+.dash-subject-stats { display: flex; gap: 6px; margin-bottom: 8px; flex-wrap: wrap; }
+.dash-pill { font-family: var(--font-mono); font-size: 10px; padding: 2px 8px; border-radius: 99px; background: var(--bg-raised); border: 1px solid var(--border-soft); color: var(--text-secondary); }
+.dash-pill.due { color: var(--accent); border-color: var(--accent-dim); background: var(--accent-soft); }
+.dash-subject-bar-wrap { display: flex; align-items: center; gap: 10px; }
+.dash-test-btn { background: transparent; border: 1px solid var(--border); border-radius: 8px; padding: 4px 9px; cursor: pointer; font-size: 14px; flex-shrink: 0; }
+.dash-no-plan { font-family: var(--font-mono); font-size: 12px; color: var(--text-muted); padding: 10px 0; }
+.dash-legend { display: flex; gap: 14px; flex-wrap: wrap; margin-top: 10px; }
+.dash-legend-item { font-family: var(--font-mono); font-size: 11px; color: var(--text-secondary); display: flex; align-items: center; gap: 6px; }
+
+/* Heatmap: fixed-size cells — previously scaled to viewport width (12 huge
+   columns) making a giant empty block. */
+.heatmap-grid { grid-template-columns: repeat(12, 16px); grid-template-rows: repeat(7, 16px); width: max-content; max-width: 100%; overflow-x: auto; }
+.heatmap-cell { width: 16px; height: 16px; min-width: 0; }
+.light-theme .heatmap-cell { background: rgba(0, 0, 0, 0.08); }
+.light-theme .dash-stat-card, .light-theme .dash-pill { background: var(--bg-elevated); }

--- a/knowledgenode/www/css/components.css
+++ b/knowledgenode/www/css/components.css
@@ -4046,6 +4046,65 @@
   padding-bottom: calc(16px + env(safe-area-inset-bottom, 0px));
 }
 
+/* Composer — one rounded card holding the growing text box and its buttons,
+   so a long question stays fully visible instead of scrolling sideways in a
+   one-line field. */
+.coach-composer {
+  flex-shrink: 0; margin-top: 12px;
+  margin-bottom: calc(16px + env(safe-area-inset-bottom, 0px));
+  background: var(--bg-raised); border: 1px solid var(--border);
+  border-radius: 22px; padding: 10px 12px 8px;
+  transition: border-color .15s, box-shadow .15s;
+}
+.coach-composer:focus-within {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 18%, transparent);
+}
+.coach-textarea {
+  display: block; width: 100%; border: none; background: transparent;
+  color: var(--text-primary); font-family: var(--font-body);
+  font-size: 16px;            /* 16px stops iOS zooming in on focus */
+  line-height: 1.5; resize: none; outline: none; padding: 2px 2px 6px;
+  max-height: 160px; overflow-y: hidden;
+}
+.coach-textarea::placeholder { color: var(--text-muted); font-family: var(--font-mono); font-size: 13px; }
+.coach-composer-actions { display: flex; align-items: center; justify-content: flex-end; gap: 8px; }
+.coach-attach-btn, .coach-send-btn {
+  display: inline-flex; align-items: center; justify-content: center;
+  border-radius: 50%; cursor: pointer; flex-shrink: 0;
+  transition: background .15s, color .15s, transform .1s;
+}
+.coach-attach-btn {
+  width: 34px; height: 34px; margin-right: auto;
+  background: transparent; border: none; color: var(--text-muted);
+}
+.coach-attach-btn:hover { background: var(--bg-elevated, rgba(255,255,255,.06)); color: var(--text-primary); }
+.coach-send-btn {
+  width: 34px; height: 34px; border: none;
+  background: var(--accent); color: #fff;
+}
+.coach-send-btn:hover { transform: scale(1.05); }
+.coach-send-btn:active, .coach-attach-btn:active { transform: scale(.94); }
+
+/* Attached-photo chips, removable before sending */
+.coach-attachments { display: flex; flex-wrap: wrap; gap: 6px; padding: 2px 0 8px; }
+.coach-chip {
+  display: inline-flex; align-items: center; gap: 6px;
+  background: var(--bg-elevated, rgba(255,255,255,.06));
+  border: 1px solid var(--border); border-radius: 10px;
+  padding: 4px 6px 4px 4px; max-width: 100%;
+}
+.coach-chip img { width: 26px; height: 26px; object-fit: cover; border-radius: 6px; flex-shrink: 0; }
+.coach-chip span {
+  font-family: var(--font-mono); font-size: 11px; color: var(--text-secondary);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.coach-chip button {
+  border: none; background: transparent; color: var(--text-muted);
+  cursor: pointer; font-size: 12px; line-height: 1; padding: 2px 3px; border-radius: 5px;
+}
+.coach-chip button:hover { color: var(--red, #e5484d); background: rgba(255,255,255,.07); }
+
 .coach-msg:last-child { margin-bottom: 0; }
 
 .coach-empty {

--- a/knowledgenode/www/css/main.css
+++ b/knowledgenode/www/css/main.css
@@ -1,0 +1,604 @@
+/* ═══════════════════════════════════════════════════
+   KNOWLEDGENODE — FINAL DESIGN SYSTEM
+   Typography: Inter (UI) + Merriweather (body text)
+   Premium dark scholarly. Clean, readable, focused.
+═══════════════════════════════════════════════════ */
+
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=Merriweather:ital,wght@0,300;0,400;0,700;1,300;1,400&family=JetBrains+Mono:wght@300;400;500&display=swap');
+
+:root {
+  /* ── Palette ── */
+  --bg-base:       #07080b;
+  --bg-surface:    #0d0f14;
+  --bg-raised:     #131720;
+  --bg-card:       #181d26;
+  --bg-hover:      #1c2130;
+  --border:        #242b38;
+  --border-soft:   #181e29;
+  --border-bright: #303a4e;
+
+  --text-primary:  #edecea;
+  --text-secondary:#8892a4;
+  --text-muted:    #4a5366;
+
+  --accent:        #f0a500;
+  --accent-light:  #f5bc3a;
+  --accent-dim:    #5c3f00;
+  --accent-glow:   rgba(240,165,0,0.16);
+  --accent-soft:   rgba(240,165,0,0.07);
+
+  --green:         #34c77b;
+  --green-dim:     rgba(52,199,123,0.1);
+  --red:           #f0564a;
+  --red-dim:       rgba(240,86,74,0.1);
+  --blue:          #4e8ef7;
+  --blue-dim:      rgba(78,142,247,0.1);
+  --purple:        #9b7ef5;
+  --purple-dim:    rgba(155,126,245,0.1);
+
+  /* ── Typography ── */
+  --font-ui:      'Inter', system-ui, sans-serif;
+  --font-body:    'Merriweather', Georgia, serif;
+  --font-mono:    'JetBrains Mono', 'Courier New', monospace;
+
+  /* ── Spacing / Shape ── */
+  --radius-xs:    3px;
+  --radius-sm:    6px;
+  --radius-md:    10px;
+  --radius-lg:    16px;
+  --radius-xl:    22px;
+  --radius-2xl:   32px;
+
+  /* ── Shadows ── */
+  --shadow-sm:    0 1px 3px rgba(0,0,0,0.5);
+  --shadow-md:    0 4px 18px rgba(0,0,0,0.55);
+  --shadow-lg:    0 12px 48px rgba(0,0,0,0.65);
+
+  /* ── Layout ── */
+  --sidebar-w:    248px;
+  --sidebar-w-sm: 64px;
+
+  /* ── Motion ── */
+  --ease:         0.18s ease;
+  --ease-slow:    0.38s cubic-bezier(0.4,0,0.2,1);
+}
+
+/* ─── RESET ─── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+html { font-size: 16px; scroll-behavior: smooth; overflow-x: hidden; max-width: 100vw; }
+body {
+  background: var(--bg-base);
+  color: var(--text-primary);
+  font-family: var(--font-body);
+  font-size: 15px;
+  line-height: 1.75;
+  min-height: 100vh;
+  overflow-x: hidden;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+img { max-width: 100%; display: block; }
+button { cursor: pointer; font-family: var(--font-ui); }
+input, select, textarea { font-family: var(--font-ui); }
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+h1,h2,h3,h4 { font-family: var(--font-ui); letter-spacing: -0.02em; }
+
+/* ─── SCROLLBAR ─── */
+::-webkit-scrollbar { width: 5px; height: 5px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--border); border-radius: 99px; }
+::-webkit-scrollbar-thumb:hover { background: var(--border-bright); }
+
+/* ══════════════════════════════
+   APP SHELL
+══════════════════════════════ */
+#app { display: flex; min-height: 100vh; overflow-x: hidden; max-width: 100vw; }
+
+/* ─── SIDEBAR ─── */
+.sidebar {
+  width: var(--sidebar-w);
+  min-height: 100vh;
+  background: var(--bg-surface);
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  position: fixed;
+  top: 0; left: 0; bottom: 0;
+  z-index: 200;
+  transition: width var(--ease-slow);
+  overflow: hidden;
+}
+.sidebar.collapsed { width: var(--sidebar-w-sm); }
+
+.sidebar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px 16px 18px;
+  border-bottom: 1px solid var(--border-soft);
+  gap: 10px;
+  flex-shrink: 0;
+}
+.logo { display: flex; align-items: center; gap: 10px; overflow: hidden; white-space: nowrap; min-width: 0; }
+.logo-mark {
+  width: 32px; height: 32px;
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-light) 100%);
+  border-radius: 8px;
+  display: flex; align-items: center; justify-content: center;
+  font-family: var(--font-ui); font-size: 16px; font-weight: 800; color: #000;
+  flex-shrink: 0;
+  box-shadow: 0 2px 10px rgba(240,165,0,0.35);
+}
+.logo-text {
+  font-family: var(--font-ui); font-size: 14px; font-weight: 700;
+  letter-spacing: -0.01em; color: var(--text-primary);
+  white-space: nowrap; overflow: hidden;
+  transition: opacity var(--ease);
+}
+.sidebar.collapsed .logo-text { opacity: 0; width: 0; }
+
+.sidebar-toggle {
+  width: 26px; height: 26px;
+  border: 1px solid var(--border); border-radius: var(--radius-sm);
+  color: var(--text-muted); font-size: 10px;
+  display: flex; align-items: center; justify-content: center;
+  transition: all var(--ease); flex-shrink: 0;
+  background: transparent; cursor: pointer;
+}
+.sidebar-toggle:hover { border-color: var(--accent); color: var(--accent); }
+
+.sidebar-nav { display: flex; flex-direction: column; gap: 2px; padding: 12px 8px; flex: 1; overflow-y: auto; }
+
+.nav-item {
+  display: flex; align-items: center; gap: 11px;
+  padding: 10px 11px; border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  font-family: var(--font-ui); font-size: 13px; font-weight: 500;
+  transition: all var(--ease); white-space: nowrap; overflow: hidden;
+  width: 100%; text-align: left; cursor: pointer;
+  background: transparent; border: 1px solid transparent;
+}
+.nav-item:hover { background: var(--bg-hover); color: var(--text-primary); }
+.nav-item.active { background: var(--accent-soft); color: var(--accent); border-color: var(--accent-dim); }
+.nav-icon { font-size: 15px; flex-shrink: 0; width: 20px; text-align: center; }
+.nav-label { transition: opacity var(--ease); }
+.sidebar.collapsed .nav-label { opacity: 0; pointer-events: none; }
+
+.sidebar-footer { padding: 12px 8px; border-top: 1px solid var(--border-soft); flex-shrink: 0; }
+
+.stats-grid { display: flex; gap: 0; background: var(--bg-raised); border: 1px solid var(--border); border-radius: var(--radius-md); overflow: hidden; margin-bottom: 10px; }
+.stat-cell { flex: 1; padding: 10px 6px; text-align: center; border-right: 1px solid var(--border-soft); }
+.stat-cell:last-child { border-right: none; }
+.stat-val { display: block; font-family: var(--font-mono); font-size: 15px; font-weight: 500; color: var(--accent); line-height: 1; margin-bottom: 4px; }
+.stat-key { font-family: var(--font-ui); font-size: 9px; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text-muted); }
+.sidebar.collapsed .stats-grid { display: none; }
+
+.ai-settings-btn {
+  width: 100%; padding: 9px 12px;
+  background: transparent; border: 1px solid var(--border); border-radius: var(--radius-md);
+  color: var(--text-muted); font-family: var(--font-ui); font-size: 11px; font-weight: 500;
+  cursor: pointer; transition: all var(--ease);
+  display: flex; align-items: center; justify-content: center; gap: 6px;
+}
+.ai-settings-btn:hover { border-color: var(--accent-dim); color: var(--accent); background: var(--accent-soft); }
+
+/* ─── MAIN CONTENT ─── */
+.main-content {
+  flex: 1; margin-left: var(--sidebar-w);
+  min-height: 100vh; transition: margin-left var(--ease-slow);
+  overflow-x: hidden; min-width: 0;
+}
+.sidebar.collapsed ~ .main-content { margin-left: var(--sidebar-w-sm); }
+
+/* ── Collapsed sidebar: footer widgets go icon-only (fixes squished iPad rail) ── */
+.sidebar.collapsed .sidebar-footer { padding: 12px 6px; }
+.sidebar.collapsed .ai-director-btn { padding: 10px 4px; }
+.sidebar.collapsed .ai-director-btn span:not(.aidir-btn-orb) { display: none; }
+.sidebar.collapsed .ai-settings-btn span + span { display: none; }
+.sidebar.collapsed .ai-settings-btn { justify-content: center; padding: 8px 0; min-width: 0; }
+.sidebar.collapsed .sidebar-footer > div:not(.stats-grid) { flex-direction: column; align-items: center; }
+.sidebar.collapsed .sidebar-footer > div:last-child { display: none; }  /* streak / shortcuts line */
+
+
+/* ─── VIEWS ─── */
+.view { display: none; padding: 44px 52px 64px; min-height: 100vh; animation: view-in 0.25s ease; overflow-x: hidden; box-sizing: border-box; width: 100%; }
+.view.active { display: block; }
+.node-detail-view { padding: 0; }
+@keyframes view-in { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: translateY(0); } }
+
+.view-header { margin-bottom: 36px; padding-bottom: 22px; border-bottom: 1px solid var(--border); }
+.view-title { font-family: var(--font-ui); font-size: 28px; font-weight: 800; color: var(--text-primary); line-height: 1.1; margin-bottom: 6px; letter-spacing: -0.03em; }
+.view-subtitle { font-family: var(--font-body); font-size: 14px; color: var(--text-secondary); font-style: italic; line-height: 1.6; }
+
+/* ══════════════════════════════
+   BUTTONS
+══════════════════════════════ */
+.btn-primary {
+  display: inline-flex; align-items: center; gap: 7px;
+  padding: 11px 22px;
+  background: var(--accent); color: #060709;
+  border-radius: var(--radius-md); border: none;
+  font-family: var(--font-ui); font-size: 13px; font-weight: 700; letter-spacing: 0.01em;
+  transition: all var(--ease); cursor: pointer;
+  box-shadow: 0 2px 12px rgba(240,165,0,0.3);
+  white-space: nowrap;
+}
+.btn-primary:hover { background: var(--accent-light); box-shadow: 0 4px 22px rgba(240,165,0,0.45); transform: translateY(-1px); }
+.btn-primary:active { transform: translateY(0); box-shadow: none; }
+.btn-primary:disabled { opacity: 0.45; cursor: not-allowed; transform: none; box-shadow: none; }
+
+.btn-secondary {
+  display: inline-flex; align-items: center; gap: 7px;
+  padding: 10px 18px;
+  background: transparent; color: var(--text-secondary);
+  border: 1px solid var(--border); border-radius: var(--radius-md);
+  font-family: var(--font-ui); font-size: 13px; font-weight: 500;
+  transition: all var(--ease); cursor: pointer; white-space: nowrap;
+}
+.btn-secondary:hover { border-color: var(--border-bright); color: var(--text-primary); background: var(--bg-hover); }
+.btn-secondary:disabled { opacity: 0.4; cursor: not-allowed; }
+
+.btn-ghost { display: inline-flex; align-items: center; gap: 6px; padding: 8px 12px; background: transparent; color: var(--text-muted); border-radius: var(--radius-sm); font-family: var(--font-ui); font-size: 13px; transition: color var(--ease); cursor: pointer; border: none; }
+.btn-ghost:hover { color: var(--text-primary); }
+.review-front-actions { display: flex; flex-direction: column; align-items: center; gap: 4px; margin-top: 16px; }
+
+.btn-danger { display: inline-flex; align-items: center; gap: 7px; padding: 10px 18px; background: var(--red-dim); color: var(--red); border: 1px solid rgba(240,86,74,0.25); border-radius: var(--radius-md); font-family: var(--font-ui); font-size: 13px; font-weight: 600; transition: all var(--ease); cursor: pointer; }
+.btn-danger:hover { background: var(--red); color: #fff; }
+
+/* ══════════════════════════════
+   FORMS
+══════════════════════════════ */
+.config-input, .config-select, .search-input {
+  width: 100%; padding: 10px 14px;
+  background: var(--bg-raised); border: 1px solid var(--border);
+  border-radius: var(--radius-md); color: var(--text-primary);
+  font-family: var(--font-mono); font-size: 13px;
+  transition: border-color var(--ease), box-shadow var(--ease); outline: none;
+}
+.config-input::placeholder, .search-input::placeholder { color: var(--text-muted); }
+.config-input:focus, .config-select:focus, .search-input:focus { border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-glow); }
+textarea.config-input { resize: vertical; line-height: 1.6; font-family: var(--font-body); font-size: 14px; }
+.config-select { appearance: none; cursor: pointer; }
+.config-label { display: block; font-family: var(--font-ui); font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text-muted); margin-bottom: 7px; }
+.config-row { display: flex; flex-direction: column; gap: 0; }
+
+/* ══════════════════════════════
+   MODAL
+══════════════════════════════ */
+.modal-overlay { position: fixed; inset: 0; background: rgba(4,5,8,0.88); z-index: 9000; display: flex; align-items: center; justify-content: center; backdrop-filter: blur(6px); padding: 20px; }
+.modal-overlay.hidden { display: none !important; }
+
+/* Background scroll-lock while any overlay/popup is open (set by ScrollLock.js).
+   Uses overflow:hidden (not position:fixed) to avoid mobile page-jump. */
+html.scroll-locked, body.scroll-locked { overflow: hidden !important; }
+body.scroll-locked { overscroll-behavior: none; }
+.modal { background: var(--bg-surface); border: 1px solid var(--border-bright); border-radius: var(--radius-xl); padding: 36px 40px 40px; max-width: 560px; width: 100%; max-height: 88vh; max-height: 88dvh; overflow: hidden; display: flex; flex-direction: column; position: relative; animation: modal-in 0.22s cubic-bezier(0.34,1.56,0.64,1); box-shadow: var(--shadow-lg); }
+/* Inner content scrolls instead of the whole modal, so the absolutely-positioned
+   .modal-close stays pinned to the modal frame (was scrolling off the top on long content). */
+#modal-content { overflow-y: auto; min-height: 0; -webkit-overflow-scrolling: touch; }
+@keyframes modal-in { from { opacity: 0; transform: scale(0.93) translateY(10px); } to { opacity: 1; transform: scale(1) translateY(0); } }
+.modal-close { position: absolute; top: 16px; right: 16px; width: 28px; height: 28px; background: var(--bg-raised); border: 1px solid var(--border); border-radius: 50%; color: var(--text-muted); font-size: 13px; display: flex; align-items: center; justify-content: center; transition: all var(--ease); cursor: pointer; }
+.modal-close:hover { border-color: var(--red); color: var(--red); }
+.sheet-close-x { position: absolute; top: 14px; right: 14px; width: 30px; height: 30px; background: var(--bg-base); border: 1px solid var(--border); border-radius: 50%; color: var(--text-muted); font-size: 14px; display: flex; align-items: center; justify-content: center; transition: all var(--ease); cursor: pointer; z-index: 2; }
+.sheet-close-x:hover { border-color: var(--red); color: var(--red); }
+
+/* ══════════════════════════════
+   TOAST
+══════════════════════════════ */
+.toast-container { position: fixed; bottom: 24px; right: 24px; z-index: 9999; display: flex; flex-direction: column; gap: 8px; pointer-events: none; }
+.toast { display: flex; align-items: center; gap: 12px; padding: 12px 18px; background: var(--bg-card); border: 1px solid var(--border-bright); border-radius: var(--radius-md); box-shadow: var(--shadow-lg); font-family: var(--font-mono); font-size: 13px; color: var(--text-primary); min-width: 240px; max-width: 360px; animation: toast-in 0.25s ease; pointer-events: all; }
+.toast.toast-success { border-left: 3px solid var(--green); }
+.toast.toast-error   { border-left: 3px solid var(--red); }
+.toast.toast-info    { border-left: 3px solid var(--blue); }
+.toast.toast-warn    { border-left: 3px solid var(--accent); }
+.toast.toast-out     { animation: toast-out 0.22s ease forwards; }
+.toast .toast-msg    { flex: 1; }
+.toast-close { background: none; border: none; color: var(--text-muted); font-size: 14px; cursor: pointer; padding: 2px 4px; line-height: 1; flex-shrink: 0; }
+.toast-close:hover   { color: var(--text-primary); }
+@keyframes toast-in  { from { opacity:0; transform:translateX(14px); } to { opacity:1; transform:translateX(0); } }
+@keyframes toast-out { from { opacity:1; } to { opacity:0; transform:translateX(14px); } }
+
+/* ══════════════════════════════
+   UTILITY
+══════════════════════════════ */
+.hidden { display: none !important; }
+.empty-state { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 14px; min-height: 260px; text-align: center; color: var(--text-muted); }
+.empty-icon { font-size: 40px; opacity: 0.2; }
+.empty-state p { font-family: var(--font-mono); font-size: 13px; }
+
+/* API Key Banner */
+#api-key-banner { position: fixed; top: 0; left: 0; right: 0; z-index: 300; background: linear-gradient(135deg, var(--bg-surface) 0%, var(--bg-raised) 100%); border-bottom: 1px solid var(--accent-dim); padding: 11px 24px 11px calc(var(--sidebar-w) + 24px); display: flex; align-items: center; justify-content: space-between; font-family: var(--font-mono); font-size: 12px; color: var(--text-secondary); gap: 12px; }
+
+/* NODE DETAIL */
+.detail-tabs-bar { display: none; gap: 4px; padding: 4px; margin: 0 16px 8px; background: var(--bg-raised); border: 1px solid var(--border); border-radius: var(--radius-lg); position: sticky; top: 65px; z-index: 40; }
+.detail-tab-btn { flex: 1 1 0; min-width: 0; padding: 9px 4px; border: none; background: transparent; color: var(--text-secondary); font-family: var(--font-ui); font-size: 11.5px; font-weight: 600; letter-spacing: -0.01em; border-radius: var(--radius-md); cursor: pointer; transition: color var(--ease), background var(--ease), box-shadow var(--ease); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.detail-tab-btn:hover { color: var(--text-primary); }
+.detail-tab-btn.active { background: var(--bg-card); color: var(--accent); box-shadow: var(--shadow-sm), inset 0 0 0 1px var(--accent-dim); }
+
+/* SELECT TOOLBAR */
+.select-toolbar { position: absolute; z-index: 8000; display: flex; gap: 3px; background: var(--bg-raised); border: 1px solid var(--border-bright); border-radius: var(--radius-lg); padding: 5px 7px; box-shadow: var(--shadow-lg); animation: toolbar-pop 0.15s ease; }
+@keyframes toolbar-pop { from { opacity:0; transform:scale(0.9) translateY(4px); } to { opacity:1; transform:scale(1) translateY(0); } }
+.sel-btn { padding: 6px 11px; background: transparent; border: 1px solid var(--border); border-radius: var(--radius-sm); color: var(--text-secondary); font-family: var(--font-ui); font-size: 11px; font-weight: 600; cursor: pointer; white-space: nowrap; transition: all 0.15s ease; }
+.sel-btn:hover { background: var(--accent-soft); border-color: var(--accent-dim); color: var(--accent); }
+
+/* HIGHLIGHTS */
+mark.kn-highlight { background: rgba(240,165,0,0.22); border-bottom: 2px solid var(--accent); border-radius: 2px; padding: 0 1px; cursor: pointer; color: inherit; }
+mark.kn-highlight:hover { background: rgba(240,165,0,0.38); }
+
+/* MOBILE SELECT BAR */
+.mobile-select-bar { position: fixed; bottom: 64px; left: 0; right: 0; background: var(--bg-raised); border-top: 1px solid var(--border-bright); border-radius: var(--radius-xl) var(--radius-xl) 0 0; padding: 12px 14px; z-index: 9500; box-shadow: 0 -4px 24px rgba(0,0,0,0.4); animation: slide-up 0.2s ease; }
+.mobile-select-bar.hidden { display: none !important; }
+.msb-title { font-family: var(--font-mono); font-size: 11px; color: var(--text-muted); margin-bottom: 8px; text-transform: uppercase; letter-spacing: 0.08em; }
+.msb-btns { display: flex; gap: 7px; }
+.msb-btn { flex:1; padding: 10px 6px; background: var(--bg-surface); border: 1px solid var(--border); border-radius: var(--radius-md); color: var(--text-secondary); font-family: var(--font-ui); font-size: 11px; font-weight: 600; cursor: pointer; transition: all var(--ease); text-align: center; }
+.msb-btn:active { background: var(--accent-soft); border-color: var(--accent-dim); color: var(--accent); }
+
+/* MOBILE NAV */
+.mobile-nav { display: none; position: fixed; bottom: 0; left: 0; right: 0; background: var(--bg-surface); border-top: 1px solid var(--border); z-index: 150; padding-bottom: env(safe-area-inset-bottom); }
+.mobile-nav-btn { flex: 1; display: flex; flex-direction: column; align-items: center; gap: 3px; padding: 10px 4px; background: transparent; border: none; color: var(--text-muted); font-family: var(--font-ui); font-size: 9px; font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; cursor: pointer; transition: color var(--ease); }
+.mobile-nav-btn .mnav-icon { font-size: 18px; }
+.mobile-nav-btn.active { color: var(--accent); }
+
+/* MORE MENU */
+.more-menu-panel { position: fixed; bottom: 0; left: 0; right: 0; background: var(--bg-surface); border-top: 1px solid var(--border); border-radius: var(--radius-xl) var(--radius-xl) 0 0; z-index: 400; padding: 16px 16px calc(16px + env(safe-area-inset-bottom)); animation: slide-up 0.25s ease; display: block; }
+.more-menu-panel.hidden { display: none !important; }
+@keyframes slide-up { from { transform: translateY(100%); } to { transform: translateY(0); } }
+.more-menu-header { display: flex; align-items: center; justify-content: space-between; padding-bottom: 14px; border-bottom: 1px solid var(--border-soft); margin-bottom: 14px; }
+.more-menu-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
+.more-menu-section { grid-column: 1 / -1; font-family: var(--font-mono); font-size: 10px; font-weight: 700; letter-spacing: 0.14em; text-transform: uppercase; color: var(--text-muted); padding: 8px 2px 0; }
+.more-menu-section:first-child { padding-top: 0; }
+.more-menu-item { display: flex; flex-direction: column; align-items: center; gap: 8px; padding: 16px 12px; background: var(--bg-raised); border: 1px solid var(--border); border-radius: var(--radius-md); font-family: var(--font-ui); font-size: 12px; font-weight: 600; color: var(--text-secondary); cursor: pointer; transition: all var(--ease); }
+.more-menu-item span:first-child { font-size: 22px; }
+.more-menu-item:active { background: var(--bg-hover); color: var(--text-primary); }
+
+/* LIGHT THEME */
+.light-theme {
+  --bg-base:       #eceef2;
+  --bg-surface:    #f5f6f9;
+  --bg-raised:     #f5f6f9;
+  --bg-card:       #f5f6f9;
+  --bg-elevated:   #eeeff3;
+  --bg-hover:      #eaecf2;
+  --border:        #d0d5e0;
+  --border-soft:   #e2e5ee;
+  --border-bright: #b8bfce;
+  --text-primary:  #0d1117;
+  --text-secondary:#374151;
+  --text-muted:    #6b7280;
+  --accent-glow:   rgba(200,130,0,0.12);
+  --accent-soft:   rgba(200,130,0,0.1);
+  --accent-dim:    #c88200;
+  --accent:        #c07800;
+  --accent-light:  #e09000;
+  --green:         #16a34a;
+  --green-soft:    rgba(22,163,74,0.12);
+  --green-dim:     rgba(22,163,74,0.1);
+  --red:           #dc2626;
+  --red-dim:       rgba(220,38,38,0.1);
+  --shadow-lg:     0 8px 32px rgba(0,0,0,0.12);
+}
+.light-theme body { background: var(--bg-base); color: var(--text-primary); }
+.light-theme .sidebar { background: #ffffff; border-right: 1px solid var(--border); }
+.light-theme .nav-item { color: var(--text-secondary); }
+.light-theme .nav-item:hover, .light-theme .nav-item.active { background: var(--bg-hover); color: var(--text-primary); }
+.light-theme .detail-body { background: var(--bg-surface); }
+.light-theme .card, .light-theme .node-card { background: var(--bg-card); box-shadow: 0 1px 4px rgba(0,0,0,0.08); }
+.light-theme .config-input, .light-theme .config-select { background: var(--bg-surface); border-color: var(--border); color: var(--text-primary); }
+.light-theme .modal { background: var(--bg-surface); }
+.light-theme .kn-block { background: var(--bg-surface); border-color: var(--border); }
+.light-theme .kn-blk-head { background: var(--bg-elevated); }
+.light-theme .outcome-row, .light-theme .toc-row { background: var(--bg-surface); border-color: var(--border-soft); }
+.light-theme .toc-expandable { background: var(--bg-elevated); }
+.light-theme .toc-add-panel { background: var(--bg-elevated); }
+.light-theme .notes-section-title { color: var(--text-primary); }
+.light-theme .kn-def-term { color: var(--text-primary); }
+.light-theme .kn-table th { background: var(--bg-elevated); color: var(--text-primary); }
+.light-theme .btn-secondary { background: var(--bg-surface); border-color: var(--border); color: var(--text-secondary); }
+.light-theme .btn-secondary:hover { background: var(--bg-hover); color: var(--text-primary); }
+.light-theme .aif-panel { background: var(--bg-surface); border-color: var(--border); }
+.light-theme .aif-card { background: var(--bg-elevated); border-color: var(--border); }
+.light-theme .library-list { background: var(--bg-base); }
+.light-theme .node-card { border-color: var(--border); }
+.light-theme .detail-tab-bar { background: var(--bg-surface); border-color: var(--border); }
+.light-theme .outcomes-panel { background: var(--bg-surface); border-color: var(--border); }
+.light-theme .outcomes-summary { background: var(--bg-elevated); }
+.light-theme input, .light-theme textarea, .light-theme select { background: var(--bg-surface) !important; color: var(--text-primary) !important; border-color: var(--border) !important; }
+
+/* OVERFLOW GLOBAL FIX */
+.main-content, .detail-body, #notes-display, .step-content, #studyplan-body, #dashboard-body { overflow-x: hidden; min-width: 0; word-wrap: break-word; overflow-wrap: break-word; }
+.formula-block, .formula-expr { overflow-x: auto; }
+.user-notes-block, .summary-block { white-space: pre-wrap; word-break: break-word; }
+table { max-width: 100%; overflow-x: auto; display: block; }
+
+/* RESPONSIVE */
+@media (max-width: 768px) {
+  .sidebar { display: none !important; }
+  .main-content { margin-left: 0 !important; padding-bottom: 72px; }
+  /* When checklist is showing, body gets .has-checklist — extra space needed */
+  body.has-checklist .main-content { padding-bottom: 160px; }
+  body.has-checklist .toast-container { bottom: 160px; }
+  .mobile-nav { display: flex; }
+  .view { padding: 16px 16px 80px; }
+  .view-title { font-size: 22px; }
+  .node-detail-view { padding: 0 0 80px; }
+  .detail-layout { display: block; }
+  .detail-sidebar-nav { display: none !important; }
+  .detail-tabs-bar { display: flex; }
+  .detail-body { padding: 16px 16px 120px; }
+  .detail-topbar { padding: 10px 14px; flex-wrap: nowrap; gap: 8px; }
+  .detail-action-btn { width: 38px; height: 38px; padding: 0 !important; justify-content: center; font-size: 16px !important; }
+  .library-grid { grid-template-columns: 1fr; }
+  .library-toolbar { flex-wrap: wrap; }
+  .library-toolbar .search-input { min-width: 0; flex: 1; }
+  .upload-zone { padding: 32px 16px; }
+  .flashcard { padding: 28px 16px; min-height: 260px; }
+  .card-question { font-size: 16px; margin-bottom: 20px; }
+  .rating-btns { gap: 6px; }
+  .rating-btn { padding: 10px 10px; font-size: 12px; flex: 1; }
+  .guided-container { max-width: 100%; }
+  .step-content { padding: 16px; }
+  .step-tab { padding: 6px 2px 4px; }
+  .guided-nav { flex-direction: row; gap: 8px; }
+  .guided-nav button { flex: 1; justify-content: center; }
+  .definition-item { grid-template-columns: 1fr; gap: 3px; }
+  .mastery-overview { grid-template-columns: repeat(2, 1fr); }
+  .dash-stats-row { grid-template-columns: repeat(3, 1fr); gap: 8px; }
+  #api-key-banner { padding: 10px 14px; flex-wrap: wrap; font-size: 11px; }
+  .modal-overlay { align-items: flex-end; padding: 0; }
+  .modal { border-radius: var(--radius-xl) var(--radius-xl) 0 0; max-height: 92vh; max-height: 88dvh; width: 100%; max-width: 100%; padding: 24px 20px calc(24px + env(safe-area-inset-bottom)); animation: modal-slide-up 0.28s ease; }
+  /* Bigger, clearer close target on touch, always pinned to the sheet's top edge. */
+  .modal-close { top: 14px; right: 14px; width: 34px; height: 34px; font-size: 15px; background: var(--bg-card); color: var(--text-secondary); z-index: 2; }
+  @keyframes modal-slide-up { from { transform: translateY(100%); } to { transform: translateY(0); } }
+  .toast-container { bottom: 80px; right: 12px; left: 12px; }
+  .toast { min-width: 0; max-width: 100%; }
+}
+@media (max-width: 380px) {
+  .dash-stats-row { grid-template-columns: repeat(2, 1fr); }
+  .rating-btns { flex-wrap: wrap; }
+}
+
+/* ══════════════════════════════
+   TEXTAREA SCROLL FIX
+   Prevents parent page scroll when editing textarea on mobile
+══════════════════════════════ */
+textarea.config-input {
+  touch-action: pan-y;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
+  scroll-behavior: auto;
+}
+
+/* Larger tap targets for edit row inputs on mobile */
+@media (max-width: 768px) {
+  .edit-row input.config-input {
+    padding: 12px 14px;
+    font-size: 15px;
+    min-height: 46px;
+  }
+  .edit-row .edit-del-btn {
+    width: 38px;
+    height: 38px;
+    font-size: 15px;
+  }
+  textarea.config-input {
+    min-height: 100px;
+    font-size: 15px;
+    line-height: 1.7;
+  }
+  /* Prevent zoom on input focus (iOS/Android) */
+  input.config-input,
+  select.config-select {
+    font-size: 16px;
+  }
+  .config-input:focus,
+  .config-select:focus {
+    font-size: 16px;
+  }
+}
+
+/* Manual text panel */
+#manual-text-panel {
+  border: 2px solid var(--blue);
+  border-radius: var(--radius-lg);
+}
+
+/* ── Speech Pill ── */
+@keyframes pill-in  { from { opacity:0; transform:translateY(12px) scale(.9); } to { opacity:1; transform:none; } }
+@keyframes pill-out { from { opacity:1; transform:none; } to { opacity:0; transform:translateY(8px) scale(.95); } }
+
+/* ── App shell: the page itself NEVER scrolls — only the content pane does.
+   iPad Safari displaces fixed/sticky rails when the page is pinch- or
+   double-tap-zoomed and when browser chrome collapses. An in-flow sidebar
+   beside an inner scroller physically cannot move, no matter what. ── */
+html, body { height: 100%; }
+body { overflow: hidden; }
+#app { height: 100%; min-height: 0; }
+.sidebar { position: static; height: 100%; min-height: 0; flex-shrink: 0; }
+.main-content {
+  margin-left: 0;
+  height: 100%; min-height: 0;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
+}
+.sidebar.collapsed ~ .main-content { margin-left: 0; }
+.view { min-height: 100%; }
+/* overlay open → freeze the pane too, not just the body */
+body.scroll-locked .main-content { overflow: hidden; }
+
+/* Kill accidental double-tap zoom (iPad): zoomed-in state is what made the
+   nav "disappear" — you were panning a magnified page. manipulation keeps
+   normal scrolling; intentional pinch still works where the browser insists. */
+body, #app, #app * { touch-action: manipulation; }
+.main-content { touch-action: pan-y pinch-zoom; }
+
+/* Kill the last sliver of document scroll on iPad: an older rule kept body
+   min-height at 100vh (taller than the visible screen when browser chrome is
+   showing), and Safari adds elastic bounce on top. The content pane is the
+   only scroller — the document itself must have nothing to scroll. */
+html { overflow: hidden; overscroll-behavior: none; }
+body { min-height: 0; overscroll-behavior: none; }
+#app { min-height: 0; max-width: 100%; }
+
+/* Collapsed rail: footer buttons as uniform squares (AI orb, settings,
+   theme, timer). !important beats their inline width/height styles. */
+.sidebar.collapsed .ai-director-btn,
+.sidebar.collapsed .ai-settings-btn,
+.sidebar.collapsed .sidebar-footer button[data-theme-toggle],
+.sidebar.collapsed #start-timer-btn {
+  width: 40px !important; height: 40px !important;
+  min-width: 40px; min-height: 40px; flex-shrink: 0; padding: 0 !important;
+  box-shadow: none !important;   /* the orb's glow made it look bigger */
+  margin-bottom: 6px !important;
+  display: flex; align-items: center; justify-content: center;
+  border-radius: var(--radius-md);
+  margin: 0 auto 6px;
+  font-size: 17px;
+}
+.sidebar.collapsed .aidir-btn-orb { font-size: 17px; }
+
+/* ── Study Color modes — additive accent palettes, layered on top of the
+   existing dark/light toggle (never replaces it). Backed by learning-science
+   color research: Focus (blue) for analytical/high-logic work, Growth
+   (green) for long low-fatigue reading sessions, Energy (orange) for
+   test-prep/flashcard alertness. Default (amber) is completely unchanged —
+   picking nothing keeps every existing user's app exactly as it was.
+   Red is deliberately NOT offered as a full theme: the same research says
+   red should stay a sparing accent (it already is — --red on due/error
+   states) rather than dominate a whole screen, which the source material
+   itself warns can raise anxiety. ── */
+:root.accent-focus {
+  --accent: #4d8dff; --accent-light: #7aabff; --accent-dim: #1c3d7a;
+  --accent-glow: rgba(77,141,255,0.16); --accent-soft: rgba(77,141,255,0.08);
+}
+:root.accent-growth {
+  --accent: #43b874; --accent-light: #6fd196; --accent-dim: #1d5c3a;
+  --accent-glow: rgba(67,184,116,0.16); --accent-soft: rgba(67,184,116,0.08);
+}
+:root.accent-energy {
+  --accent: #ff7a1a; --accent-light: #ff9c4d; --accent-dim: #7a3a08;
+  --accent-glow: rgba(255,122,26,0.18); --accent-soft: rgba(255,122,26,0.09);
+}
+:root.light-theme.accent-focus {
+  --accent: #1d5fd1; --accent-light: #2f6fe0; --accent-dim: #a9c6f5;
+  --accent-glow: rgba(29,95,209,0.12); --accent-soft: rgba(29,95,209,0.08);
+}
+:root.light-theme.accent-growth {
+  --accent: #227a48; --accent-light: #2f9159; --accent-dim: #a9d9bd;
+  --accent-glow: rgba(34,122,72,0.12); --accent-soft: rgba(34,122,72,0.08);
+}
+:root.light-theme.accent-energy {
+  --accent: #c2530a; --accent-light: #d9600a; --accent-dim: #f3c299;
+  --accent-glow: rgba(194,83,10,0.12); --accent-soft: rgba(194,83,10,0.08);
+}
+
+/* Study-color swatch picker (Settings) */
+.study-color-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; }
+.study-color-swatch { border: 1px solid var(--border); border-radius: var(--radius-md); padding: 12px 8px; text-align: center; cursor: pointer; background: var(--bg-raised); transition: border-color .15s, transform .15s; }
+.study-color-swatch:hover { transform: translateY(-1px); }
+.study-color-swatch.active { border-color: var(--swatch-color, var(--accent)); box-shadow: 0 0 0 1px var(--swatch-color, var(--accent)); }
+.study-color-dot { width: 22px; height: 22px; border-radius: 50%; margin: 0 auto 6px; background: var(--swatch-color); }
+.study-color-label { font-family: var(--font-ui); font-size: 11px; font-weight: 600; color: var(--text-primary); }
+.study-color-desc { font-family: var(--font-mono); font-size: 9.5px; color: var(--text-muted); margin-top: 2px; line-height: 1.4; display: block; }

--- a/knowledgenode/www/css/print.css
+++ b/knowledgenode/www/css/print.css
@@ -1,0 +1,139 @@
+/* ═══════════════════════════════════════════════════════════
+   KNOWLEDGE NODE — PRINT STYLES
+   Exam-ready document formatting
+═══════════════════════════════════════════════════════════ */
+
+@media print {
+  * { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+
+  body {
+    background: #fff !important;
+    color: #1a1a1a !important;
+    font-family: 'Georgia', serif;
+    font-size: 11pt;
+    line-height: 1.6;
+    margin: 0;
+    padding: 0;
+  }
+
+  #app { display: block; }
+  #sidebar, .detail-topbar, .detail-sidebar-nav, .guided-nav,
+  .toast-container, #modal-overlay, .btn-primary, .btn-secondary,
+  .btn-ghost, .view-header, .rating-btns, .question-answer-toggle,
+  #upload-zone, #upload-config, .library-toolbar,
+  .step-tabs, .review-header { display: none !important; }
+
+  .main-content { margin-left: 0 !important; }
+
+  .view { display: none !important; padding: 0; }
+  .view.print-active { display: block !important; }
+
+  /* ─── PRINT DOCUMENT ─── */
+  .print-document {
+    max-width: 100%;
+    padding: 0;
+  }
+
+  .print-header {
+    border-bottom: 2px solid #1a1a1a;
+    padding-bottom: 12pt;
+    margin-bottom: 24pt;
+  }
+
+  .print-title {
+    font-size: 20pt;
+    font-weight: bold;
+    margin-bottom: 4pt;
+    color: #1a1a1a;
+  }
+
+  .print-meta {
+    font-size: 9pt;
+    color: #555;
+    font-family: 'Courier New', monospace;
+  }
+
+  .print-section {
+    margin-bottom: 20pt;
+    page-break-inside: avoid;
+  }
+
+  .print-section-title {
+    font-size: 10pt;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 1pt;
+    border-bottom: 1px solid #ccc;
+    padding-bottom: 4pt;
+    margin-bottom: 10pt;
+    color: #333;
+  }
+
+  .print-definition {
+    display: grid;
+    grid-template-columns: 160pt 1fr;
+    gap: 0;
+    border-bottom: 0.5pt solid #ddd;
+    padding: 6pt 0;
+    font-size: 10pt;
+  }
+  .print-def-term { font-weight: bold; font-family: 'Courier New', monospace; font-size: 9.5pt; }
+  .print-def-desc { color: #222; }
+
+  .print-formula {
+    background: #f5f5f5;
+    border-left: 3pt solid #555;
+    padding: 8pt 12pt;
+    margin-bottom: 8pt;
+    font-family: 'Courier New', monospace;
+    font-size: 10pt;
+    page-break-inside: avoid;
+  }
+  .print-formula-desc { font-family: Georgia, serif; font-size: 9.5pt; color: #444; margin-top: 4pt; font-style: italic; }
+  .print-formula-constraints { font-size: 9pt; color: #666; margin-top: 3pt; }
+
+  .print-procedure { margin-bottom: 6pt; page-break-inside: avoid; }
+  .print-proc-step { display: flex; gap: 10pt; font-size: 10pt; margin-bottom: 5pt; }
+  .print-proc-num { font-weight: bold; min-width: 16pt; color: #333; }
+
+  .print-mistake {
+    border: 0.5pt solid #ccc;
+    background: #fafafa;
+    padding: 6pt 10pt;
+    margin-bottom: 6pt;
+    font-size: 10pt;
+    page-break-inside: avoid;
+  }
+  .print-mistake::before { content: '⚠ '; }
+
+  .print-summary {
+    background: #f9f9f9;
+    border: 0.5pt solid #ccc;
+    padding: 12pt;
+    font-size: 10.5pt;
+    line-height: 1.7;
+  }
+
+  .print-question {
+    border: 0.5pt solid #ccc;
+    padding: 8pt 12pt;
+    margin-bottom: 8pt;
+    page-break-inside: avoid;
+    font-size: 10pt;
+  }
+  .print-q-label { font-size: 8pt; text-transform: uppercase; letter-spacing: 0.5pt; color: #888; margin-bottom: 4pt; font-family: 'Courier New', monospace; }
+  .print-q-text { margin-bottom: 4pt; }
+  .print-q-answer { color: #555; font-style: italic; border-top: 0.5pt solid #ddd; padding-top: 6pt; margin-top: 6pt; }
+
+  .print-page-break { page-break-before: always; }
+
+  @page {
+    margin: 2cm;
+    size: A4;
+    @bottom-center {
+      content: "KnowledgeNode — " attr(data-chapter) " | Page " counter(page);
+      font-size: 8pt;
+      color: #888;
+    }
+  }
+}

--- a/knowledgenode/www/icons/icon-192.png
+++ b/knowledgenode/www/icons/icon-192.png
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" viewBox="0 0 192 192">
+  <rect width="192" height="192" rx="40" fill="#f0a500"/>
+  <text x="96" y="140" font-family="Arial Black,Arial" font-weight="900" font-size="120" text-anchor="middle" fill="#080a0d">K</text>
+</svg>

--- a/knowledgenode/www/icons/icon-512.png
+++ b/knowledgenode/www/icons/icon-512.png
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="100" fill="#f0a500"/>
+  <text x="256" y="1100" font-family="Arial Black,Arial" font-weight="900" font-size="320" text-anchor="middle" fill="#080a0d">K</text>
+</svg>

--- a/knowledgenode/www/icons/icon.svg
+++ b/knowledgenode/www/icons/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" viewBox="0 0 192 192">
+  <rect width="192" height="192" rx="40" fill="#f0a500"/>
+  <text x="96" y="140" font-family="Arial Black,Arial" font-weight="900" font-size="120" text-anchor="middle" fill="#080a0d">K</text>
+</svg>

--- a/knowledgenode/www/index.html
+++ b/knowledgenode/www/index.html
@@ -21,8 +21,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Merriweather:ital,wght@0,400;0,700;1,400&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet"/>
-  <link rel="stylesheet" href="css/main.css?v=1783000040"/>
-  <link rel="stylesheet" href="css/components.css?v=1783000040"/>
+  <link rel="stylesheet" href="css/main.css?v=1783000041"/>
+  <link rel="stylesheet" href="css/components.css?v=1783000041"/>
   <link rel="stylesheet" href="css/print.css" media="print"/>
 </head>
 <body>
@@ -376,74 +376,74 @@
 <script src="https://cdn.jsdelivr.net/npm/pptxgenjs@3.12.0/dist/pptxgen.bundle.js" crossorigin="anonymous"></script>
 <script>window.APP_VERSION = '63.9';</script>
 <!-- Sanitizer must load before any renderer so AI/source HTML is cleaned. See js/core/Sanitizer.js. -->
-<script src="js/core/Sanitizer.js?v=1783000040"></script>
+<script src="js/core/Sanitizer.js?v=1783000041"></script>
 <script src="js/core/LocalGrader.js"></script>
 <script src="js/core/BackNav.js"></script>
 <script src="js/core/BackupGuard.js"></script>
 <script src="js/core/SharePack.js"></script>
 <script src="js/ui/PastPaperDrill.js"></script>
 <!-- Managed-AI build config (subscription gating). Loads early so AIService sees it. -->
-<script src="js/core/AppConfig.js?v=1783000040"></script>
+<script src="js/core/AppConfig.js?v=1783000041"></script>
 <script src="js/core/LearnerState.js"></script>
-<script src="js/core/CoachFacts.js?v=1783000040"></script>
+<script src="js/core/CoachFacts.js?v=1783000041"></script>
 <script src="js/core/AppFeatures.js"></script>
-<script src="js/core/ScrollLock.js?v=1783000040"></script>
-<script src="js/core/KnowledgeNode.js?v=1783000040"></script>
-<script src="js/core/NodeStore.js?v=1783000040"></script>
-<script src="js/core/BackupVault.js?v=1783000040"></script>
-<script src="js/core/SpacedRepetition.js?v=1783000040"></script>
-<script src="js/core/StudyPlan.js?v=1783000040"></script>
-<script src="js/core/ExamReadiness.js?v=1783000040"></script>
-<script src="js/core/NewCardPacer.js?v=1783000040"></script>
-<script src="js/core/LeechDetector.js?v=1783000040"></script>
-<script src="js/core/MatchOptions.js?v=1783000040"></script>
-<script src="js/core/MatchGroup.js?v=1783000040"></script>
-<script src="js/ai/LearnerMemory.js?v=1783000040"></script>
-<script src="js/ai/AICorrections.js?v=1783000040"></script>
-<script src="js/ai/LearnerContext.js?v=1783000040"></script>
-<script src="js/ai/AIService.js?v=1783000040"></script>
-<script src="js/ai/CoachEngine.js?v=1783000040"></script>
-<script src="js/ui/Toast.js?v=1783000040"></script>
-<script src="js/ui/KNLoader.js?v=1783000040"></script>
-<script src="js/ui/Modal.js?v=1783000040"></script>
-<script src="js/ui/NotesRenderer.js?v=1783000040"></script>
-<script src="js/ui/BlockEngine.js?v=1783000040"></script>
-<script src="js/ui/ReactiveReshaper.js?v=1783000040"></script>
-<script src="js/ui/StudyFitCheck.js?v=1783000040"></script>
-<script src="js/ui/AIDirector.js?v=1783000040"></script>
-<script src="js/ui/StudyCoach.js?v=1783000040"></script>
-<script src="js/ui/AISettingsModal.js?v=1783000040"></script>
-<script src="js/ui/Paywall.js?v=1783000040"></script>
-<script src="js/ui/LectureMode.js?v=1783000040"></script>
-    <script src="js/ui/LearnPanel.js?v=1783000040"></script>
-<script src="js/ui/PrintExport.js?v=1783000040"></script>
-<script src="js/ui/ImageManager.js?v=1783000040"></script>
-<script src="js/ui/TextAnnotator.js?v=1783000040"></script>
-<script src="js/ui/SelectToAction.js?v=1783000040"></script>
-<script src="js/ui/StreakTracker.js?v=1783000040"></script>
-<script src="js/ui/Dashboard.js?v=1783000040"></script>
-<script src="js/ui/Onboarding.js?v=1783000040"></script>
-<script src="js/ui/Guide.js?v=1783000040"></script>
-<script src="js/ui/StudySession.js?v=1783000040"></script>
-<script src="js/ui/SettingsPanel.js?v=1783000040"></script>
-<script src="js/ui/NoteTemplates.js?v=1783000040"></script>
-<script src="js/ui/BlankRecall.js?v=1783000040"></script>
-<script src="js/ui/BulkImport.js?v=1783000040"></script>
-<script src="js/ui/UnderstandingCheck.js?v=1783000040"></script>
-<script src="js/ui/UploadView.js?v=1783000040"></script>
-<script src="js/ui/SpeechPill.js?v=1783000040"></script>
-<script src="js/ui/GuidedView.js?v=1783000040"></script>
-<script src="js/ui/LibraryView.js?v=1783000040"></script>
-<script src="js/ui/SocraticTutor.js?v=1783000040"></script>
-    <script src="js/ui/NodeDetailView.js?v=1783000040"></script>
-<script src="js/ui/ReviewView.js?v=1783000040"></script>
-<script src="js/ui/OCRReview.js?v=1783000040"></script>
-<script src="js/ui/AINodeTools.js?v=1783000040"></script>
-<script src="js/ui/ImageResponseBlock.js?v=1783000040"></script>
-<script src="js/ui/StudyPlanBuilder.js?v=1783000040"></script>
-<script src="js/ui/StudyPlanView.js?v=1783000040"></script>
-<script src="js/ui/CompetencyView.js?v=1783000040"></script>
-<script src="js/app.js?v=1783000040"></script>
+<script src="js/core/ScrollLock.js?v=1783000041"></script>
+<script src="js/core/KnowledgeNode.js?v=1783000041"></script>
+<script src="js/core/NodeStore.js?v=1783000041"></script>
+<script src="js/core/BackupVault.js?v=1783000041"></script>
+<script src="js/core/SpacedRepetition.js?v=1783000041"></script>
+<script src="js/core/StudyPlan.js?v=1783000041"></script>
+<script src="js/core/ExamReadiness.js?v=1783000041"></script>
+<script src="js/core/NewCardPacer.js?v=1783000041"></script>
+<script src="js/core/LeechDetector.js?v=1783000041"></script>
+<script src="js/core/MatchOptions.js?v=1783000041"></script>
+<script src="js/core/MatchGroup.js?v=1783000041"></script>
+<script src="js/ai/LearnerMemory.js?v=1783000041"></script>
+<script src="js/ai/AICorrections.js?v=1783000041"></script>
+<script src="js/ai/LearnerContext.js?v=1783000041"></script>
+<script src="js/ai/AIService.js?v=1783000041"></script>
+<script src="js/ai/CoachEngine.js?v=1783000041"></script>
+<script src="js/ui/Toast.js?v=1783000041"></script>
+<script src="js/ui/KNLoader.js?v=1783000041"></script>
+<script src="js/ui/Modal.js?v=1783000041"></script>
+<script src="js/ui/NotesRenderer.js?v=1783000041"></script>
+<script src="js/ui/BlockEngine.js?v=1783000041"></script>
+<script src="js/ui/ReactiveReshaper.js?v=1783000041"></script>
+<script src="js/ui/StudyFitCheck.js?v=1783000041"></script>
+<script src="js/ui/AIDirector.js?v=1783000041"></script>
+<script src="js/ui/StudyCoach.js?v=1783000041"></script>
+<script src="js/ui/AISettingsModal.js?v=1783000041"></script>
+<script src="js/ui/Paywall.js?v=1783000041"></script>
+<script src="js/ui/LectureMode.js?v=1783000041"></script>
+    <script src="js/ui/LearnPanel.js?v=1783000041"></script>
+<script src="js/ui/PrintExport.js?v=1783000041"></script>
+<script src="js/ui/ImageManager.js?v=1783000041"></script>
+<script src="js/ui/TextAnnotator.js?v=1783000041"></script>
+<script src="js/ui/SelectToAction.js?v=1783000041"></script>
+<script src="js/ui/StreakTracker.js?v=1783000041"></script>
+<script src="js/ui/Dashboard.js?v=1783000041"></script>
+<script src="js/ui/Onboarding.js?v=1783000041"></script>
+<script src="js/ui/Guide.js?v=1783000041"></script>
+<script src="js/ui/StudySession.js?v=1783000041"></script>
+<script src="js/ui/SettingsPanel.js?v=1783000041"></script>
+<script src="js/ui/NoteTemplates.js?v=1783000041"></script>
+<script src="js/ui/BlankRecall.js?v=1783000041"></script>
+<script src="js/ui/BulkImport.js?v=1783000041"></script>
+<script src="js/ui/UnderstandingCheck.js?v=1783000041"></script>
+<script src="js/ui/UploadView.js?v=1783000041"></script>
+<script src="js/ui/SpeechPill.js?v=1783000041"></script>
+<script src="js/ui/GuidedView.js?v=1783000041"></script>
+<script src="js/ui/LibraryView.js?v=1783000041"></script>
+<script src="js/ui/SocraticTutor.js?v=1783000041"></script>
+    <script src="js/ui/NodeDetailView.js?v=1783000041"></script>
+<script src="js/ui/ReviewView.js?v=1783000041"></script>
+<script src="js/ui/OCRReview.js?v=1783000041"></script>
+<script src="js/ui/AINodeTools.js?v=1783000041"></script>
+<script src="js/ui/ImageResponseBlock.js?v=1783000041"></script>
+<script src="js/ui/StudyPlanBuilder.js?v=1783000041"></script>
+<script src="js/ui/StudyPlanView.js?v=1783000041"></script>
+<script src="js/ui/CompetencyView.js?v=1783000041"></script>
+<script src="js/app.js?v=1783000041"></script>
 
 <!-- Back to Top Button -->
 <button id="back-to-top" aria-label="Back to top" title="Back to top" style="display:none;position:fixed;bottom:80px;right:16px;z-index:900;width:40px;height:40px;border-radius:50%;background:var(--bg-card);border:1px solid var(--border);color:var(--text-muted);font-size:16px;cursor:pointer;box-shadow:0 2px 12px rgba(0,0,0,.4);transition:opacity .2s,transform .2s;display:flex;align-items:center;justify-content:center;">↑</button>

--- a/knowledgenode/www/index.html
+++ b/knowledgenode/www/index.html
@@ -21,8 +21,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Merriweather:ital,wght@0,400;0,700;1,400&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet"/>
-  <link rel="stylesheet" href="css/main.css?v=1783000042"/>
-  <link rel="stylesheet" href="css/components.css?v=1783000042"/>
+  <link rel="stylesheet" href="css/main.css?v=1783000043"/>
+  <link rel="stylesheet" href="css/components.css?v=1783000043"/>
   <link rel="stylesheet" href="css/print.css" media="print"/>
 </head>
 <body>
@@ -376,74 +376,75 @@
 <script src="https://cdn.jsdelivr.net/npm/pptxgenjs@3.12.0/dist/pptxgen.bundle.js" crossorigin="anonymous"></script>
 <script>window.APP_VERSION = '63.9';</script>
 <!-- Sanitizer must load before any renderer so AI/source HTML is cleaned. See js/core/Sanitizer.js. -->
-<script src="js/core/Sanitizer.js?v=1783000042"></script>
+<script src="js/core/Sanitizer.js?v=1783000043"></script>
 <script src="js/core/LocalGrader.js"></script>
 <script src="js/core/BackNav.js"></script>
 <script src="js/core/BackupGuard.js"></script>
 <script src="js/core/SharePack.js"></script>
 <script src="js/ui/PastPaperDrill.js"></script>
 <!-- Managed-AI build config (subscription gating). Loads early so AIService sees it. -->
-<script src="js/core/AppConfig.js?v=1783000042"></script>
+<script src="js/core/AppConfig.js?v=1783000043"></script>
 <script src="js/core/LearnerState.js"></script>
-<script src="js/core/CoachFacts.js?v=1783000042"></script>
+<script src="js/core/CoachFacts.js?v=1783000043"></script>
 <script src="js/core/AppFeatures.js"></script>
-<script src="js/core/ScrollLock.js?v=1783000042"></script>
-<script src="js/core/KnowledgeNode.js?v=1783000042"></script>
-<script src="js/core/NodeStore.js?v=1783000042"></script>
-<script src="js/core/BackupVault.js?v=1783000042"></script>
-<script src="js/core/SpacedRepetition.js?v=1783000042"></script>
-<script src="js/core/StudyPlan.js?v=1783000042"></script>
-<script src="js/core/ExamReadiness.js?v=1783000042"></script>
-<script src="js/core/NewCardPacer.js?v=1783000042"></script>
-<script src="js/core/LeechDetector.js?v=1783000042"></script>
-<script src="js/core/MatchOptions.js?v=1783000042"></script>
-<script src="js/core/MatchGroup.js?v=1783000042"></script>
-<script src="js/ai/LearnerMemory.js?v=1783000042"></script>
-<script src="js/ai/AICorrections.js?v=1783000042"></script>
-<script src="js/ai/LearnerContext.js?v=1783000042"></script>
-<script src="js/ai/AIService.js?v=1783000042"></script>
-<script src="js/ai/CoachEngine.js?v=1783000042"></script>
-<script src="js/ui/Toast.js?v=1783000042"></script>
-<script src="js/ui/KNLoader.js?v=1783000042"></script>
-<script src="js/ui/Modal.js?v=1783000042"></script>
-<script src="js/ui/NotesRenderer.js?v=1783000042"></script>
-<script src="js/ui/BlockEngine.js?v=1783000042"></script>
-<script src="js/ui/ReactiveReshaper.js?v=1783000042"></script>
-<script src="js/ui/StudyFitCheck.js?v=1783000042"></script>
-<script src="js/ui/AIDirector.js?v=1783000042"></script>
-<script src="js/ui/StudyCoach.js?v=1783000042"></script>
-<script src="js/ui/AISettingsModal.js?v=1783000042"></script>
-<script src="js/ui/Paywall.js?v=1783000042"></script>
-<script src="js/ui/LectureMode.js?v=1783000042"></script>
-    <script src="js/ui/LearnPanel.js?v=1783000042"></script>
-<script src="js/ui/PrintExport.js?v=1783000042"></script>
-<script src="js/ui/ImageManager.js?v=1783000042"></script>
-<script src="js/ui/TextAnnotator.js?v=1783000042"></script>
-<script src="js/ui/SelectToAction.js?v=1783000042"></script>
-<script src="js/ui/StreakTracker.js?v=1783000042"></script>
-<script src="js/ui/Dashboard.js?v=1783000042"></script>
-<script src="js/ui/Onboarding.js?v=1783000042"></script>
-<script src="js/ui/Guide.js?v=1783000042"></script>
-<script src="js/ui/StudySession.js?v=1783000042"></script>
-<script src="js/ui/SettingsPanel.js?v=1783000042"></script>
-<script src="js/ui/NoteTemplates.js?v=1783000042"></script>
-<script src="js/ui/BlankRecall.js?v=1783000042"></script>
-<script src="js/ui/BulkImport.js?v=1783000042"></script>
-<script src="js/ui/UnderstandingCheck.js?v=1783000042"></script>
-<script src="js/ui/UploadView.js?v=1783000042"></script>
-<script src="js/ui/SpeechPill.js?v=1783000042"></script>
-<script src="js/ui/GuidedView.js?v=1783000042"></script>
-<script src="js/ui/LibraryView.js?v=1783000042"></script>
-<script src="js/ui/SocraticTutor.js?v=1783000042"></script>
-    <script src="js/ui/NodeDetailView.js?v=1783000042"></script>
-<script src="js/ui/ReviewView.js?v=1783000042"></script>
-<script src="js/ui/OCRReview.js?v=1783000042"></script>
-<script src="js/ui/AINodeTools.js?v=1783000042"></script>
-<script src="js/ui/ImageResponseBlock.js?v=1783000042"></script>
-<script src="js/ui/StudyPlanBuilder.js?v=1783000042"></script>
-<script src="js/ui/StudyPlanView.js?v=1783000042"></script>
-<script src="js/ui/CompetencyView.js?v=1783000042"></script>
-<script src="js/app.js?v=1783000042"></script>
+<script src="js/core/ScrollLock.js?v=1783000043"></script>
+<script src="js/core/QuestionKind.js?v=1783000043"></script>
+<script src="js/core/KnowledgeNode.js?v=1783000043"></script>
+<script src="js/core/NodeStore.js?v=1783000043"></script>
+<script src="js/core/BackupVault.js?v=1783000043"></script>
+<script src="js/core/SpacedRepetition.js?v=1783000043"></script>
+<script src="js/core/StudyPlan.js?v=1783000043"></script>
+<script src="js/core/ExamReadiness.js?v=1783000043"></script>
+<script src="js/core/NewCardPacer.js?v=1783000043"></script>
+<script src="js/core/LeechDetector.js?v=1783000043"></script>
+<script src="js/core/MatchOptions.js?v=1783000043"></script>
+<script src="js/core/MatchGroup.js?v=1783000043"></script>
+<script src="js/ai/LearnerMemory.js?v=1783000043"></script>
+<script src="js/ai/AICorrections.js?v=1783000043"></script>
+<script src="js/ai/LearnerContext.js?v=1783000043"></script>
+<script src="js/ai/AIService.js?v=1783000043"></script>
+<script src="js/ai/CoachEngine.js?v=1783000043"></script>
+<script src="js/ui/Toast.js?v=1783000043"></script>
+<script src="js/ui/KNLoader.js?v=1783000043"></script>
+<script src="js/ui/Modal.js?v=1783000043"></script>
+<script src="js/ui/NotesRenderer.js?v=1783000043"></script>
+<script src="js/ui/BlockEngine.js?v=1783000043"></script>
+<script src="js/ui/ReactiveReshaper.js?v=1783000043"></script>
+<script src="js/ui/StudyFitCheck.js?v=1783000043"></script>
+<script src="js/ui/AIDirector.js?v=1783000043"></script>
+<script src="js/ui/StudyCoach.js?v=1783000043"></script>
+<script src="js/ui/AISettingsModal.js?v=1783000043"></script>
+<script src="js/ui/Paywall.js?v=1783000043"></script>
+<script src="js/ui/LectureMode.js?v=1783000043"></script>
+    <script src="js/ui/LearnPanel.js?v=1783000043"></script>
+<script src="js/ui/PrintExport.js?v=1783000043"></script>
+<script src="js/ui/ImageManager.js?v=1783000043"></script>
+<script src="js/ui/TextAnnotator.js?v=1783000043"></script>
+<script src="js/ui/SelectToAction.js?v=1783000043"></script>
+<script src="js/ui/StreakTracker.js?v=1783000043"></script>
+<script src="js/ui/Dashboard.js?v=1783000043"></script>
+<script src="js/ui/Onboarding.js?v=1783000043"></script>
+<script src="js/ui/Guide.js?v=1783000043"></script>
+<script src="js/ui/StudySession.js?v=1783000043"></script>
+<script src="js/ui/SettingsPanel.js?v=1783000043"></script>
+<script src="js/ui/NoteTemplates.js?v=1783000043"></script>
+<script src="js/ui/BlankRecall.js?v=1783000043"></script>
+<script src="js/ui/BulkImport.js?v=1783000043"></script>
+<script src="js/ui/UnderstandingCheck.js?v=1783000043"></script>
+<script src="js/ui/UploadView.js?v=1783000043"></script>
+<script src="js/ui/SpeechPill.js?v=1783000043"></script>
+<script src="js/ui/GuidedView.js?v=1783000043"></script>
+<script src="js/ui/LibraryView.js?v=1783000043"></script>
+<script src="js/ui/SocraticTutor.js?v=1783000043"></script>
+    <script src="js/ui/NodeDetailView.js?v=1783000043"></script>
+<script src="js/ui/ReviewView.js?v=1783000043"></script>
+<script src="js/ui/OCRReview.js?v=1783000043"></script>
+<script src="js/ui/AINodeTools.js?v=1783000043"></script>
+<script src="js/ui/ImageResponseBlock.js?v=1783000043"></script>
+<script src="js/ui/StudyPlanBuilder.js?v=1783000043"></script>
+<script src="js/ui/StudyPlanView.js?v=1783000043"></script>
+<script src="js/ui/CompetencyView.js?v=1783000043"></script>
+<script src="js/app.js?v=1783000043"></script>
 
 <!-- Back to Top Button -->
 <button id="back-to-top" aria-label="Back to top" title="Back to top" style="display:none;position:fixed;bottom:80px;right:16px;z-index:900;width:40px;height:40px;border-radius:50%;background:var(--bg-card);border:1px solid var(--border);color:var(--text-muted);font-size:16px;cursor:pointer;box-shadow:0 2px 12px rgba(0,0,0,.4);transition:opacity .2s,transform .2s;display:flex;align-items:center;justify-content:center;">↑</button>

--- a/knowledgenode/www/index.html
+++ b/knowledgenode/www/index.html
@@ -21,8 +21,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Merriweather:ital,wght@0,400;0,700;1,400&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet"/>
-  <link rel="stylesheet" href="css/main.css?v=1783000041"/>
-  <link rel="stylesheet" href="css/components.css?v=1783000041"/>
+  <link rel="stylesheet" href="css/main.css?v=1783000042"/>
+  <link rel="stylesheet" href="css/components.css?v=1783000042"/>
   <link rel="stylesheet" href="css/print.css" media="print"/>
 </head>
 <body>
@@ -376,74 +376,74 @@
 <script src="https://cdn.jsdelivr.net/npm/pptxgenjs@3.12.0/dist/pptxgen.bundle.js" crossorigin="anonymous"></script>
 <script>window.APP_VERSION = '63.9';</script>
 <!-- Sanitizer must load before any renderer so AI/source HTML is cleaned. See js/core/Sanitizer.js. -->
-<script src="js/core/Sanitizer.js?v=1783000041"></script>
+<script src="js/core/Sanitizer.js?v=1783000042"></script>
 <script src="js/core/LocalGrader.js"></script>
 <script src="js/core/BackNav.js"></script>
 <script src="js/core/BackupGuard.js"></script>
 <script src="js/core/SharePack.js"></script>
 <script src="js/ui/PastPaperDrill.js"></script>
 <!-- Managed-AI build config (subscription gating). Loads early so AIService sees it. -->
-<script src="js/core/AppConfig.js?v=1783000041"></script>
+<script src="js/core/AppConfig.js?v=1783000042"></script>
 <script src="js/core/LearnerState.js"></script>
-<script src="js/core/CoachFacts.js?v=1783000041"></script>
+<script src="js/core/CoachFacts.js?v=1783000042"></script>
 <script src="js/core/AppFeatures.js"></script>
-<script src="js/core/ScrollLock.js?v=1783000041"></script>
-<script src="js/core/KnowledgeNode.js?v=1783000041"></script>
-<script src="js/core/NodeStore.js?v=1783000041"></script>
-<script src="js/core/BackupVault.js?v=1783000041"></script>
-<script src="js/core/SpacedRepetition.js?v=1783000041"></script>
-<script src="js/core/StudyPlan.js?v=1783000041"></script>
-<script src="js/core/ExamReadiness.js?v=1783000041"></script>
-<script src="js/core/NewCardPacer.js?v=1783000041"></script>
-<script src="js/core/LeechDetector.js?v=1783000041"></script>
-<script src="js/core/MatchOptions.js?v=1783000041"></script>
-<script src="js/core/MatchGroup.js?v=1783000041"></script>
-<script src="js/ai/LearnerMemory.js?v=1783000041"></script>
-<script src="js/ai/AICorrections.js?v=1783000041"></script>
-<script src="js/ai/LearnerContext.js?v=1783000041"></script>
-<script src="js/ai/AIService.js?v=1783000041"></script>
-<script src="js/ai/CoachEngine.js?v=1783000041"></script>
-<script src="js/ui/Toast.js?v=1783000041"></script>
-<script src="js/ui/KNLoader.js?v=1783000041"></script>
-<script src="js/ui/Modal.js?v=1783000041"></script>
-<script src="js/ui/NotesRenderer.js?v=1783000041"></script>
-<script src="js/ui/BlockEngine.js?v=1783000041"></script>
-<script src="js/ui/ReactiveReshaper.js?v=1783000041"></script>
-<script src="js/ui/StudyFitCheck.js?v=1783000041"></script>
-<script src="js/ui/AIDirector.js?v=1783000041"></script>
-<script src="js/ui/StudyCoach.js?v=1783000041"></script>
-<script src="js/ui/AISettingsModal.js?v=1783000041"></script>
-<script src="js/ui/Paywall.js?v=1783000041"></script>
-<script src="js/ui/LectureMode.js?v=1783000041"></script>
-    <script src="js/ui/LearnPanel.js?v=1783000041"></script>
-<script src="js/ui/PrintExport.js?v=1783000041"></script>
-<script src="js/ui/ImageManager.js?v=1783000041"></script>
-<script src="js/ui/TextAnnotator.js?v=1783000041"></script>
-<script src="js/ui/SelectToAction.js?v=1783000041"></script>
-<script src="js/ui/StreakTracker.js?v=1783000041"></script>
-<script src="js/ui/Dashboard.js?v=1783000041"></script>
-<script src="js/ui/Onboarding.js?v=1783000041"></script>
-<script src="js/ui/Guide.js?v=1783000041"></script>
-<script src="js/ui/StudySession.js?v=1783000041"></script>
-<script src="js/ui/SettingsPanel.js?v=1783000041"></script>
-<script src="js/ui/NoteTemplates.js?v=1783000041"></script>
-<script src="js/ui/BlankRecall.js?v=1783000041"></script>
-<script src="js/ui/BulkImport.js?v=1783000041"></script>
-<script src="js/ui/UnderstandingCheck.js?v=1783000041"></script>
-<script src="js/ui/UploadView.js?v=1783000041"></script>
-<script src="js/ui/SpeechPill.js?v=1783000041"></script>
-<script src="js/ui/GuidedView.js?v=1783000041"></script>
-<script src="js/ui/LibraryView.js?v=1783000041"></script>
-<script src="js/ui/SocraticTutor.js?v=1783000041"></script>
-    <script src="js/ui/NodeDetailView.js?v=1783000041"></script>
-<script src="js/ui/ReviewView.js?v=1783000041"></script>
-<script src="js/ui/OCRReview.js?v=1783000041"></script>
-<script src="js/ui/AINodeTools.js?v=1783000041"></script>
-<script src="js/ui/ImageResponseBlock.js?v=1783000041"></script>
-<script src="js/ui/StudyPlanBuilder.js?v=1783000041"></script>
-<script src="js/ui/StudyPlanView.js?v=1783000041"></script>
-<script src="js/ui/CompetencyView.js?v=1783000041"></script>
-<script src="js/app.js?v=1783000041"></script>
+<script src="js/core/ScrollLock.js?v=1783000042"></script>
+<script src="js/core/KnowledgeNode.js?v=1783000042"></script>
+<script src="js/core/NodeStore.js?v=1783000042"></script>
+<script src="js/core/BackupVault.js?v=1783000042"></script>
+<script src="js/core/SpacedRepetition.js?v=1783000042"></script>
+<script src="js/core/StudyPlan.js?v=1783000042"></script>
+<script src="js/core/ExamReadiness.js?v=1783000042"></script>
+<script src="js/core/NewCardPacer.js?v=1783000042"></script>
+<script src="js/core/LeechDetector.js?v=1783000042"></script>
+<script src="js/core/MatchOptions.js?v=1783000042"></script>
+<script src="js/core/MatchGroup.js?v=1783000042"></script>
+<script src="js/ai/LearnerMemory.js?v=1783000042"></script>
+<script src="js/ai/AICorrections.js?v=1783000042"></script>
+<script src="js/ai/LearnerContext.js?v=1783000042"></script>
+<script src="js/ai/AIService.js?v=1783000042"></script>
+<script src="js/ai/CoachEngine.js?v=1783000042"></script>
+<script src="js/ui/Toast.js?v=1783000042"></script>
+<script src="js/ui/KNLoader.js?v=1783000042"></script>
+<script src="js/ui/Modal.js?v=1783000042"></script>
+<script src="js/ui/NotesRenderer.js?v=1783000042"></script>
+<script src="js/ui/BlockEngine.js?v=1783000042"></script>
+<script src="js/ui/ReactiveReshaper.js?v=1783000042"></script>
+<script src="js/ui/StudyFitCheck.js?v=1783000042"></script>
+<script src="js/ui/AIDirector.js?v=1783000042"></script>
+<script src="js/ui/StudyCoach.js?v=1783000042"></script>
+<script src="js/ui/AISettingsModal.js?v=1783000042"></script>
+<script src="js/ui/Paywall.js?v=1783000042"></script>
+<script src="js/ui/LectureMode.js?v=1783000042"></script>
+    <script src="js/ui/LearnPanel.js?v=1783000042"></script>
+<script src="js/ui/PrintExport.js?v=1783000042"></script>
+<script src="js/ui/ImageManager.js?v=1783000042"></script>
+<script src="js/ui/TextAnnotator.js?v=1783000042"></script>
+<script src="js/ui/SelectToAction.js?v=1783000042"></script>
+<script src="js/ui/StreakTracker.js?v=1783000042"></script>
+<script src="js/ui/Dashboard.js?v=1783000042"></script>
+<script src="js/ui/Onboarding.js?v=1783000042"></script>
+<script src="js/ui/Guide.js?v=1783000042"></script>
+<script src="js/ui/StudySession.js?v=1783000042"></script>
+<script src="js/ui/SettingsPanel.js?v=1783000042"></script>
+<script src="js/ui/NoteTemplates.js?v=1783000042"></script>
+<script src="js/ui/BlankRecall.js?v=1783000042"></script>
+<script src="js/ui/BulkImport.js?v=1783000042"></script>
+<script src="js/ui/UnderstandingCheck.js?v=1783000042"></script>
+<script src="js/ui/UploadView.js?v=1783000042"></script>
+<script src="js/ui/SpeechPill.js?v=1783000042"></script>
+<script src="js/ui/GuidedView.js?v=1783000042"></script>
+<script src="js/ui/LibraryView.js?v=1783000042"></script>
+<script src="js/ui/SocraticTutor.js?v=1783000042"></script>
+    <script src="js/ui/NodeDetailView.js?v=1783000042"></script>
+<script src="js/ui/ReviewView.js?v=1783000042"></script>
+<script src="js/ui/OCRReview.js?v=1783000042"></script>
+<script src="js/ui/AINodeTools.js?v=1783000042"></script>
+<script src="js/ui/ImageResponseBlock.js?v=1783000042"></script>
+<script src="js/ui/StudyPlanBuilder.js?v=1783000042"></script>
+<script src="js/ui/StudyPlanView.js?v=1783000042"></script>
+<script src="js/ui/CompetencyView.js?v=1783000042"></script>
+<script src="js/app.js?v=1783000042"></script>
 
 <!-- Back to Top Button -->
 <button id="back-to-top" aria-label="Back to top" title="Back to top" style="display:none;position:fixed;bottom:80px;right:16px;z-index:900;width:40px;height:40px;border-radius:50%;background:var(--bg-card);border:1px solid var(--border);color:var(--text-muted);font-size:16px;cursor:pointer;box-shadow:0 2px 12px rgba(0,0,0,.4);transition:opacity .2s,transform .2s;display:flex;align-items:center;justify-content:center;">↑</button>

--- a/knowledgenode/www/index.html
+++ b/knowledgenode/www/index.html
@@ -21,8 +21,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Merriweather:ital,wght@0,400;0,700;1,400&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet"/>
-  <link rel="stylesheet" href="css/main.css?v=1783000039"/>
-  <link rel="stylesheet" href="css/components.css?v=1783000039"/>
+  <link rel="stylesheet" href="css/main.css?v=1783000040"/>
+  <link rel="stylesheet" href="css/components.css?v=1783000040"/>
   <link rel="stylesheet" href="css/print.css" media="print"/>
 </head>
 <body>
@@ -376,74 +376,74 @@
 <script src="https://cdn.jsdelivr.net/npm/pptxgenjs@3.12.0/dist/pptxgen.bundle.js" crossorigin="anonymous"></script>
 <script>window.APP_VERSION = '63.9';</script>
 <!-- Sanitizer must load before any renderer so AI/source HTML is cleaned. See js/core/Sanitizer.js. -->
-<script src="js/core/Sanitizer.js?v=1783000039"></script>
+<script src="js/core/Sanitizer.js?v=1783000040"></script>
 <script src="js/core/LocalGrader.js"></script>
 <script src="js/core/BackNav.js"></script>
 <script src="js/core/BackupGuard.js"></script>
 <script src="js/core/SharePack.js"></script>
 <script src="js/ui/PastPaperDrill.js"></script>
 <!-- Managed-AI build config (subscription gating). Loads early so AIService sees it. -->
-<script src="js/core/AppConfig.js?v=1783000039"></script>
+<script src="js/core/AppConfig.js?v=1783000040"></script>
 <script src="js/core/LearnerState.js"></script>
-<script src="js/core/CoachFacts.js?v=1783000039"></script>
+<script src="js/core/CoachFacts.js?v=1783000040"></script>
 <script src="js/core/AppFeatures.js"></script>
-<script src="js/core/ScrollLock.js?v=1783000039"></script>
-<script src="js/core/KnowledgeNode.js?v=1783000039"></script>
-<script src="js/core/NodeStore.js?v=1783000039"></script>
-<script src="js/core/BackupVault.js?v=1783000039"></script>
-<script src="js/core/SpacedRepetition.js?v=1783000039"></script>
-<script src="js/core/StudyPlan.js?v=1783000039"></script>
-<script src="js/core/ExamReadiness.js?v=1783000039"></script>
-<script src="js/core/NewCardPacer.js?v=1783000039"></script>
-<script src="js/core/LeechDetector.js?v=1783000039"></script>
-<script src="js/core/MatchOptions.js?v=1783000039"></script>
-<script src="js/core/MatchGroup.js?v=1783000039"></script>
-<script src="js/ai/LearnerMemory.js?v=1783000039"></script>
-<script src="js/ai/AICorrections.js?v=1783000039"></script>
-<script src="js/ai/LearnerContext.js?v=1783000039"></script>
-<script src="js/ai/AIService.js?v=1783000039"></script>
-<script src="js/ai/CoachEngine.js?v=1783000039"></script>
-<script src="js/ui/Toast.js?v=1783000039"></script>
-<script src="js/ui/KNLoader.js?v=1783000039"></script>
-<script src="js/ui/Modal.js?v=1783000039"></script>
-<script src="js/ui/NotesRenderer.js?v=1783000039"></script>
-<script src="js/ui/BlockEngine.js?v=1783000039"></script>
-<script src="js/ui/ReactiveReshaper.js?v=1783000039"></script>
-<script src="js/ui/StudyFitCheck.js?v=1783000039"></script>
-<script src="js/ui/AIDirector.js?v=1783000039"></script>
-<script src="js/ui/StudyCoach.js?v=1783000039"></script>
-<script src="js/ui/AISettingsModal.js?v=1783000039"></script>
-<script src="js/ui/Paywall.js?v=1783000039"></script>
-<script src="js/ui/LectureMode.js?v=1783000039"></script>
-    <script src="js/ui/LearnPanel.js?v=1783000039"></script>
-<script src="js/ui/PrintExport.js?v=1783000039"></script>
-<script src="js/ui/ImageManager.js?v=1783000039"></script>
-<script src="js/ui/TextAnnotator.js?v=1783000039"></script>
-<script src="js/ui/SelectToAction.js?v=1783000039"></script>
-<script src="js/ui/StreakTracker.js?v=1783000039"></script>
-<script src="js/ui/Dashboard.js?v=1783000039"></script>
-<script src="js/ui/Onboarding.js?v=1783000039"></script>
-<script src="js/ui/Guide.js?v=1783000039"></script>
-<script src="js/ui/StudySession.js?v=1783000039"></script>
-<script src="js/ui/SettingsPanel.js?v=1783000039"></script>
-<script src="js/ui/NoteTemplates.js?v=1783000039"></script>
-<script src="js/ui/BlankRecall.js?v=1783000039"></script>
-<script src="js/ui/BulkImport.js?v=1783000039"></script>
-<script src="js/ui/UnderstandingCheck.js?v=1783000039"></script>
-<script src="js/ui/UploadView.js?v=1783000039"></script>
-<script src="js/ui/SpeechPill.js?v=1783000039"></script>
-<script src="js/ui/GuidedView.js?v=1783000039"></script>
-<script src="js/ui/LibraryView.js?v=1783000039"></script>
-<script src="js/ui/SocraticTutor.js?v=1783000039"></script>
-    <script src="js/ui/NodeDetailView.js?v=1783000039"></script>
-<script src="js/ui/ReviewView.js?v=1783000039"></script>
-<script src="js/ui/OCRReview.js?v=1783000039"></script>
-<script src="js/ui/AINodeTools.js?v=1783000039"></script>
-<script src="js/ui/ImageResponseBlock.js?v=1783000039"></script>
-<script src="js/ui/StudyPlanBuilder.js?v=1783000039"></script>
-<script src="js/ui/StudyPlanView.js?v=1783000039"></script>
-<script src="js/ui/CompetencyView.js?v=1783000039"></script>
-<script src="js/app.js?v=1783000039"></script>
+<script src="js/core/ScrollLock.js?v=1783000040"></script>
+<script src="js/core/KnowledgeNode.js?v=1783000040"></script>
+<script src="js/core/NodeStore.js?v=1783000040"></script>
+<script src="js/core/BackupVault.js?v=1783000040"></script>
+<script src="js/core/SpacedRepetition.js?v=1783000040"></script>
+<script src="js/core/StudyPlan.js?v=1783000040"></script>
+<script src="js/core/ExamReadiness.js?v=1783000040"></script>
+<script src="js/core/NewCardPacer.js?v=1783000040"></script>
+<script src="js/core/LeechDetector.js?v=1783000040"></script>
+<script src="js/core/MatchOptions.js?v=1783000040"></script>
+<script src="js/core/MatchGroup.js?v=1783000040"></script>
+<script src="js/ai/LearnerMemory.js?v=1783000040"></script>
+<script src="js/ai/AICorrections.js?v=1783000040"></script>
+<script src="js/ai/LearnerContext.js?v=1783000040"></script>
+<script src="js/ai/AIService.js?v=1783000040"></script>
+<script src="js/ai/CoachEngine.js?v=1783000040"></script>
+<script src="js/ui/Toast.js?v=1783000040"></script>
+<script src="js/ui/KNLoader.js?v=1783000040"></script>
+<script src="js/ui/Modal.js?v=1783000040"></script>
+<script src="js/ui/NotesRenderer.js?v=1783000040"></script>
+<script src="js/ui/BlockEngine.js?v=1783000040"></script>
+<script src="js/ui/ReactiveReshaper.js?v=1783000040"></script>
+<script src="js/ui/StudyFitCheck.js?v=1783000040"></script>
+<script src="js/ui/AIDirector.js?v=1783000040"></script>
+<script src="js/ui/StudyCoach.js?v=1783000040"></script>
+<script src="js/ui/AISettingsModal.js?v=1783000040"></script>
+<script src="js/ui/Paywall.js?v=1783000040"></script>
+<script src="js/ui/LectureMode.js?v=1783000040"></script>
+    <script src="js/ui/LearnPanel.js?v=1783000040"></script>
+<script src="js/ui/PrintExport.js?v=1783000040"></script>
+<script src="js/ui/ImageManager.js?v=1783000040"></script>
+<script src="js/ui/TextAnnotator.js?v=1783000040"></script>
+<script src="js/ui/SelectToAction.js?v=1783000040"></script>
+<script src="js/ui/StreakTracker.js?v=1783000040"></script>
+<script src="js/ui/Dashboard.js?v=1783000040"></script>
+<script src="js/ui/Onboarding.js?v=1783000040"></script>
+<script src="js/ui/Guide.js?v=1783000040"></script>
+<script src="js/ui/StudySession.js?v=1783000040"></script>
+<script src="js/ui/SettingsPanel.js?v=1783000040"></script>
+<script src="js/ui/NoteTemplates.js?v=1783000040"></script>
+<script src="js/ui/BlankRecall.js?v=1783000040"></script>
+<script src="js/ui/BulkImport.js?v=1783000040"></script>
+<script src="js/ui/UnderstandingCheck.js?v=1783000040"></script>
+<script src="js/ui/UploadView.js?v=1783000040"></script>
+<script src="js/ui/SpeechPill.js?v=1783000040"></script>
+<script src="js/ui/GuidedView.js?v=1783000040"></script>
+<script src="js/ui/LibraryView.js?v=1783000040"></script>
+<script src="js/ui/SocraticTutor.js?v=1783000040"></script>
+    <script src="js/ui/NodeDetailView.js?v=1783000040"></script>
+<script src="js/ui/ReviewView.js?v=1783000040"></script>
+<script src="js/ui/OCRReview.js?v=1783000040"></script>
+<script src="js/ui/AINodeTools.js?v=1783000040"></script>
+<script src="js/ui/ImageResponseBlock.js?v=1783000040"></script>
+<script src="js/ui/StudyPlanBuilder.js?v=1783000040"></script>
+<script src="js/ui/StudyPlanView.js?v=1783000040"></script>
+<script src="js/ui/CompetencyView.js?v=1783000040"></script>
+<script src="js/app.js?v=1783000040"></script>
 
 <!-- Back to Top Button -->
 <button id="back-to-top" aria-label="Back to top" title="Back to top" style="display:none;position:fixed;bottom:80px;right:16px;z-index:900;width:40px;height:40px;border-radius:50%;background:var(--bg-card);border:1px solid var(--border);color:var(--text-muted);font-size:16px;cursor:pointer;box-shadow:0 2px 12px rgba(0,0,0,.4);transition:opacity .2s,transform .2s;display:flex;align-items:center;justify-content:center;">↑</button>

--- a/knowledgenode/www/index.html
+++ b/knowledgenode/www/index.html
@@ -1,0 +1,535 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8"/>
+  <!-- Content Security Policy enforced INSIDE the app (the Android WebView does not
+       see the Netlify/Vercel HTTP headers, so this meta tag is what protects the
+       shipped app). 'unsafe-inline' is needed for the app's inline scripts/onclick
+       handlers and 'unsafe-eval' for the in-browser code sandbox (BlockEngine runs
+       user JS via Function()); removing those is future hardening (externalise inline
+       handlers + drop the runnable-code feature). object-src/base-uri are locked down
+       and connect-src bounds where data can be sent. -->
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' blob: https://cdn.jsdelivr.net https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob:; connect-src 'self' blob: data: https://openrouter.ai https://api.anthropic.com https://api.openai.com https://generativelanguage.googleapis.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://tessdata.projectnaptha.com; worker-src 'self' blob: https://cdn.jsdelivr.net; object-src 'none'; base-uri 'none'"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"/>
+  <meta name="theme-color" content="#f0a500"/>
+  <meta name="apple-mobile-web-app-capable" content="yes"/>
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent"/>
+  <meta name="apple-mobile-web-app-title" content="KnowledgeNode"/>
+  <link rel="manifest" href="manifest.json"/>
+  <link rel="apple-touch-icon" href="icons/icon.svg"/>
+  <title>KnowledgeNode</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com"/>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Merriweather:ital,wght@0,400;0,700;1,400&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet"/>
+  <link rel="stylesheet" href="css/main.css?v=1783000039"/>
+  <link rel="stylesheet" href="css/components.css?v=1783000039"/>
+  <link rel="stylesheet" href="css/print.css" media="print"/>
+</head>
+<body>
+<!-- DIAGNOSTIC: shows any JS error on screen (mobile has no console). Remove once stable. -->
+<div id="kn-error-banner" style="display:none;position:fixed;top:0;left:0;right:0;z-index:999999;background:#b00020;color:#fff;font-family:monospace;font-size:12px;padding:10px 14px;max-height:50vh;overflow:auto;white-space:pre-wrap;box-shadow:0 2px 12px rgba(0,0,0,.5);"></div>
+<script>
+(function(){
+  var banner = document.getElementById('kn-error-banner');
+  function show(msg){
+    if(!banner) return;
+    banner.style.display = 'block';
+    banner.textContent += msg + '\n';
+  }
+  window.addEventListener('error', function(e){
+    show('JS ERROR: ' + (e.message||'') + '  @ ' + (e.filename||'').split('/').pop() + ':' + (e.lineno||'?'));
+  });
+  window.addEventListener('unhandledrejection', function(e){
+    show('PROMISE REJECT: ' + (e.reason && (e.reason.message||e.reason) || 'unknown'));
+  });
+  // Confirm scripts are running at all
+  window.__knBoot = [];
+  window.__knMark = function(m){ window.__knBoot.push(m); };
+})();
+</script>
+<div id="app">
+
+  <!-- ═══ SIDEBAR — desktop only ═══ -->
+  <aside id="sidebar" class="sidebar">
+    <div class="sidebar-header">
+      <div class="logo">
+        <div class="logo-mark">K</div>
+        <span class="logo-text">KnowledgeNode</span>
+      </div>
+      <button class="sidebar-toggle" id="sidebar-toggle">◀</button>
+    </div>
+
+    <nav class="sidebar-nav">
+      <button class="nav-item active" data-view="upload">   <span class="nav-icon">↑</span> <span class="nav-label">Add Notes</span></button>
+      <button class="nav-item" data-view="studyplan">       <span class="nav-icon">📅</span><span class="nav-label">Study Plan</span></button>
+      <button class="nav-item" data-view="guided">          <span class="nav-icon">▶</span> <span class="nav-label">Study Session</span></button>
+      <button class="nav-item" data-view="library">         <span class="nav-icon">⊞</span> <span class="nav-label">Library</span></button>
+      <button class="nav-item" data-view="review">          <span class="nav-icon">↺</span> <span class="nav-label">Review</span></button>
+      <button class="nav-item" data-view="competency">      <span class="nav-icon">🏆</span> <span class="nav-label">Exam</span></button>
+      <button class="nav-item" data-view="dashboard">       <span class="nav-icon">◉</span> <span class="nav-label">Progress</span></button>
+    </nav>
+
+    <div class="sidebar-footer">
+      <button id="ai-director-btn" class="ai-director-btn" title="Let the AI evaluate you and reshape your nodes, note methods and study method">
+        <span class="aidir-btn-orb">⬡</span><span>Let AI take the wheel</span>
+      </button>
+      <div class="stats-grid">
+        <div class="stat-cell"><span class="stat-val" id="stat-nodes">0</span><span class="stat-key">Nodes</span></div>
+        <div class="stat-cell"><span class="stat-val" id="stat-mastery">0%</span><span class="stat-key">Mastery</span></div>
+        <div class="stat-cell"><span class="stat-val" id="stat-due">0</span><span class="stat-key">Due</span></div>
+      </div>
+      <div style="display:flex;gap:6px;margin-top:10px;flex-wrap:wrap;">
+        <button class="ai-settings-btn" id="ai-settings-sidebar-btn" style="flex:1;"><span>⚙</span><span>Settings</span></button>
+        <button data-theme-toggle style="width:36px;height:36px;background:transparent;border:1px solid var(--border);border-radius:var(--radius-md);color:var(--text-muted);font-size:15px;cursor:pointer;transition:all 0.2s;display:flex;align-items:center;justify-content:center;flex-shrink:0;" title="Toggle theme">☀</button>
+        <button id="start-timer-btn" style="width:36px;height:36px;background:transparent;border:1px solid var(--border);border-radius:var(--radius-md);color:var(--text-muted);font-size:15px;cursor:pointer;transition:all 0.2s;display:flex;align-items:center;justify-content:center;flex-shrink:0;" title="Start study session">⏱</button>
+      </div>
+      <div style="text-align:center;margin-top:10px;font-family:var(--font-mono);font-size:11px;color:var(--text-muted);">
+        <span class="streak-fire">📅</span> <span class="streak-count">0</span>d · <button onclick="KeyboardShortcuts.showHelp()" style="background:transparent;border:none;color:var(--text-muted);font-family:var(--font-mono);font-size:11px;cursor:pointer;">? keys</button> · <button onclick="Onboarding.showTour()" style="background:transparent;border:none;color:var(--text-muted);font-family:var(--font-mono);font-size:11px;cursor:pointer;">how it works</button>
+      </div>
+    </div>
+  </aside>
+
+  <!-- ═══ MAIN ═══ -->
+  <main id="main-content" class="main-content">
+
+    <!-- UPLOAD -->
+    <section id="view-upload" class="view active">
+      <div class="view-header">
+        <h1 class="view-title" id="upload-view-title">Upload Content</h1>
+        <p class="view-subtitle" id="upload-view-subtitle">Add your notes or files, then choose how to import them.</p>
+      </div>
+      <div id="append-badge-container"></div>
+      <div class="upload-zone" id="upload-zone">
+        <div class="upload-inner">
+          <span class="upload-icon">⬡</span>
+          <p class="upload-label">Drop files here or <label class="upload-link" for="file-input">browse</label></p>
+          <p class="upload-hint">Images · PDF · Word (.docx) · Excel (.xlsx) · Text / CSV</p>
+          <div style="margin-top:16px;display:flex;gap:8px;justify-content:center;flex-wrap:wrap;">
+            <button id="scan-camera-btn" class="btn-secondary" style="font-size:12px;padding:8px 16px;" onclick="event.stopPropagation()">📷 Scan / Camera</button>
+            <button id="manual-text-btn" class="btn-secondary" style="font-size:12px;padding:8px 16px;" onclick="event.stopPropagation()">✏ Type Notes</button>
+            <button id="create-empty-node-btn" class="btn-secondary" style="font-size:12px;padding:8px 16px;" onclick="event.stopPropagation()">⬡ New Empty Node</button>
+            <button id="exam-paper-btn" class="btn-secondary" style="font-size:12px;padding:8px 16px;border-color:var(--accent-dim);color:var(--accent);" onclick="event.stopPropagation()">📝 Past Exam Paper</button>
+            <button id="revision-questions-btn" class="btn-secondary" style="font-size:12px;padding:8px 16px;border-color:var(--blue,#4d8dff);color:var(--blue,#4d8dff);" onclick="event.stopPropagation()">📚 Revision Questions</button>
+            <button id="bulk-import-btn" class="btn-secondary" style="font-size:12px;padding:8px 16px;border-color:var(--green);color:var(--green);" onclick="event.stopPropagation()">📚 Bulk Import (40+ photos)</button>
+            <input type="file" id="bulk-import-input" accept="image/*" multiple hidden/>
+
+          </div>
+          <input type="file" id="file-input" accept="image/*,.pdf,.docx,.doc,.xlsx,.xls,.txt,.csv,.md" multiple hidden/>
+        </div>
+      </div>
+      <div id="upload-preview" class="upload-preview hidden"></div>
+      <div id="upload-config" class="upload-config hidden">
+        <div class="config-row"><label class="config-label">Subject / Topic</label><input type="text" id="node-subject" class="config-input" placeholder="e.g. Income Tax Returns"/></div>
+        <div class="config-row"><label class="config-label">Chapter / Module</label><input type="text" id="node-chapter" class="config-input" placeholder="e.g. Module 1"/></div>
+        <div id="existing-modules-hint" class="existing-modules-hint hidden"></div>
+
+        <!-- Best practice tip -->
+        <div style="background:var(--accent-soft);border:1px solid var(--accent-dim);border-radius:var(--radius-md);padding:11px 14px;margin-bottom:14px;display:flex;gap:10px;align-items:flex-start;">
+          <span style="font-size:16px;flex-shrink:0;margin-top:1px;">💡</span>
+          <div>
+            <div style="font-family:var(--font-ui);font-size:12px;font-weight:700;color:var(--text-primary);margin-bottom:3px;">One node = one topic, not one module</div>
+            <div style="font-family:var(--font-body);font-size:12px;color:var(--text-secondary);line-height:1.55;">
+              For best results, scan <strong>one section at a time</strong> — e.g. "M1.1 - Gross Income" as its own node, "M1.2 - Deductions" as another.
+              This gives you focused questions, accurate mastery tracking, and better AI explanations per topic.
+              <span style="color:var(--text-muted);"> Aim for 3–5 pages per node.</span>
+            </div>
+          </div>
+        </div>
+        <div style="border:1px solid var(--border);border-radius:var(--radius-lg);overflow:hidden;">
+          <div style="padding:18px 20px;border-bottom:1px solid var(--border);">
+            <div style="display:flex;align-items:flex-start;justify-content:space-between;gap:12px;flex-wrap:wrap;">
+              <div><div style="display:flex;align-items:center;gap:8px;margin-bottom:4px;"><span style="font-family:var(--font-display);font-size:13px;font-weight:700;color:var(--text-primary);">⬡ AI Controlled Import</span><span style="font-family:var(--font-mono);font-size:9px;font-weight:700;background:var(--accent);color:#000;padding:2px 7px;border-radius:10px;letter-spacing:.05em;">AI</span></div><div style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);">AI reads, structures, and generates study questions from your content.</div></div>
+              <button id="process-ai-btn" class="btn-primary" style="flex-shrink:0;">Generate Node</button>
+            </div>
+            <div class="config-row" style="margin-top:12px;"><label class="config-label">Detail Level</label><select id="node-detail" class="config-select"><option value="standard">Standard — thorough breakdown</option><option value="quick">Quick — key points only</option></select></div>
+            <div class="config-row" style="margin-top:12px;">
+              <label class="config-label">Note-Taking Method</label>
+              <div id="template-picker-container"></div>
+            </div>
+          </div>
+          <div style="padding:18px 20px;background:var(--bg-raised);">
+            <div style="display:flex;align-items:flex-start;justify-content:space-between;gap:12px;flex-wrap:wrap;">
+              <div><div style="display:flex;align-items:center;gap:8px;margin-bottom:4px;"><span style="font-family:var(--font-display);font-size:13px;font-weight:700;color:var(--text-primary);">📋 Plain Import</span><span style="font-family:var(--font-mono);font-size:9px;font-weight:700;background:var(--bg-raised);color:var(--text-muted);padding:2px 7px;border-radius:10px;border:1px solid var(--border);letter-spacing:.05em;">NO AI</span></div><div style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);">Saves your content exactly as typed — no processing, instant save.</div></div>
+              <button id="process-plain-btn" class="btn-secondary" style="flex-shrink:0;">Import Notes</button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Manual text entry panel -->
+      <div id="manual-text-panel" class="upload-config hidden" style="margin-bottom:16px;">
+        <div class="config-row">
+          <label class="config-label">Type or paste your notes</label>
+          <textarea id="manual-text-input" class="config-input" rows="10"
+            placeholder="Type your notes here… paste from textbook, type key points, write summaries.&#10;&#10;You can also paste copied text from any source."
+            style="resize:vertical;min-height:200px;font-family:var(--font-body);font-size:14px;line-height:1.7;touch-action:pan-y;"></textarea>
+        </div>
+        <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
+          <button id="manual-text-confirm-btn" class="btn-primary">Use This Text</button>
+          <button id="manual-text-cancel-btn" class="btn-secondary">Cancel</button>
+          <span style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);" id="manual-word-count">0 words</span>
+        </div>
+      </div>
+
+      <div id="processing-status" class="processing-status hidden">
+        <div class="processing-animation"><span class="kn-hex-wrap" style="width:60px;height:60px;"><svg viewBox="0 0 100 100" width="60" height="60" style="overflow:visible;"><polygon class="kn-hex-track" points="50,4 89.8,27 89.8,73 50,96 10.2,73 10.2,27"/><polygon class="kn-hex-core" points="50,22 74.2,36 74.2,64 50,78 25.8,64 25.8,36"/><polygon class="kn-hex-trace" points="50,4 89.8,27 89.8,73 50,96 10.2,73 10.2,27" pathLength="100"/></svg></span></div>
+        <p class="processing-label" id="processing-label">Processing…</p>
+        <div class="processing-steps">
+          <div class="proc-step" id="pstep-1">① Extract</div>
+          <div class="proc-step" id="pstep-2">② Structure</div>
+          <div class="proc-step" id="pstep-3">③ Questions</div>
+          <div class="proc-step" id="pstep-4">④ Build</div>
+        </div>
+      </div>
+    </section>
+
+    <!-- GUIDED -->
+    <section id="view-guided" class="view">
+      <div class="view-header" id="guided-page-header"><h1 class="view-title">Study Session</h1><p class="view-subtitle">AI-guided step-by-step learning. Adapts to your subject and progress.</p></div>
+      <div id="guided-empty" class="empty-state"><span class="empty-icon">▶</span><p>Upload content to begin.</p></div>
+      <div id="guided-container" class="guided-container hidden">
+        <div class="guided-progress-bar"><div class="progress-track"><div class="progress-fill" id="guided-progress-fill"></div></div><span class="progress-label" id="guided-progress-label"></span></div>
+        <div class="guided-node-header"><div class="node-badge" id="guided-node-badge">Node</div><h2 class="guided-node-title" id="guided-node-title"></h2><div class="node-meta" id="guided-node-meta"></div></div>
+        <div class="guided-steps">
+          <div class="step-tabs" id="step-tabs"></div>
+          <div class="step-content" id="step-content"></div>
+        </div>
+        <div class="guided-nav"><button class="btn-secondary" id="guided-prev">← Prev</button><button class="btn-primary" id="guided-next">Next →</button></div>
+      </div>
+    </section>
+
+    <!-- LIBRARY -->
+    <section id="view-library" class="view">
+      <div class="view-header"><h1 class="view-title">Library</h1><p class="view-subtitle">All your nodes. Tap to explore.</p></div>
+      <div class="library-toolbar">
+        <input type="text" id="library-search" class="search-input" placeholder="Search…"/>
+        <select id="library-filter" class="config-select" style="width:auto;min-width:120px;"><option value="all">All Subjects</option></select>
+        <button class="btn-secondary" id="export-all-btn">⎙ Export</button>
+      </div>
+      <div id="library-empty" class="empty-state"><span class="empty-icon">⊞</span><p>Upload content to get started.</p></div>
+      <div id="library-grid" class="library-grid"></div>
+    </section>
+
+    <!-- NODE DETAIL — full screen on mobile, no competing sidebar -->
+    <section id="view-node-detail" class="view node-detail-view">
+      <div class="detail-topbar">
+        <button class="btn-ghost" id="detail-back">← Library</button>
+        <div class="detail-actions">
+          <button class="btn-secondary detail-action-btn" id="detail-learn-btn" title="Learn">🎓</button>
+          <button class="btn-secondary detail-action-btn" id="detail-export-btn">⎙</button>
+          <button class="btn-secondary detail-action-btn" id="detail-print-btn">🖨</button>
+        </div>
+      </div>
+      <!-- Tab bar instead of side panel on mobile -->
+      <div class="detail-tabs-bar">
+        <button class="detail-tab-btn active" data-section="notes">📋 Notes</button>
+        <button class="detail-tab-btn" data-section="questions">❓ Questions</button>
+        <button class="detail-tab-btn" data-section="examples">💡 Examples</button>
+        <button class="detail-tab-btn" data-section="mastery">📊 Mastery</button>
+      </div>
+      <div class="detail-body" id="detail-body"></div>
+    </section>
+
+    <!-- REVIEW -->
+    <section id="view-review" class="view">
+      <div class="view-header"><h1 class="view-title">Review</h1><p class="view-subtitle">Spaced repetition — filter by subject or chapter.</p></div>
+      <div id="review-empty" class="empty-state-v2" style="display:none;">
+        <div class="empty-state-icon">↺</div>
+        <h3 class="empty-state-title">No cards to review yet</h3>
+        <p class="empty-state-body">Upload your notes and the app will generate questions automatically. Cards are scheduled using spaced repetition — easy ones fade, hard ones resurface.</p>
+        <button class="btn-primary empty-state-cta" onclick="App.navigateTo('upload')">↑ Upload your first topic</button>
+      </div>
+      <div id="review-filter-panel"></div>
+      <div id="review-container" class="review-container hidden">
+        <div class="review-header"><div class="review-counter" id="review-counter">Card 1 of 8</div><div class="review-node-tag" id="review-node-tag"></div></div>
+        <div class="flashcard">
+          <div class="flashcard-inner">
+            <div class="flashcard-front">
+              <p class="card-type-label" id="card-type-label">Recall</p>
+              <p class="card-question" id="card-question"></p>
+              <div class="review-front-actions">
+                <button class="btn-primary" id="reveal-btn">Reveal Answer</button>
+                <button class="btn-ghost" id="skip-btn">Skip for now</button>
+              </div>
+            </div>
+            <div class="flashcard-back hidden" id="flashcard-back">
+              <p class="card-answer" id="card-answer"></p>
+              <p class="rating-prompt">How well did you know this?</p>
+              <div class="rating-btns">
+                <button class="rating-btn rating-1" data-rating="1">Again</button>
+                <button class="rating-btn rating-2" data-rating="2">Hard</button>
+                <button class="rating-btn rating-3" data-rating="3">Good</button>
+                <button class="rating-btn rating-4" data-rating="4">Easy</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div id="review-complete" class="review-complete hidden">
+        <div class="complete-icon">✓</div><h2>Session Complete!</h2>
+        <p id="review-complete-stats"></p>
+        <button class="btn-primary" id="review-again-btn">Review Again</button>
+      </div>
+    </section>
+
+    <!-- DASHBOARD (Progress) -->
+    <section id="view-dashboard" class="view">
+      <div class="view-header"><h1 class="view-title">Progress</h1><p class="view-subtitle">Streaks, mastery, and today's study plan.</p></div>
+      <div id="dashboard-body"></div>
+    </section>
+
+    <!-- STUDY PLAN -->
+    <section id="view-studyplan" class="view">
+      <div class="view-header">
+        <h1 class="view-title">Study Plan</h1>
+        <p class="view-subtitle">Daily schedule, competency tests, and progress tracking.</p>
+        <div style="display:flex;gap:10px;flex-wrap:wrap;margin-top:14px;">
+          <button class="btn-primary" id="new-plan-header-btn">+ Create Study Plan</button>
+          <button class="btn-secondary" onclick="App.navigateTo('upload')" style="font-size:13px;">↑ Add Notes First</button>
+        </div>
+      </div>
+      <div id="studyplan-body"></div>
+    </section>
+
+    <section id="view-competency" class="view">
+      <div class="view-header">
+        <button class="btn-ghost" id="competency-back" style="margin-bottom:10px;">← Study Plan</button>
+        <h1 class="view-title">Competency Test</h1>
+        <p class="view-subtitle">Check where you stand across a subject — report card, timed quiz, or AI exam.</p>
+      </div>
+      <div id="competency-body"></div>
+    </section>
+
+  </main>
+</div>
+
+<!-- ═══ MOBILE BOTTOM NAV — 5 items max ═══ -->
+<nav class="mobile-nav" id="mobile-nav">
+  <button class="mobile-nav-btn active" data-view="guided">   <span class="mnav-icon">▶</span><span class="mnav-label">Study</span></button>
+  <button class="mobile-nav-btn" data-view="review">          <span class="mnav-icon">↺</span><span class="mnav-label">Review</span></button>
+  <button class="mobile-nav-btn" data-view="library">         <span class="mnav-icon">⊞</span><span class="mnav-label">Library</span></button>
+  <button class="mobile-nav-btn" data-view="upload">          <span class="mnav-icon">↑</span><span class="mnav-label">Add</span></button>
+  <button class="mobile-nav-btn" data-view="more-menu">       <span class="mnav-icon">≡</span><span class="mnav-label">More</span></button>
+</nav>
+
+<!-- MOBILE MORE MENU -->
+<div id="more-menu-panel" class="more-menu-panel hidden">
+  <div class="more-menu-header">
+    <span style="font-family:var(--font-display);font-size:14px;font-weight:700;">More</span>
+    <button id="more-menu-close" style="background:transparent;border:none;color:var(--text-muted);font-size:20px;cursor:pointer;">✕</button>
+  </div>
+  <div class="more-menu-grid">
+    <div class="more-menu-section">AI</div>
+    <button class="more-menu-item" id="more-menu-aidirector"><span>⬡</span><span>Let AI take the wheel</span></button>
+    <button class="more-menu-item" id="more-menu-coach"><span>💬</span><span>Talk to your coach</span></button>
+    <div class="more-menu-section">Study</div>
+    <button class="more-menu-item" data-view="studyplan"><span>📅</span><span>Study Plan</span></button>
+    <button class="more-menu-item" data-view="competency"><span>🏆</span><span>Exam</span></button>
+    <button class="more-menu-item" id="more-menu-timer"><span>⏱</span><span>Study Timer</span></button>
+    <div class="more-menu-section">App</div>
+    <button class="more-menu-item" id="more-menu-settings"><span>⚙</span><span>Settings</span></button>
+    <button class="more-menu-item" data-theme-toggle><span data-theme-icon>☀</span><span>Theme</span></button>
+  </div>
+</div>
+
+<!-- SELECT TOOLBAR -->
+<div id="select-toolbar" class="select-toolbar hidden">
+  <button id="sel-question"  class="sel-btn" title="Quick Question">❓ Question</button>
+  <button id="sel-recall"    class="sel-btn" title="Recall Question">🔁 Recall</button>
+  <button id="sel-apply"     class="sel-btn" title="Application Question">🧩 Apply</button>
+  <button id="sel-define"    class="sel-btn" title="Add Definition">📖 Define</button>
+  <button id="sel-highlight" class="sel-btn" title="Highlight text">🖊 Mark</button>
+  <button id="sel-correct"   class="sel-btn" title="Correct the AI on this content">✏️ Correct AI</button>
+</div>
+
+<!-- TOAST & MODAL -->
+<div id="toast-container" class="toast-container"></div>
+<div id="modal-overlay" class="modal-overlay hidden">
+  <div class="modal"><button class="modal-close" id="modal-close">✕</button><div id="modal-content"></div></div>
+</div>
+
+<!--
+  ⚠ THIRD-PARTY LIBRARIES — HARDEN BEFORE STORE RELEASE
+  These run with full app privilege and can reach the native bridges + the stored
+  API key, so a compromised CDN asset = full app compromise. For a shipped /
+  app-store build, do ONE of the following:
+    (1) PREFERRED: vendor these libraries locally (put each .js under js/vendor/
+        and reference it from there) so the released app fetches no executable
+        JS from a CDN at runtime — also makes the app work fully offline; OR
+    (2) pin each tag with a Subresource Integrity hash:
+        <script src="…/pdf.min.js" integrity="sha384-…" crossorigin="anonymous"></script>
+        generate with: openssl dgst -sha384 -binary file.js | openssl base64 -A
+  crossorigin="anonymous" is set so SRI can be added without other changes.
+-->
+<!-- Tesseract.js for local OCR (no API key needed) -->
+<!-- PDF.js for reliable PDF text extraction -->
+<script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@3.11.174/build/pdf.min.js" crossorigin="anonymous"></script>
+<script>
+  if (window.pdfjsLib) {
+    pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdn.jsdelivr.net/npm/pdfjs-dist@3.11.174/build/pdf.worker.min.js';
+  }
+</script>
+<script src="https://cdn.jsdelivr.net/npm/tesseract.js@5/dist/tesseract.min.js" crossorigin="anonymous"></script>
+<!-- mammoth.js for Word .docx text extraction -->
+<script src="https://cdn.jsdelivr.net/npm/mammoth@1.6.0/mammoth.browser.min.js" crossorigin="anonymous"></script>
+<!-- SCRIPTS -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/sql.js/1.8.0/sql-wasm.js" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/pptxgenjs@3.12.0/dist/pptxgen.bundle.js" crossorigin="anonymous"></script>
+<script>window.APP_VERSION = '63.9';</script>
+<!-- Sanitizer must load before any renderer so AI/source HTML is cleaned. See js/core/Sanitizer.js. -->
+<script src="js/core/Sanitizer.js?v=1783000039"></script>
+<script src="js/core/LocalGrader.js"></script>
+<script src="js/core/BackNav.js"></script>
+<script src="js/core/BackupGuard.js"></script>
+<script src="js/core/SharePack.js"></script>
+<script src="js/ui/PastPaperDrill.js"></script>
+<!-- Managed-AI build config (subscription gating). Loads early so AIService sees it. -->
+<script src="js/core/AppConfig.js?v=1783000039"></script>
+<script src="js/core/LearnerState.js"></script>
+<script src="js/core/CoachFacts.js?v=1783000039"></script>
+<script src="js/core/AppFeatures.js"></script>
+<script src="js/core/ScrollLock.js?v=1783000039"></script>
+<script src="js/core/KnowledgeNode.js?v=1783000039"></script>
+<script src="js/core/NodeStore.js?v=1783000039"></script>
+<script src="js/core/BackupVault.js?v=1783000039"></script>
+<script src="js/core/SpacedRepetition.js?v=1783000039"></script>
+<script src="js/core/StudyPlan.js?v=1783000039"></script>
+<script src="js/core/ExamReadiness.js?v=1783000039"></script>
+<script src="js/core/NewCardPacer.js?v=1783000039"></script>
+<script src="js/core/LeechDetector.js?v=1783000039"></script>
+<script src="js/core/MatchOptions.js?v=1783000039"></script>
+<script src="js/core/MatchGroup.js?v=1783000039"></script>
+<script src="js/ai/LearnerMemory.js?v=1783000039"></script>
+<script src="js/ai/AICorrections.js?v=1783000039"></script>
+<script src="js/ai/LearnerContext.js?v=1783000039"></script>
+<script src="js/ai/AIService.js?v=1783000039"></script>
+<script src="js/ai/CoachEngine.js?v=1783000039"></script>
+<script src="js/ui/Toast.js?v=1783000039"></script>
+<script src="js/ui/KNLoader.js?v=1783000039"></script>
+<script src="js/ui/Modal.js?v=1783000039"></script>
+<script src="js/ui/NotesRenderer.js?v=1783000039"></script>
+<script src="js/ui/BlockEngine.js?v=1783000039"></script>
+<script src="js/ui/ReactiveReshaper.js?v=1783000039"></script>
+<script src="js/ui/StudyFitCheck.js?v=1783000039"></script>
+<script src="js/ui/AIDirector.js?v=1783000039"></script>
+<script src="js/ui/StudyCoach.js?v=1783000039"></script>
+<script src="js/ui/AISettingsModal.js?v=1783000039"></script>
+<script src="js/ui/Paywall.js?v=1783000039"></script>
+<script src="js/ui/LectureMode.js?v=1783000039"></script>
+    <script src="js/ui/LearnPanel.js?v=1783000039"></script>
+<script src="js/ui/PrintExport.js?v=1783000039"></script>
+<script src="js/ui/ImageManager.js?v=1783000039"></script>
+<script src="js/ui/TextAnnotator.js?v=1783000039"></script>
+<script src="js/ui/SelectToAction.js?v=1783000039"></script>
+<script src="js/ui/StreakTracker.js?v=1783000039"></script>
+<script src="js/ui/Dashboard.js?v=1783000039"></script>
+<script src="js/ui/Onboarding.js?v=1783000039"></script>
+<script src="js/ui/Guide.js?v=1783000039"></script>
+<script src="js/ui/StudySession.js?v=1783000039"></script>
+<script src="js/ui/SettingsPanel.js?v=1783000039"></script>
+<script src="js/ui/NoteTemplates.js?v=1783000039"></script>
+<script src="js/ui/BlankRecall.js?v=1783000039"></script>
+<script src="js/ui/BulkImport.js?v=1783000039"></script>
+<script src="js/ui/UnderstandingCheck.js?v=1783000039"></script>
+<script src="js/ui/UploadView.js?v=1783000039"></script>
+<script src="js/ui/SpeechPill.js?v=1783000039"></script>
+<script src="js/ui/GuidedView.js?v=1783000039"></script>
+<script src="js/ui/LibraryView.js?v=1783000039"></script>
+<script src="js/ui/SocraticTutor.js?v=1783000039"></script>
+    <script src="js/ui/NodeDetailView.js?v=1783000039"></script>
+<script src="js/ui/ReviewView.js?v=1783000039"></script>
+<script src="js/ui/OCRReview.js?v=1783000039"></script>
+<script src="js/ui/AINodeTools.js?v=1783000039"></script>
+<script src="js/ui/ImageResponseBlock.js?v=1783000039"></script>
+<script src="js/ui/StudyPlanBuilder.js?v=1783000039"></script>
+<script src="js/ui/StudyPlanView.js?v=1783000039"></script>
+<script src="js/ui/CompetencyView.js?v=1783000039"></script>
+<script src="js/app.js?v=1783000039"></script>
+
+<!-- Back to Top Button -->
+<button id="back-to-top" aria-label="Back to top" title="Back to top" style="display:none;position:fixed;bottom:80px;right:16px;z-index:900;width:40px;height:40px;border-radius:50%;background:var(--bg-card);border:1px solid var(--border);color:var(--text-muted);font-size:16px;cursor:pointer;box-shadow:0 2px 12px rgba(0,0,0,.4);transition:opacity .2s,transform .2s;display:flex;align-items:center;justify-content:center;">↑</button>
+<script>
+(function(){
+  const btn = document.getElementById('back-to-top');
+  if (!btn) return;
+  btn.style.display = 'none';
+
+  // All scrollable containers in the app
+  const scrollers = () => [
+    document.getElementById('main-content'),
+    document.getElementById('detail-body'),
+    document.querySelector('.library-list'),
+    document.querySelector('.view.active'),
+    document.documentElement,
+  ].filter(Boolean);
+
+  let _activeScroller = null;
+
+  const show = (el) => {
+    const top = el === document.documentElement ? window.scrollY : el.scrollTop;
+    if (top > 200) {
+      btn.style.display = 'flex';
+      btn.style.opacity = '1';
+      _activeScroller = el;
+    } else {
+      btn.style.display = 'none';
+    }
+  };
+
+  // Attach scroll listeners to all known scrollers
+  const attachListeners = () => {
+    scrollers().forEach(el => {
+      if (el._bttBound) return;
+      el._bttBound = true;
+      el.addEventListener('scroll', () => show(el), { passive: true });
+    });
+  };
+
+  // Re-attach when views change (MutationObserver on body)
+  attachListeners();
+  new MutationObserver(attachListeners).observe(document.body, { childList: true, subtree: true });
+
+  btn.addEventListener('click', () => {
+    const el = _activeScroller || document.getElementById('detail-body') || document.getElementById('main-content');
+    if (el && el !== document.documentElement) {
+      el.scrollTo({ top: 0, behavior: 'smooth' });
+    } else {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+    btn.style.display = 'none';
+  });
+})();
+</script>
+<script>
+(function(){
+  setTimeout(function(){
+    var banner = document.getElementById('kn-error-banner');
+    var ranInit = (typeof App !== 'undefined' && App._initialized === true);
+    var navBtns = document.querySelectorAll('.mobile-nav-btn, .nav-item').length;
+
+    // FAILSAFE: if App.init did not bind nav (no currentView), wire a minimal
+    // navigation handler directly so the user can at least move between tabs.
+    if (typeof App !== 'undefined' && typeof App.navigateTo === 'function' && !ranInit) {
+      document.querySelectorAll('.mobile-nav-btn, .nav-item').forEach(function(b){
+        if (b._navBound) return; // already wired by App._bindNavigation
+        b._navBound = true;
+        b.addEventListener('click', function(){
+          var v = b.dataset.view;
+          if (v === 'more-menu') { document.getElementById('more-menu-panel')?.classList.toggle('hidden'); return; }
+          try { App.navigateTo(v); } catch(e){}
+        });
+      });
+    }
+    if (!ranInit || !banner) {
+      if (banner) {
+        banner.style.display = 'block';
+        banner.textContent += 'DIAGNOSTIC: App defined=' + (typeof App !== 'undefined')
+          + ' currentView=' + (typeof App !== 'undefined' ? App._currentView : 'N/A')
+          + ' navButtons=' + navBtns
+          + ' nodeStore=' + (typeof nodeStore !== 'undefined') + '\n';
+      }
+    }
+  }, 1500);
+})();
+</script>
+</body>
+</html>

--- a/knowledgenode/www/js/ai/AICorrections.js
+++ b/knowledgenode/www/js/ai/AICorrections.js
@@ -1,0 +1,295 @@
+/**
+ * AICorrections.js — User correction loop
+ *
+ * When the AI gets something wrong, the user can tap a thumbs-down
+ * button next to any AI output. They explain what was wrong. The
+ * correction is:
+ *
+ *   1. Saved to node.aiCorrections[] (persistent per-node memory)
+ *   2. Injected into all FUTURE AI prompts for that node as
+ *      "previous AI mistakes — do not repeat"
+ *   3. Visible to the user as a list under Settings → Corrections
+ *
+ * This means the AI genuinely learns from each user — corrections
+ * for one node only affect that node's future generations.
+ */
+
+const AICorrections = {
+
+  /* ─────────────────────────────────────────────────────
+     RECORD A CORRECTION
+  ───────────────────────────────────────────────────── */
+
+  /**
+   * Record that the AI got something wrong.
+   * @param {object} node     — the node this correction belongs to
+   * @param {string} category — 'definition' | 'question' | 'answer' | 'scaffold' | 'example' | 'lecture' | 'general'
+   * @param {string} aiOutput — what the AI said (kept short)
+   * @param {string} userNote — what the user says is wrong / correct
+   */
+  record(node, category, aiOutput, userNote) {
+    if (!node || !userNote?.trim()) return;
+    if (!node.aiCorrections) node.aiCorrections = [];
+
+    node.aiCorrections.push({
+      id:       'cor_' + Date.now() + '_' + Math.random().toString(36).slice(2,6),
+      ts:       Date.now(),
+      category: category || 'general',
+      aiOutput: (aiOutput || '').slice(0, 240),
+      userNote: userNote.trim().slice(0, 480),
+    });
+
+    // Keep last 20 corrections per node — older ones get dropped
+    if (node.aiCorrections.length > 20) {
+      node.aiCorrections = node.aiCorrections.slice(-20);
+    }
+
+    nodeStore.save(node);
+
+    // Also log to LearnerMemory so it shows up in session history
+    if (typeof LearnerMemory !== 'undefined') {
+      try {
+        LearnerMemory._writeToNode(node, {
+          type:    'correction',
+          category,
+          summary: 'User corrected AI: ' + userNote.slice(0, 100),
+        });
+        nodeStore.save(node);
+      } catch(e) { /* non-critical */ }
+    }
+  },
+
+  /**
+   * Open the correction modal for the user to record what's wrong.
+   * @param {object} node
+   * @param {string} category
+   * @param {string} aiOutput  — the offending AI output to show in the modal
+   * @param {function} onSaved — optional callback after save
+   */
+  promptUser(node, category, aiOutput, onSaved) {
+    const safe = (aiOutput || '').slice(0, 300).replace(/</g, '&lt;');
+    Modal.open(`
+      <div style="font-family:var(--font-ui);">
+        <h2 style="font-size:18px;font-weight:800;margin-bottom:6px;">Correct the AI</h2>
+        <p style="font-family:var(--font-body);font-size:13px;color:var(--text-muted);margin-bottom:18px;">
+          Tell the AI what it got wrong. It will remember this for future answers on this node.
+        </p>
+
+        <div style="margin-bottom:14px;">
+          <label class="config-label" style="margin-bottom:6px;">What the AI said:</label>
+          <div style="background:var(--bg-base);border:1px solid var(--border);border-radius:8px;
+                      padding:10px 12px;font-family:var(--font-body);font-size:13px;
+                      color:var(--text-secondary);line-height:1.5;max-height:120px;overflow-y:auto;">
+            ${safe || '<em style="color:var(--text-muted);">(no specific text)</em>'}
+          </div>
+        </div>
+
+        <div style="margin-bottom:18px;">
+          <label class="config-label" style="margin-bottom:6px;">What's wrong / what should it have said?</label>
+          <textarea id="aic-note" class="config-input" rows="4" style="resize:vertical;width:100%;
+                    font-family:var(--font-body);font-size:13px;line-height:1.55;"
+            placeholder="e.g. 'This formula isn't in my notes — use the one on page 12 instead' or 'The answer should mention X based on the source'"></textarea>
+        </div>
+
+        <div style="display:flex;gap:8px;justify-content:flex-end;">
+          <button class="btn-secondary" id="aic-cancel" style="font-size:13px;padding:9px 16px;">Cancel</button>
+          <button class="btn-primary" id="aic-save" style="font-size:13px;padding:9px 16px;">Save correction</button>
+        </div>
+      </div>
+    `);
+
+    setTimeout(() => document.getElementById('aic-note')?.focus(), 100);
+
+    document.getElementById('aic-cancel')?.addEventListener('click', () => Modal.close());
+    document.getElementById('aic-save')?.addEventListener('click', () => {
+      const note = document.getElementById('aic-note')?.value || '';
+      if (!note.trim()) {
+        Toast.error('Please describe what was wrong.');
+        return;
+      }
+      this.record(node, category, aiOutput, note);
+      Modal.close();
+      Toast.success('Got it — the AI will remember this for "' + node.title + '"');
+      if (typeof onSaved === 'function') onSaved();
+    });
+  },
+
+  /* ─────────────────────────────────────────────────────
+     INJECT INTO PROMPTS — called by LearnerContext
+  ───────────────────────────────────────────────────── */
+
+  /**
+   * Returns a formatted string of past corrections for a node,
+   * to be injected into AI prompts.
+   * Returns '' if no corrections exist.
+   */
+  forPrompt(node) {
+    const cors = (node?.aiCorrections || []).slice(-10); // last 10 corrections
+    if (!cors.length) return '';
+
+    return 'PREVIOUS AI MISTAKES ON THIS NODE — DO NOT REPEAT:\n'
+      + cors.map((c, i) => {
+        const ago = this._timeAgo(c.ts);
+        const aiPart = c.aiOutput ? ' (AI previously said: "' + c.aiOutput.slice(0, 120) + '")' : '';
+        return (i + 1) + '. [' + c.category + ', ' + ago + '] User correction: "' + c.userNote + '"' + aiPart;
+      }).join('\n')
+      + '\nApply these corrections to your current response.';
+  },
+
+  /* ─────────────────────────────────────────────────────
+     RENDER A CORRECTION BUTTON
+  ───────────────────────────────────────────────────── */
+
+  /**
+   * Returns the HTML attributes for a "correctable" wrapper element.
+   * Instead of an always-visible button (easy to misclick), the correction
+   * is triggered by:
+   *   - Long-press (mobile, 500ms hold)
+   *   - Right-click (desktop)
+   *   - Double-tap on the small ⋯ indicator in the corner
+   * The element gets a subtle ⋯ indicator on hover so users discover it.
+   *
+   * @param {string} category — e.g. 'definition'
+   * @param {string} aiOutput — what the AI said
+   * @returns {string} HTML attributes to add to any element
+   */
+  wrapperAttrs(category, aiOutput) {
+    const encoded = encodeURIComponent(aiOutput || '').slice(0, 1000);
+    return `data-ai-correct="1" data-ai-correct-category="${category}" data-ai-correct-output="${encoded}"`;
+  },
+
+  /**
+   * Legacy alias — kept for any existing renderButton callers.
+   * Now returns nothing visible by default; the actual UI lives on the
+   * parent element via wrapperAttrs and bindCorrectionButtons.
+   */
+  renderButton(category, aiOutput) {
+    // Tiny dot indicator that fades in on hover, signalling "correctable"
+    const encoded = encodeURIComponent(aiOutput || '').slice(0, 1000);
+    return `<span class="ai-correct-dot"
+      data-ai-correct="1"
+      data-ai-correct-category="${category}"
+      data-ai-correct-output="${encoded}"
+      title="Long-press or right-click to correct the AI"
+      style="display:inline-block;width:6px;height:6px;border-radius:50%;
+             background:var(--text-muted);opacity:.25;margin-left:8px;
+             vertical-align:middle;cursor:context-menu;
+             transition:opacity .15s, background .15s;"></span>`;
+  },
+
+  /**
+   * After rendering, activate correction triggers inside a container.
+   * Triggers: long-press, right-click, and click on the small dot indicator.
+   */
+  bindCorrectionButtons(container, node) {
+    if (!container || !node) return;
+
+    // First-time hint — only shown once across the whole app
+    if (!localStorage.getItem('kn_correct_hint_seen')) {
+      const dots = container.querySelectorAll('.ai-correct-dot');
+      if (dots.length > 0) {
+        setTimeout(() => {
+          try {
+            if (typeof Toast !== 'undefined') {
+              Toast.info('💡 If the AI gets something wrong, long-press the item to correct it.');
+              localStorage.setItem('kn_correct_hint_seen', '1');
+            }
+          } catch(e) {}
+        }, 1500);
+      }
+    }
+
+    // Find all elements that have data-ai-correct
+    container.querySelectorAll('[data-ai-correct]').forEach(el => {
+      if (el.dataset.aicBound) return;
+      el.dataset.aicBound = '1';
+
+      const open = (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        const category = el.dataset.aiCorrectCategory || 'general';
+        const output   = decodeURIComponent(el.dataset.aiCorrectOutput || '');
+        this.promptUser(node, category, output);
+      };
+
+      // Right-click (desktop)
+      el.addEventListener('contextmenu', open);
+
+      // Long-press (mobile + desktop)
+      let pressTimer = null;
+      let pressMoved = false;
+
+      const startPress = (e) => {
+        pressMoved = false;
+        pressTimer = setTimeout(() => {
+          if (!pressMoved) {
+            // Haptic feedback if available
+            if (navigator.vibrate) navigator.vibrate(30);
+            open(e);
+          }
+        }, 500);
+      };
+      const cancelPress = () => {
+        if (pressTimer) { clearTimeout(pressTimer); pressTimer = null; }
+      };
+      const markMoved = () => { pressMoved = true; cancelPress(); };
+
+      el.addEventListener('touchstart', startPress, { passive: true });
+      el.addEventListener('touchmove',  markMoved,  { passive: true });
+      el.addEventListener('touchend',   cancelPress);
+      el.addEventListener('touchcancel',cancelPress);
+
+      el.addEventListener('mousedown',  e => { if (e.button === 0) startPress(e); });
+      el.addEventListener('mousemove',  markMoved);
+      el.addEventListener('mouseup',    cancelPress);
+      el.addEventListener('mouseleave', cancelPress);
+
+      // Visual hint: brighten the dot indicator on hover of the parent
+      const dot = el.classList.contains('ai-correct-dot') ? el : el.querySelector('.ai-correct-dot');
+      if (dot) {
+        const parent = dot.classList.contains('ai-correct-dot') ? dot.parentElement : el;
+        if (parent) {
+          parent.addEventListener('mouseenter', () => { dot.style.opacity = '.7'; });
+          parent.addEventListener('mouseleave', () => { dot.style.opacity = '.25'; });
+        }
+        // Tapping the dot itself also opens (for users who discover it)
+        dot.addEventListener('click', open);
+      }
+    });
+  },
+
+  /* ─────────────────────────────────────────────────────
+     LIST / DELETE — for Settings view
+  ───────────────────────────────────────────────────── */
+
+  getAll(node) {
+    return (node?.aiCorrections || []).slice().reverse();
+  },
+
+  delete(node, correctionId) {
+    if (!node?.aiCorrections) return;
+    node.aiCorrections = node.aiCorrections.filter(c => c.id !== correctionId);
+    nodeStore.save(node);
+  },
+
+  clearAll(node) {
+    if (!node) return;
+    node.aiCorrections = [];
+    nodeStore.save(node);
+  },
+
+  /* ─────────────────────────────────────────────────────
+     HELPERS
+  ───────────────────────────────────────────────────── */
+
+  _timeAgo(ts) {
+    const diff = Date.now() - ts;
+    const days = Math.floor(diff / 86400000);
+    if (days >= 1) return days + 'd ago';
+    const hrs = Math.floor(diff / 3600000);
+    if (hrs >= 1)  return hrs + 'h ago';
+    const mins = Math.floor(diff / 60000);
+    if (mins >= 1) return mins + 'm ago';
+    return 'just now';
+  },
+};

--- a/knowledgenode/www/js/ai/AIService.js
+++ b/knowledgenode/www/js/ai/AIService.js
@@ -1,0 +1,1927 @@
+/**
+ * AIService.js — Final with OpenRouter
+ *
+ * OpenRouter is the default provider. One key, 300+ models.
+ * Each function (note processing, questions, chat, grading…) uses
+ * its own model — pre-configured with sensible defaults.
+ * User just pastes their OpenRouter key and everything works.
+ *
+ * Function → default model mapping (all via OpenRouter):
+ *   noteProcessing   → google/gemini-3.5-flash    (vision, fast, current)
+ *   questionGen      → google/gemini-3.5-flash    (structured JSON output)
+ *   chat             → anthropic/claude-haiku-4.5        (fast, responsive)
+ *   lecture          → anthropic/claude-sonnet-5       (best writing)
+ *   grading          → openai/gpt-5-mini               (reliable scoring JSON)
+ *   examGeneration   → anthropic/claude-sonnet-5       (domain knowledge)
+ *   restructure      → google/gemini-3.1-flash-lite      (fastest structuring)
+ *   gapAnalysis      → anthropic/claude-haiku-4.5        (cross-topic reasoning)
+ */
+
+const AIService = {
+
+  /* ═══════════════════════════════════════════════════════
+     PROVIDER REGISTRY
+  ═══════════════════════════════════════════════════════ */
+  _providers: {
+    openrouter: {
+      name:           'OpenRouter (Recommended)',
+      endpoint:       'https://openrouter.ai/api/v1/chat/completions',
+      keyPlaceholder: 'sk-or-v1-...',
+      docsUrl:        'https://openrouter.ai/keys',
+      supportsVision: true,
+      isOpenRouter:   true,
+      // Default model for each function — user can override in Settings
+      defaults: {
+        ocr:            'google/gemini-3.5-flash',      // photo text extraction — needs vision; biggest cost driver
+        noteProcessing: 'google/gemini-3.5-flash',
+        questionGen:    'google/gemini-3.5-flash',
+        chat:           'anthropic/claude-haiku-4.5',
+        lecture:        'anthropic/claude-sonnet-5',
+        grading:        'openai/gpt-5-mini',
+        examGeneration: 'anthropic/claude-sonnet-5',
+        restructure:    'google/gemini-3.1-flash-lite',
+        gapAnalysis:    'anthropic/claude-haiku-4.5',
+        slideGen:       'google/gemini-3.5-flash',
+        director:       'anthropic/claude-haiku-4.5', // default: will be overridden by presets
+      },
+      presets: {
+        budget: {
+          label: '💰 Budget',
+          desc:  'Cheapest models. Great for most tasks.',
+          models: {
+            ocr:            'google/gemini-3.1-flash-lite',
+            slideGen:       'google/gemini-3.1-flash-lite',
+            noteProcessing: 'google/gemini-3.1-flash-lite',
+            questionGen:    'google/gemini-3.1-flash-lite',
+            chat:           'google/gemini-3.1-flash-lite',
+            lecture:        'google/gemini-3.5-flash',
+            grading:        'openai/gpt-5-mini',
+            examGeneration: 'google/gemini-3.5-flash',
+            restructure:    'google/gemini-3.1-flash-lite',
+            gapAnalysis:    'google/gemini-3.1-flash-lite',
+            director:       'google/gemini-3.5-flash',     // budget: flash handles the reasoning
+          },
+        },
+        balanced: {
+          label: '⚖ Balanced',
+          desc:  'Smart defaults. Best value for studying.',
+          models: {
+            ocr:            'google/gemini-3.5-flash',
+            slideGen:       'google/gemini-3.5-flash',
+            noteProcessing: 'google/gemini-3.5-flash',
+            questionGen:    'google/gemini-3.5-flash',
+            chat:           'anthropic/claude-haiku-4.5',
+            lecture:        'anthropic/claude-sonnet-5',
+            grading:        'openai/gpt-5-mini',
+            examGeneration: 'anthropic/claude-sonnet-5',
+            restructure:    'google/gemini-3.1-flash-lite',
+            gapAnalysis:    'anthropic/claude-haiku-4.5',
+            director:       'anthropic/claude-sonnet-5',  // balanced: Sonnet for cross-topic reasoning
+          },
+        },
+        premium: {
+          label: '🚀 Premium',
+          desc:  'Best models for every task. Higher cost.',
+          models: {
+            ocr:            'google/gemini-3.5-flash',
+            slideGen:       'google/gemini-3.1-pro-preview',
+            noteProcessing: 'google/gemini-3.1-pro-preview',
+            questionGen:    'google/gemini-3.1-pro-preview',
+            chat:           'anthropic/claude-sonnet-5',
+            lecture:        'anthropic/claude-opus-4-8',
+            grading:        'openai/gpt-5.4',
+            examGeneration: 'anthropic/claude-opus-4-8',
+            restructure:    'google/gemini-3.5-flash',
+            gapAnalysis:    'anthropic/claude-sonnet-5',
+            director:       'anthropic/claude-opus-4-8',    // premium: Opus for deepest evaluation
+          },
+        },
+      },
+    },
+    claude: {
+      name:           'Claude (Anthropic Direct)',
+      models:         ['claude-sonnet-5','claude-opus-4-8','claude-haiku-4-5-20251001'],
+      defaultModel:   'claude-sonnet-5',
+      keyPlaceholder: 'sk-ant-...',
+      docsUrl:        'https://console.anthropic.com',
+      supportsVision: true,
+    },
+    openai: {
+      name:           'ChatGPT (OpenAI Direct)',
+      models:         ['gpt-5.4','gpt-5-mini','gpt-4o'],
+      defaultModel:   'gpt-5-mini',
+      keyPlaceholder: 'sk-...',
+      docsUrl:        'https://platform.openai.com',
+      supportsVision: true,
+    },
+    gemini: {
+      name:           'Gemini (Google Direct)',
+      models:         [
+        'gemini-3.5-flash',
+        'gemini-3.1-flash-lite',
+        'gemini-2.5-flash',
+      ],
+      defaultModel:   'gemini-3.5-flash',
+      keyPlaceholder: 'AIza...',
+      docsUrl:        'https://aistudio.google.com',
+      supportsVision: true,
+    },
+    custom: {
+      name:           'Custom Endpoint',
+      models:         [],
+      defaultModel:   '',
+      keyPlaceholder: 'api-key',
+      docsUrl:        '',
+      supportsVision: false,
+    },
+  },
+
+  /* ─── Function labels for UI ─── */
+  _functionLabels: {
+    ocr:            { label:'👁 Photo Reading (OCR)', desc:'Extracting text from photos & PDFs — pick a vision-capable model; this is the biggest cost driver' },
+    noteProcessing: { label:'📄 Note Processing',     desc:'Structuring uploaded notes and images into nodes' },
+    questionGen:    { label:'❓ Question Generation', desc:'Creating recall and application questions' },
+    chat:           { label:'💬 AI Assistant Chat',   desc:'Floater chat, explanations, simplification' },
+    lecture:        { label:'🎓 Lecture Scripts',     desc:'Generating lecture and study scripts' },
+    slideGen:       { label:'🖥 Lecture Slides',      desc:'Generating slide-format lectures with narration' },
+    grading:        { label:'✅ Answer Grading',       desc:'Grading quiz and exam answers' },
+    examGeneration: { label:'🏆 Exam Questions',      desc:'Generating scenario-based exam questions' },
+    restructure:    { label:'⬡ Restructure Notes',    desc:'Reorganising raw notes into structured format' },
+    gapAnalysis:    { label:'🔍 Gap Analysis',        desc:'Analysing weak areas after study sessions' },
+    director:       { label:'⬡ AI Director',          desc:'Full cross-topic evaluation and study reshaping' },
+  },
+
+  // OpenRouter is the recommended bring-your-own-key provider and the default.
+  _activeProvider: 'openrouter',
+  _config: {},
+
+  // Server-side proxy state. When a serverless proxy (Netlify/Vercel) is
+  // deployed WITH an ANTHROPIC_API_KEY env var, every visitor can use AI with
+  // zero configuration — requests are routed through the proxy and the owner's
+  // key never touches the browser. Detected once at startup by loadConfig().
+  _proxyAvailable: false,
+  _proxyEndpoint: null,
+  _proxyChecked: false,
+
+  /* ═══════════════════════════════════════════════════════
+     CONFIG
+  ═══════════════════════════════════════════════════════ */
+  /** Set active learner profile — affects all AI responses */
+  setProfile(profile) {
+    this._activeProfile = profile || 'college';
+  },
+
+  loadConfig() {
+    try {
+      const s = localStorage.getItem('kn_ai_config_v2');
+      if (s) this._config = JSON.parse(s);
+      this._activeProvider = localStorage.getItem('kn_ai_provider') || 'openrouter';
+    } catch(e) {}
+    // Kick off proxy detection (non-blocking). The app works regardless of result.
+    this.detectProxy();
+  },
+
+  /**
+   * Detect whether a serverless Claude proxy is deployed and has a key.
+   * Tries the Netlify and Vercel routes with a tiny probe request.
+   * If found, all AI calls route through it using the OWNER's server key —
+   * users need no key of their own. Falls back silently to BYO-key mode.
+   */
+  async detectProxy() {
+    if (this._proxyChecked) return this._proxyAvailable;
+    this._proxyChecked = true;
+    // Where the serverless proxy lives. In the installed Android app the proxy is
+    // on a different origin (your Vercel/Netlify deploy), so it must be an ABSOLUTE
+    // url from AppConfig.PROXY_BASE_URL. On the web build (same origin) we probe
+    // relative paths.
+    const base = (typeof AppConfig !== 'undefined' && AppConfig.PROXY_BASE_URL)
+      ? String(AppConfig.PROXY_BASE_URL).replace(/\/$/, '') : '';
+    // With no base set, only probe when served over http(s) (a file:// origin has
+    // no backend). With an absolute base, always probe.
+    if (!base && (typeof location === 'undefined' || !/^https?:$/.test(location.protocol))) return false;
+    const candidates = base
+      ? [base + '/api/claude-proxy', base + '/.netlify/functions/claude-proxy']
+      : ['/.netlify/functions/claude-proxy', '/api/claude-proxy'];
+    for (const url of candidates) {
+      try {
+        const res = await this._fetchWithTimeout(url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          // Minimal valid Anthropic payload — proxy adds the key server-side.
+          body: JSON.stringify({
+            model: 'claude-haiku-4-5-20251001',
+            max_tokens: 1,
+            messages: [{ role: 'user', content: 'ping' }],
+          }),
+        }, 5000); // 5s probe — don't hang startup
+        // 404/405 → no proxy at this route. Try next.
+        if (res.status === 404 || res.status === 405) continue;
+        const data = await res.json().catch(() => ({}));
+        // Proxy exists but owner hasn't set a key → not usable, keep looking/BYO.
+        const msg = data?.error?.message || '';
+        if (/api key not (set|configured)|config error/i.test(msg)) continue;
+        // Anything else (200 with content, or a real Anthropic error like
+        // overloaded/invalid-model) means the proxy is live AND keyed.
+        this._proxyAvailable = true;
+        this._proxyEndpoint  = url;
+        document.dispatchEvent(new CustomEvent('kn-proxy-detected', { detail: { url } }));
+        return true;
+      } catch (e) { /* network/route error — try next candidate */ }
+    }
+    return false;
+  },
+
+  saveConfig(provider, key, model, customEndpoint='', functionModels={}) {
+    this._activeProvider = provider;
+    this._config[provider] = { key, model, customEndpoint, functionModels };
+    localStorage.setItem('kn_ai_config_v2', JSON.stringify(this._config));
+    localStorage.setItem('kn_ai_provider', provider);
+  },
+
+  /** Snapshot the full AI configuration (provider + keys + models) for backups. */
+  exportConfig() {
+    const hasAny = this._config && Object.keys(this._config).length > 0;
+    if (!hasAny) return null;
+    return { provider: this._activeProvider, config: this._config };
+  },
+
+  /** Restore AI configuration from a backup payload produced by exportConfig().
+   *  Backups can come from a file anyone could have edited, so the payload is
+   *  treated as untrusted: unknown providers are dropped, only known fields are
+   *  copied, and a `custom` endpoint (which controls where notes + keys are sent)
+   *  is accepted only if it is a valid HTTPS URL and is flagged for re-confirmation. */
+  importConfig(obj) {
+    if (!obj || typeof obj !== 'object') return false;
+    try {
+      const known    = Object.keys(this._providers);
+      const incoming = (obj.config && typeof obj.config === 'object') ? obj.config : {};
+      const clean    = {};
+      for (const [provider, cfg] of Object.entries(incoming)) {
+        if (!known.includes(provider) || !cfg || typeof cfg !== 'object') continue;
+        const safe = {
+          key:            typeof cfg.key === 'string' ? cfg.key : '',
+          model:          typeof cfg.model === 'string' ? cfg.model : '',
+          functionModels: (cfg.functionModels && typeof cfg.functionModels === 'object') ? cfg.functionModels : {},
+          customEndpoint: '',
+        };
+        if (provider === 'custom' && typeof cfg.customEndpoint === 'string') {
+          try {
+            const u = new URL(cfg.customEndpoint);
+            if (u.protocol === 'https:') {
+              safe.customEndpoint        = cfg.customEndpoint;
+              safe._endpointNeedsConfirm = true; // UI should ask before first use
+            }
+          } catch (e) { /* invalid URL → leave endpoint blank */ }
+        }
+        clean[provider] = safe;
+      }
+      this._config = clean;
+      if (obj.provider && known.includes(obj.provider)) this._activeProvider = obj.provider;
+      localStorage.setItem('kn_ai_config_v2', JSON.stringify(this._config));
+      localStorage.setItem('kn_ai_provider', this._activeProvider);
+      return true;
+    } catch (e) { console.warn('[AIService] importConfig failed:', e); return false; }
+  },
+
+  saveFunctionModel(fn, model) {
+    const cfg = this._config[this._activeProvider] || {};
+    cfg.functionModels = cfg.functionModels || {};
+    cfg.functionModels[fn] = model;
+    this._config[this._activeProvider] = cfg;
+    localStorage.setItem('kn_ai_config_v2', JSON.stringify(this._config));
+  },
+
+  applyPreset(presetKey) {
+    const p = this._providers.openrouter?.presets?.[presetKey];
+    if (!p) return;
+    const cfg = this._config.openrouter || {};
+    cfg.functionModels = { ...p.models };
+    this._config.openrouter = cfg;
+    localStorage.setItem('kn_ai_config_v2', JSON.stringify(this._config));
+  },
+
+  getActiveProvider()    { return this._providers[this._activeProvider]; },
+  getActiveProviderKey() { return this._activeProvider; },
+  getActiveConfig()      { return this._config[this._activeProvider] || {}; },
+  getProviderList()      { return Object.entries(this._providers).map(([id,p]) => ({id,...p})); },
+  /** True if AI is usable — either via the server proxy OR a user-supplied key. */
+  hasApiKey()    {
+    if (this._proxyAvailable) return true;
+    const c = this._config[this._activeProvider];
+    return !!(c && c.key);
+  },
+
+  /** Returns a profile instruction string to inject into any AI prompt */
+  profileContext(profile) {
+    // CRITICAL RULE for all profiles: cover EVERY piece of information from the source.
+    // The profile only changes HOW things are explained — never WHAT is included.
+    // Volume and completeness must be identical across all profiles.
+    const base = 'VOLUME RULE: Include ALL definitions, formulas, procedures, tables, and concepts from the source — do not skip or summarise anything just because of the level. The amount of content must be the same as college level. Only the language and explanation style changes. ';
+    const map = {
+      primary: base + 'STYLE: The student is PRIMARY SCHOOL level (age 6-11). Explain every concept using the simplest possible everyday words and analogies. No jargon — replace every technical term with a plain-English explanation AND still include the technical term in brackets so they learn it. Use short sentences. Be encouraging and warm. Give a simple real-life example for every concept.',
+      high:    base + 'STYLE: The student is HIGH SCHOOL level (age 14-18). Use straightforward language. Define technical terms clearly when first used. Relate every concept to something real-world. Include all the detail but make it accessible.',
+      college: base + 'STYLE: The student is COLLEGE/UNIVERSITY level. Use precise academic language. Include technical terms with definitions. Expect some prior knowledge but still explain each concept fully.',
+      pro:     base + 'STYLE: The student is a WORKING PROFESSIONAL. Be concise but comprehensive — cover everything, just cut unnecessary explanation. Use industry terminology. Surface practical implications, edge cases, and real-world application for every concept.',
+    };
+    return map[profile] || map.college;
+  },
+  isUsingProxy() { return this._proxyAvailable === true; },
+  supportsVision() {
+    // Proxy uses Claude (vision-capable). Otherwise depends on the chosen provider + key.
+    if (this._proxyAvailable) return true;
+    return this._providers[this._activeProvider]?.supportsVision && this.hasApiKey();
+  },
+
+  /* Get the model for a specific function — falls back to default or global model */
+  _getModelForFunction(fn) {
+    const provider = this._providers[this._activeProvider];
+    const cfg      = this._config[this._activeProvider] || {};
+
+    // OpenRouter: use per-function model
+    if (provider?.isOpenRouter) {
+      return cfg.functionModels?.[fn]
+          || provider.defaults?.[fn]
+          || (fn === 'director' ? provider.defaults?.['gapAnalysis'] : null) // director → gapAnalysis fallback
+          || provider.defaults?.noteProcessing
+          || 'google/gemini-3.5-flash';
+    }
+
+    // Direct providers: use the global model selection
+    return cfg.model || provider?.defaultModel || '';
+  },
+
+  /* ═══════════════════════════════════════════════════════
+     CORE PROCESSING PIPELINE
+  ═══════════════════════════════════════════════════════ */
+  async processContent(base64Images=[], rawText='', meta={}, onProgress=()=>{}, mediaTypes=[]) {
+    let ocrText = rawText;
+    if (base64Images.length > 0 && !rawText) {
+      onProgress(1, 'Reading ' + base64Images.length + ' image' + (base64Images.length>1?'s':'') + '…');
+      ocrText = base64Images.length > 1
+        ? await this._extractMultiPageText(base64Images, mediaTypes)
+        : await this._extractSingleImageText(base64Images[0], mediaTypes[0] || 'image/jpeg');
+    } else {
+      onProgress(1, 'Reading content…'); await this._delay(200);
+    }
+    onProgress(2, 'Structuring notes from your source…');
+
+    // Worked examples only consume `procedures` + `summary`. Skip subject
+    // detection and question generation entirely — they aren't used, and
+    // every extra API call is another chance for a transient failure to
+    // drop the whole example.
+    if (meta._isWorkedExample) {
+      const cat = await this._detectSubjectCategory(ocrText, meta).catch(() => 'general');
+      const exNotes = await this._generateFullStructure(ocrText, meta, cat, onProgress);
+      onProgress(4, 'Building example…');
+      return {
+        rawOCR: ocrText,
+        subjectCategory: cat,
+        title: exNotes.title || meta.title || 'Worked Example',
+        definitions: [], tables: [],
+        formulas: exNotes.formulas || [],
+        procedures: (exNotes.procedures||[]).map(p => typeof p==='string'
+          ? {id:'proc_'+Math.random().toString(36).slice(2,8),title:'Step',appliesTo:'',steps:[p],notes:''}
+          : p),
+        commonMistakes: [],
+        summary: exNotes.summary || '',
+        questions: [],
+        processingStatus: 'ready',
+      };
+    }
+
+    // Detect subject category in parallel with structuring (saves ~1-2s)
+    const [subjectCategory, ] = await Promise.all([
+      this._detectSubjectCategory(ocrText, meta),
+      this._delay(50),
+    ]);
+    const notes = await this._generateFullStructure(ocrText, meta, subjectCategory, onProgress);
+    onProgress(3, 'Generating questions…');
+    const qData = await this._generateQuestions(notes, meta, subjectCategory);
+    onProgress(4, 'Building node…');
+    const questions = [
+      ...(qData.recall||[]).map(q => ({ id:KnowledgeNode._generateQuestionId(), type:'recall', question:q.question, answer:q.answer, accept: Array.isArray(q.accept) ? q.accept.filter(a => typeof a === 'string').slice(0, 6) : [] })),
+      ...(qData.application||[]).map(q => ({ id:KnowledgeNode._generateQuestionId(), type:'application', question:q.question, answer:q.answer })),
+    ];
+    return {
+      rawOCR: ocrText,
+      subjectCategory,
+      title:  notes.title || meta.chapter || 'Untitled',
+      definitions:    (notes.definitions||[]).map(d=>({term:d.term||'',examples:d.examples||'',description:d.description||''})),
+      tables:          notes.tables          || [],
+      formulas:        notes.formulas        || [],
+      procedures:     (notes.procedures||[]).map(p => typeof p==='string'
+        ? {id:'proc_'+Math.random().toString(36).slice(2,8),title:'Procedure',appliesTo:'',steps:[p],notes:''}
+        : p),
+      commonMistakes:  notes.commonMistakes  || [],
+      summary:         notes.summary         || '',
+      sectionOrder:    Array.isArray(notes.blocks) ? notes.blocks : [],
+      questions,
+      processingStatus:'ready',
+    };
+  },
+
+  /* ─── Subject category detection ──────────────────── */
+  async _detectSubjectCategory(text, meta) {
+    const hint = ((meta.subject||'') + ' ' + (meta.chapter||'')).toLowerCase();
+    // Fast keyword detection first — no API call needed
+    const rules = [
+      { cat:'accounting', words:['debit','credit','ledger','balance sheet','income statement','vat','tax','depreciation','journal','trial balance','assets','liabilities','equity','profit','loss','revenue','expense','accrual','invoice'] },
+      { cat:'law',        words:['section','act','statute','court','plaintiff','defendant','judgment','legislation','constitution','regulation','clause','contract','tort','criminal','civil','liability','jurisdiction'] },
+      { cat:'programming',words:['function','variable','class','array','loop','algorithm','database','api','html','css','javascript','python','sql','code','syntax','runtime','compiler','framework','library','object','method'] },
+      { cat:'science',    words:['hypothesis','experiment','element','molecule','reaction','force','energy','velocity','cell','organism','evolution','atom','bond','photosynthesis','nucleus','wave','current','voltage'] },
+      { cat:'medicine',   words:['diagnosis','symptom','treatment','patient','anatomy','pathology','pharmacology','dose','clinical','syndrome','anatomy','physiology','drug','therapy','prognosis','infection'] },
+      { cat:'maths',      words:['equation','derivative','integral','matrix','vector','probability','theorem','proof','function','limit','calculus','algebra','geometry','trigonometry','coefficient'] },
+      { cat:'history',    words:['century','war','empire','revolution','dynasty','colonialism','treaty','parliament','monarchy','republic','president','independence','reform','civilization'] },
+      { cat:'language',   words:['grammar','syntax','vocabulary','conjugation','tense','verb','noun','adjective','phonetics','semantics','discourse','linguistic','prose','poetry','literature'] },
+    ];
+    const combined = (hint + ' ' + text.slice(0, 800)).toLowerCase();
+    let best = null; let bestCount = 0;
+    for (const r of rules) {
+      const count = r.words.filter(w => combined.includes(w)).length;
+      if (count > bestCount) { bestCount = count; best = r.cat; }
+    }
+    if (bestCount >= 3) return best;
+    // Fall back to AI detection if keyword match is weak
+    try {
+      const prompt = 'Classify this academic content into ONE category. Content: "'
+        + text.slice(0,400) + '" Subject hint: "' + (meta.subject||'') + '"'
+        + '\nCategories: accounting, law, programming, science, medicine, maths, history, language, general'
+        + '\nOutput ONLY the single category word, nothing else.';
+      const raw = (await this._callWithFunction('chat', [{role:'user',content:prompt}], 20)).trim().toLowerCase();
+      const valid = ['accounting','law','programming','science','medicine','maths','history','language','general'];
+      return valid.includes(raw) ? raw : (best || 'general');
+    } catch { return best || 'general'; }
+  },
+
+  /* ═══════════════════════════════════════════════════════
+     IN-NODE AI ACTIONS
+  ═══════════════════════════════════════════════════════ */
+  async generateFromImage(base64Image, node, targetSection='auto') {
+    const hint = {
+      auto:      'Detect what this image contains and generate the most appropriate structure.',
+      definitions:'Extract all terms and definitions.',
+      table:     'Extract the tabular data and structure as a table.',
+      procedure: 'Extract the step-by-step procedure.',
+      formulas:  'Extract all formulas and equations.',
+    }[targetSection] || 'Generate the most appropriate structure.';
+
+    const ctx = LearnerContext.forNoteGeneration(node);
+    const prompt = ctx + '\n\n' + hint
+      + '\n\nOutput ONLY valid JSON (no markdown):\n{"definitions":[{"term":"","examples":"","description":""}],"tables":[{"title":"","columns":["Name","Type","Example"],"rows":[["","",""]]}],"formulas":[{"expression":"","description":"","constraints":""}],"procedures":[{"title":"","appliesTo":"","steps":[""],"notes":""}],"commonMistakes":[],"summary":""}'
+      + '\n\nOnly include items present in the image. Empty arrays for anything not shown.';
+
+    const msgs = [{ role:'user', content:[
+      { type:'image_url', image_url:{ url:'data:image/jpeg;base64,' + base64Image } },
+      { type:'text', text:prompt }
+    ]}];
+    const raw = await this._callWithFunction('noteProcessing', msgs, 3000);
+    return this._parseJSON(raw);
+  },
+
+  async restructureNotes(node) {
+    const ctx = LearnerContext.forNoteGeneration(node);
+    const prompt = ctx
+      + '\n\nReorganise the SOURCE MATERIAL above into the structured JSON format below.'
+      + '\nDO NOT add or remove content. Preserve every definition, formula, procedure, and value from the source.'
+      + '\n\nOutput ONLY valid JSON:'
+      + '\n{"title":"","definitions":[{"term":"","examples":"","description":""}],"tables":[{"title":"","columns":[],"rows":[[]]}],"formulas":[{"expression":"","description":"","constraints":""}],"procedures":[{"title":"","appliesTo":"","steps":[""],"notes":""}],"commonMistakes":[],"summary":""}';
+    const raw = await this._callWithFunction('restructure', [{role:'user',content:prompt}], 3000);
+    return this._parseJSON(raw);
+  },
+
+  /* ═══════════════════════════════════════════════════════
+     STUDY-FIT CHECK — does each block display well for focused
+     reading? Flags content (e.g. worked examples) that would be
+     clearer in a structured format, and asks before reshaping.
+  ═══════════════════════════════════════════════════════ */
+  async analyzeStudyFit(node) {
+    const preview = (b) => {
+      if (b.html) return String(b.html).replace(/<[^>]+>/g,' ').replace(/\s+/g,' ').trim().slice(0, 320);
+      if (b.steps) return 'Steps: ' + (b.steps||[]).join(' | ').slice(0, 320);
+      if (b.items) return (b.items||[]).map(i => i.term || i.expression || '').join('; ').slice(0, 320);
+      if (b.rows)  return 'Table with ' + (b.rows||[]).length + ' rows';
+      return '';
+    };
+    const blockList = (node.blocks || []).map(b =>
+      '[id=' + b.id + ' | type=' + b.type + ' | title=' + (b.title || '(none)') + '] ' + preview(b)
+    ).join('\n');
+
+    const prompt =
+      'You are reviewing a student\'s study notes, shown below as content blocks for the "Study / read & absorb" step.\n'
+      + 'Some blocks may be WORKED EXAMPLES or illustrative examples that read poorly as plain prose during focused study — they would be clearer in a structured format.\n\n'
+      + 'For each block, decide ONLY if it would display MORE CLEARLY in a different format. Flag a block only when switching genuinely helps:\n'
+      + '  - a worked example / step-by-step solution → "procedure" (numbered steps)\n'
+      + '  - a comparison or set of paired facts → "table"\n'
+      + '  - a list of question/answer facts to memorise → "flashcards"\n'
+      + '  - an important warning or key takeaway buried in prose → "callout"\n'
+      + 'Do NOT flag well-formed definitions, formulas, tables, diagrams, or short clean prose. Be conservative.\n\n'
+      + 'BLOCKS:\n' + blockList + '\n\n'
+      + 'Output ONLY valid JSON, at most 2 suggestions:\n'
+      + '{"suggestions":[{"blockId":"","suggestedType":"procedure|table|flashcards|callout","label":"short human label e.g. a worked example","reason":"one short sentence why it would read better"}]}\n'
+      + 'If nothing needs changing, return {"suggestions":[]}.';
+
+    const raw = await this._callWithFunction('chat', [{role:'user',content:prompt}], 700);
+    const data = this._parseJSON(raw);
+    return { suggestions: Array.isArray(data?.suggestions) ? data.suggestions : [] };
+  },
+
+  /** Convert ONE existing block into a different display format.
+   *  Returns a block object WITHOUT id (caller assigns id + position). */
+  async reshapeBlockTo(block, targetType, node) {
+    const schemas = {
+      procedure:  '{"type":"procedure","title":"","appliesTo":"","steps":["step 1","step 2"],"notes":""}',
+      table:      '{"type":"table","title":"","columns":["Col A","Col B"],"rows":[["",""]]}',
+      flashcards: '{"type":"flashcards","title":"","cards":[{"front":"question","back":"answer"}]}',
+      callout:    '{"type":"callout","title":"","tone":"tip","html":"<p>...</p>"}',
+    };
+    const schema = schemas[targetType] || schemas.procedure;
+
+    const source = JSON.stringify({
+      type: block.type, title: block.title || '',
+      html: block.html || '', steps: block.steps || undefined,
+      items: block.items || undefined, rows: block.rows || undefined,
+      columns: block.columns || undefined, notes: block.notes || undefined,
+    });
+
+    const prompt =
+      'Convert the SOURCE content block below into a "' + targetType + '" block.\n'
+      + 'Preserve every fact, number, and step from the source — do not invent or drop content. '
+      + 'Reorganise it so it reads clearly in the new format.\n\n'
+      + 'SOURCE BLOCK:\n' + source + '\n\n'
+      + 'Output ONLY valid JSON matching exactly this shape:\n' + schema;
+
+    const raw = await this._callWithFunction('chat', [{role:'user',content:prompt}], 1500);
+    const out = this._parseJSON(raw);
+    if (!out || typeof out !== 'object') throw new Error('Could not reshape this block.');
+    out.type = targetType; // force, in case the model echoed the old type
+    return out;
+  },
+
+  /* ═══════════════════════════════════════════════════════
+     UNDERSTANDING CHECK — assess-first teaching.
+     Generates questions specific to THIS node's content, then
+     evaluates the learner's answers gently against the source.
+  ═══════════════════════════════════════════════════════ */
+  async generateUnderstandingQuestions(node) {
+    const ctx = LearnerContext.forQuestionGen(node);
+    const prompt = ctx
+      + '\n\nYou are a warm teacher checking what the student already knows BEFORE they read the notes.'
+      + '\nGenerate exactly 3 short diagnostic questions about THIS specific topic, based only on the source material.'
+      + '\nThe questions should surface the most important things to understand — the core concept, when it applies, and the easiest thing to get wrong.'
+      + '\nMake them specific to the actual content, not generic. Each question one sentence.'
+      + '\n\nOutput ONLY valid JSON:\n{"questions":[{"q":"","hint":"a short placeholder example answer to guide them"}]}';
+    const raw = await this._callWithFunction('questionGen', [{ role:'user', content: prompt }], 700);
+    return this._parseJSON(raw);
+  },
+
+  async evaluateUnderstanding(node, qaPairs) {
+    const ctx = LearnerContext.forQuestionGen(node);
+    const prompt = ctx
+      + '\n\nYou are a warm, encouraging teacher. The student answered these diagnostic questions from memory BEFORE reading the notes.'
+      + '\nTheir answers: ' + JSON.stringify(qaPairs)
+      + '\n\nFor each answer, following these teaching rules:'
+      + '\n- Praise what they got right and their reasoning, specifically (not generic praise).'
+      + '\n- Gently note what is missing or slightly off — explain WHY, do not just say wrong.'
+      + '\n- Base everything ONLY on the source material. Never introduce outside facts.'
+      + '\n- Keep each piece of feedback to 2-3 short sentences. Simple language.'
+      + '\nThen identify the 1-3 things they should focus on most while reading.'
+      + '\n\nOutput ONLY valid JSON:\n{"perAnswer":[{"q":"","feedback":"","gotRight":"","toImprove":""}],"focusAreas":["",""],"encouragement":"one warm sentence"}';
+    const raw = await this._callWithFunction('grading', [{ role:'user', content: prompt }], 1200);
+    return this._parseJSON(raw);
+  },
+
+  /** Find how this node connects to other nodes in the same subject.
+   *  Given the current node's source and a list of {id,title,summary} for
+   *  sibling nodes, returns links the learner should be aware of. */
+  async findConnections(node, otherNodes) {
+    if (!otherNodes.length) return { connections: [] };
+    const ctx = LearnerContext.forNode(node, { includeWeakness: false, includeHistory: false, maxSourceChars: 3000 });
+    const list = otherNodes.map(n => '- [' + n.id + '] ' + n.title + (n.summary ? ': ' + n.summary.slice(0, 120) : '')).join('\n');
+    const prompt = ctx
+      + '\n\nHere are OTHER topics the student is studying in this subject:\n' + list
+      + '\n\nIdentify up to 4 genuine connections between THIS topic and the others — where this topic builds on, depends on, contrasts with, or is applied by another. Base links ONLY on the actual content; do not invent relationships.'
+      + '\nFor each, give the other topic id, a short relationship label (e.g. "builds on", "prerequisite for", "contrasts with"), and one plain sentence explaining the link.'
+      + '\n\nOutput ONLY valid JSON:\n{"connections":[{"id":"","title":"","relationship":"","explanation":""}]}';
+    const raw = await this._callWithFunction('chat', [{ role:'user', content: prompt }], 900);
+    return this._parseJSON(raw);
+  },
+
+  async generateExamQuestion(node) {
+    const ctx = LearnerContext.forQuestionGen(node);
+    const prompt = ctx
+      + '\n\nGenerate ONE realistic exam-style scenario question for this topic. Use only values, scenarios, and concepts that appear in the SOURCE MATERIAL above.'
+      + '\n\nOutput ONLY valid JSON:\n{"scenario":"Full scenario with specific values from source…","requirement":"Required: Calculate/Explain…","marks":10,"modelAnswer":"Full worked answer using only source content…","markingGuidance":["1 mark for…"]}';
+    const raw = await this._callWithFunction('examGeneration', [{role:'user',content:prompt}], 1500);
+    return this._parseJSON(raw);
+  },
+
+  async analyzeSessionGaps(sessionData, allNodes) {
+    const sessionCtx = LearnerContext.forSession();
+    const prompt = sessionCtx
+      + '\n\nThis session\'s data: ' + JSON.stringify(sessionData)
+      + '\n\nAnalyse what happened. Reference real node names from the learner overview above.'
+      + '\n\nOutput ONLY valid JSON:\n{"sessionSummary":"","strongAreas":[],"weakAreas":[],"nextSessionFocus":[],"examReadiness":"68%","dailyRecommendation":"45 min/day"}';
+    const raw = await this._callWithFunction('gapAnalysis', [{role:'user',content:prompt}], 600);
+    return this._parseJSON(raw);
+  },
+
+  async generateLecture(node) {
+    const ctx = LearnerContext.forGuidedStudy(node);
+    const prompt = ctx
+      + '\n\nYou are a professional audiobook narrator and university lecturer. Write a lecture script (800-1200 words) using ONLY the SOURCE MATERIAL above.'
+      + '\n\nWriting style for natural narration:'
+      + '\n- Write in clear, complete sentences of moderate length. Avoid very long run-on sentences.'
+      + '\n- Use short paragraphs (2-4 sentences each), separated by a blank line. Each paragraph covers one idea.'
+      + '\n- Use natural spoken transitions ("Now,", "Next,", "Here\'s the key part,").'
+      + '\n- Punctuate carefully — commas where a speaker would pause, full stops at every idea boundary.'
+      + '\n- Conversational and warm, like reading a great textbook aloud to one student.'
+      + '\n- End with three review questions whose answers are in the source.'
+      + '\n\nDo NOT introduce facts, examples, or explanations not present in the source.'
+      + '\nDo NOT use markdown, bullet points, or headers — write flowing prose meant to be read aloud.'
+      + '\n\nLecture:';
+    return await this._callWithFunction('lecture', [{role:'user',content:prompt}], 2000);
+  },
+
+  /** Slide-format lecture: structured JSON of teaching slides, drawn ONLY from
+   *  the source material. Each slide is one idea: a title, a few bullet points,
+   *  and a short spoken explanation meant to be read aloud. Activity slides are
+   *  interleaved as break points where the learner does something. */
+  async generateLectureSlides(node) {
+    const ctx = LearnerContext.forGuidedStudy(node);
+    const prompt = ctx
+      + '\n\nYou are a university lecturer building a slide deck to teach this topic, using ONLY the SOURCE MATERIAL above.'
+      + '\n\nBreak the material into a logical sequence of slides (aim for 5-10 teaching slides, more only if the source is large). There are TWO kinds of slide:'
+      + '\n\n1. A TEACHING slide ("kind":"teach") covers ONE idea and has:'
+      + '\n   - "title": a short slide heading (3-7 words).'
+      + '\n   - "bullets": 2-4 concise bullet points (each a short phrase, the key facts for this slide).'
+      + '\n   - "explanation": 2-4 sentences a lecturer would SAY aloud to explain this slide in plain, warm language. Complete sentences, well punctuated for natural narration.'
+      + '\n\n2. An ACTIVITY slide ("kind":"activity") is a BREAK POINT where the learner does something before continuing:'
+      + '\n   - "title": a short heading like "Your turn" or "Quick check".'
+      + '\n   - "prompt": a clear question or short task the learner answers, based on what the PRECEDING slides just taught.'
+      + '\n   - "answer": the correct/model answer, taken from the source — used to give the learner feedback.'
+      + '\n   - "activityType": one of "recall" (state a fact/definition), "apply" (work a small problem/scenario), or "reflect" (explain in their own words).'
+      + '\n\nSTRUCTURE: After every 2-3 teaching slides, insert ONE activity slide that checks what was just taught. Include a final activity near the end that pulls the topic together. So the deck flows: teach, teach, activity, teach, teach, activity, …'
+      + '\n\nRULES:'
+      + '\n- Use ONLY facts, definitions, formulas, and examples present in the source. Never add outside knowledge. Activity answers must be supported by the source.'
+      + '\n- Cover the whole topic across the teaching slides — do not skip source content.'
+      + '\n- The first slide should orient the learner; a teaching slide near the end should summarise the key takeaways.'
+      + '\n- Bullets are for the eye; the explanation is for the ear. Do not just repeat the bullets verbatim in the explanation.'
+      + '\n\nOutput ONLY valid JSON in exactly this shape (no markdown, no prose, no code fences):'
+      + '\n{"slides":[{"kind":"teach","title":"","bullets":["",""],"explanation":""},{"kind":"activity","title":"","prompt":"","answer":"","activityType":"recall"}]}';
+    // slideGen is a JSON-mode function, so the model is instructed to return raw
+    // JSON on every provider path. Retry once if the first response won't parse.
+    let raw = await this._callWithFunction('slideGen', [{role:'user',content:prompt}], 4000);
+    try {
+      return this._normalizeSlides(this._parseJSON(raw));
+    } catch (e) {
+      raw = await this._callWithFunction('slideGen', [
+        {role:'user', content: prompt},
+        {role:'assistant', content: raw},
+        {role:'user', content: 'That was not valid JSON. Reply with ONLY the JSON object — start with { and end with } — no prose, no markdown, no code fences.'},
+      ], 4000);
+      return this._normalizeSlides(this._parseJSON(raw));
+    }
+  },
+
+  /** Validate + clean a raw {slides:[...]} object into safe slide records.
+   *  Handles both teaching slides and activity (break-point) slides.
+   *  Pure and synchronous so it can be unit-tested. Throws if nothing usable. */
+  _normalizeSlides(data) {
+    const slides = Array.isArray(data?.slides) ? data.slides : [];
+    const clean = slides.map(s => {
+      if (s && s.kind === 'activity') {
+        return {
+          kind: 'activity',
+          title: String(s.title || '').trim() || 'Your turn',
+          prompt: String(s.prompt || s.question || '').trim(),
+          answer: String(s.answer || '').trim(),
+          activityType: ['recall','apply','reflect'].includes(s.activityType) ? s.activityType : 'recall',
+        };
+      }
+      return {
+        kind: 'teach',
+        title: String(s?.title || '').trim() || 'Untitled slide',
+        bullets: Array.isArray(s?.bullets) ? s.bullets.map(b => String(b || '').trim()).filter(Boolean).slice(0, 6) : [],
+        explanation: String(s?.explanation || '').trim(),
+      };
+    }).filter(s => s.kind === 'activity' ? !!s.prompt : (s.bullets.length || s.explanation));
+    if (!clean.length) throw new Error('The AI did not return any usable slides. Try again.');
+    return clean;
+  },
+
+  /* ═══════════════════════════════════════════════════════
+     REACTIVE RESHAPING — called automatically when a learner
+     struggles with a question during review/practice. Produces
+     a simpler breakdown plus an easier follow-up question, which
+     the app injects into the node as a scaffold block.
+  ═══════════════════════════════════════════════════════ */
+  async generateScaffold(node, question) {
+    const ctx = LearnerContext.forReviewCard(node, question);
+    const prompt = ctx
+      + '\n\nThe student is STRUGGLING with this question. Build a scaffold to help them understand.'
+      + '\n\nWrite a SIMPLER breakdown using ONLY content from the source: 3-4 short plain-language sentences, ideally with a concrete analogy drawn from the source material. Then ONE easier, scaffolded practice question with its answer (also from source).'
+      + '\n\nOutput ONLY valid JSON:\n{"scaffold":"the simpler breakdown","easierQuestion":{"question":"","answer":""}}';
+    const raw = await this._callWithFunction('gapAnalysis', [{ role: 'user', content: prompt }], 700);
+    return this._parseJSON(raw);
+  },
+
+  /* ═══════════════════════════════════════════════════════
+     AI DIRECTOR — the AI takes the wheel. It evaluates the
+     learner across all nodes and DICTATES a coordinated set of
+     changes: per-node note method + learner profile + which
+     blocks to emphasise, an overall study method, and study-plan
+     guidance. Returns a structured directive the app applies.
+  ═══════════════════════════════════════════════════════ */
+  /** Study coach — answers questions about HOW the learner is studying
+   *  (where to start, what's weak, what the plan is), using the full
+   *  cross-node brain. Read-only: it advises, it doesn't change settings. */
+  async studyCoach(question, history = [], exampleContext = null, tutorContext = null, resourceContext = null) {
+    const ctx = LearnerContext.forSession();
+    const toolkit =
+      '\n\nYou also have a toolkit of proven techniques to draw on WHEN the question calls for it (do not dump the whole list — pick what fits, and tie it to their actual situation):'
+      + '\n\nLEARNING & MEMORY:'
+      + '\n- Active recall: test yourself from memory instead of re-reading. In this app: use the Review tab and the Recall step in Guided Study. You can also use the AI Lecture slideshow (tap the Study tab on any topic — it generates slides with narration and can be presented full-screen or played automatically).'
+      + '\n- Spaced repetition: review just before you would forget; revisit weak cards more often. The Review tab schedules this automatically.'
+      + '\n- The Feynman technique: explain a topic in plain words as if teaching it; the gaps you hit are what to study.'
+      + '\n- Interleaving: mix related topics in a session rather than blocking one for hours — better for telling similar ideas apart (useful for accounting where formats look alike).'
+      + '\n- Worked-example study: for accounting, study a full solved example, then redo it covered-up before attempting a new one.'
+      + '\nTIME MANAGEMENT:'
+      + '\n- Pomodoro: 25 min focused, 5 min break; longer break every 4 rounds. Good for starting when motivation is low.'
+      + '\n- Time-blocking: assign topics to specific slots so decisions are made in advance.'
+      + '\n- Eat-the-frog: do the hardest/most-dreaded topic first while energy is highest.'
+      + '\n- 2-minute start: commit to just 2 minutes; starting is the hard part.'
+      + '\nSTRESS & WELLBEING:'
+      + '\n- Box breathing (4-4-4-4) or slow exhales to settle pre-exam nerves.'
+      + '\n- Reframe: some arousal sharpens performance; "I am prepared" beats "I must not fail".'
+      + '\n- Protect sleep before an exam — cramming past exhaustion loses more than it gains. No all-nighters.'
+      + '\n- Break overwhelm into the single next small action rather than the whole mountain.'
+      + '\nEXAM TECHNIQUE:'
+      + '\n- Skim the paper, do easiest marks first, watch mark allocations for time-per-question.'
+      + '\n- For accounting: lay out the format first (account/statement headings), then fill figures.'
+      + '\n- Practise under timed, closed-book conditions before the exam, not just open review.';
+    let streakLine = '';
+    try {
+      if (typeof StreakTracker !== 'undefined') {
+        const st = StreakTracker.getStats();
+        const studiedToday = st.lastDate === new Date().toISOString().slice(0, 10);
+        streakLine = '\n\nSTREAK: ' + st.streak + '-day streak (longest ' + st.longest + '). They have ' + (studiedToday ? 'already studied today' : 'NOT studied yet today') + '.'
+          + '\nIf they have not studied today and it fits the conversation, you may gently note that one small session keeps the streak alive — but never guilt-trip, and do not bring it up every turn.';
+      }
+    } catch {}
+    const sys = ctx
+      + ((typeof CoachFacts !== 'undefined') ? CoachFacts.block() : '')
+      + '\n\nCURRENT DATE & TIME on the student\'s device: ' + this._nowContext() + '.'
+      + '\nUse this to gauge urgency against any exam date, to frame what is due today, and to fit suggestions to the time of day (e.g. a shorter recall-focused session late at night). It is context for better advice only — do NOT comment on the time, the day, or tell them to rest/sleep unless they raise it themselves.'
+      + streakLine
+      + '\n\nYou are the student\'s personal study coach. You can see their whole library: every topic, mastery level, weak spots, study history, and plan.'
+      + '\nAnswer questions about HOW they should study — where to start, what to prioritise, what they keep getting wrong, how to manage time, and how to handle stress.'
+      + '\n\nAPP FEATURES (always current — read from AppFeatures.js):\n'
+      + (typeof AppFeatures !== 'undefined'
+          ? AppFeatures.map(f =>
+              '- ' + f.name + ' [' + f.where + ']: ' + f.what
+              + (f.coachTip ? ' Coach tip: ' + f.coachTip : '')
+            ).join('\n')
+          : '(feature list unavailable)')
+      + toolkit
+      + '\n\nBe specific and reference their actual topics, numbers, and weak areas. When you give a technique, briefly say how to apply it to THEIR situation, and point to the app feature that helps where relevant. Be warm and direct. Keep replies SHORT — at most 2-3 short paragraphs or 4-5 brief bullet-style points, and always finish your final sentence. Do not pad. A complete short answer is far better than a long one that gets cut off.'
+      + '\nFORMATTING: Write in plain text suitable for a phone chat bubble. Do NOT use LaTeX or math delimiters ($$, \\frac, \\text, \\times) — write maths in plain words and symbols, e.g. "R414 000 / 1.15 = R360 000" and "R360 000 x 10% = R36 000". Do NOT use markdown tables (no | pipes |), markdown headers (no ##), or HTML tags (no <br/>). For step layouts, use short labelled lines or simple numbered steps. Keep figures readable in prose.'
+      + '\nYou mainly advise. You may also PROPOSE an action (see below) which the student must confirm before anything happens — you never change things directly or silently.'
+      + '\nNever invent topics or numbers not in the data above. You are not a medical professional; for serious or persistent distress, gently suggest they reach out to a person they trust or a campus counsellor.'
+      + '\n\nACTIONS: if (and only if) the student clearly wants you to DO something you are able to do, you may propose ONE action for them to confirm. Append it on the VERY LAST line, alone, in this exact format:'
+      + '\n[[ACTION:startGuided|node=EXACT NODE TITLE]] — begin a guided study session at that topic'
+      + '\n[[ACTION:openExamples|node=EXACT NODE TITLE]] — open that topic\u2019s Examples tab in the Library so they can work through its worked examples'
+      + '\n[[ACTION:teachExample|node=EXACT NODE TITLE]] — pull up that topic\u2019s worked example and teach it step by step right here in the chat'
+      + '\n[[ACTION:openReview]] — open the Review tab'
+      + '\n[[ACTION:openLibrary]] — open the Library'
+      + '\n[[ACTION:openStudyPlan]] — open the Study Plan tab so they can view or create a study plan'
+      + '\n[[ACTION:tutorQuestions|node=EXACT NODE TITLE]] — start SOCRATIC TUTORING through that topic’s practice questions right here in the chat. Use this when the student wants to be walked/tutored through their uploaded questions rather than just drilled or given answers.'
+      + '\n[[ACTION:studyNode|node=EXACT NODE TITLE]] — pivot into RESOURCE MODE on that topic: its full saved material is loaded into this chat (no re-upload) so you can explain its concepts, build summaries, or quiz from it directly.'
+      + '\n[[ACTION:compileQuestions|node=EXACT NODE TITLE]] — programmatically build a linked Revision Questions topic from that topic’s saved material, ready to drill or be tutored through. Use when the student wants a question set made from their existing notes.'
+      + '\n[[ACTION:runDirector]] — trigger a full AI assessment (the Director) that reshapes the student\'s entire study approach based on their current evidence. Use this when they ask for a deep evaluation or feel lost.'
+      + '\n[[ACTION:setLoad|level=light|reason=SHORT REASON]] — set how heavy THIS study session should be. Levels: light (tired/busy/short on time — fewer cards, focused), normal (default), deep (energised/free time — more cards, draws in any deferred backlog). CRITICAL: never assume the level from their mood. CONFIRM first in your reply — e.g. ask \u201cWant me to keep tonight light, or push through?\u201d — and only append this action once they have actually chosen. The student owns this lever, not you. Skipped work on a light day is not lost — review cards stay due and plan tasks roll forward.'
+      + '\nRules for actions: only use a node title that appears in the data above; propose at most one; never propose an action they did not ask for; if they are only asking for advice, do NOT append an action. Write your normal helpful answer first, THEN the action line if warranted.'
+      + '\n\nINTENT ROUTING — match your operating mode to what the student is trying to do:'
+      + '\n- GUIDED/TUTOR intent ("tutor me through these questions", "walk me through my revision questions", "help me work through this paper"): propose [[ACTION:tutorQuestions|node=...]] for the matching topic. Once tutoring is active you will receive the current question in a SOCRATIC TUTORING MODE block — follow its rules strictly.'
+      + '\n- RESOURCE/STUDY intent (asking about their notes, "summarise this topic", "explain X", "help me understand my Gross Income notes"): propose [[ACTION:studyNode|node=...]] to load that topic\'s full saved material into the chat, then work from it — summarise it, explain the core concepts in plain language, or quiz them with short active-recall questions drawn from it. Once resource mode is active you will receive the material in a RESOURCE MODE block.'
+      + '\n- COMPILE intent ("make me practice questions from my notes", "turn this topic into revision questions"): propose [[ACTION:compileQuestions|node=...]] — it builds a linked Revision Questions topic from the saved material programmatically.'
+      + '\n\nMEMORY — RECORDING DURABLE FACTS: when the student states a STABLE fact about their situation, record it by appending a hidden line (never shown to them) in this exact format, one per fact:'
+      + '\n[[FACT: key = value]]'
+      + '\nRecord things that stay true and that you would otherwise have to ask for again, for example:'
+      + '\n[[FACT: exam dates = first week of December, all subjects]]'
+      + '\n[[FACT: daily study time = 30 min morning + 30 min evening on weekdays, 1-2 hours weekend]]'
+      + '\n[[FACT: subjects = Financial Statements, Cost & Management Accounting, Income Tax Returns, Business Law & Accounting Control (4 total)]]'
+      + '\n[[FACT: work schedule = works Monday to Friday, studies around work]]'
+      + '\n[[FACT: assessments = 2 tests + 3 assignments per subject, all due last week of November, must pass to sit exams]]'
+      + '\n[[FACT: study strategy = scan revision questions per subject in order, drill them, then scan source material only for the gaps]]'
+      + '\nRULES: use a SHORT stable key (exam dates, daily study time, subjects, work schedule, study strategy, subject order…). Reuse the SAME key when the student corrects something so the correction REPLACES the old value — never invent a second key for the same thing. Record only what the student actually said, never your own suggestions or assumptions. Do not re-record a fact that is already in the CONFIRMED FACTS block unchanged. Omit these lines entirely when nothing new or corrected was stated.'
+      + '\nCRITICAL: never ask the student for information already in the CONFIRMED FACTS block or clearly visible in the conversation above. If you genuinely need one missing detail, ask ONLY for that one, and acknowledge what you already know.'
+      + '\nSIGNAL: After your answer (and action if any), append ONE final line in this exact format — this is for internal memory, never shown to the student:'
+      + '\n[[SIGNAL:one sentence — what this student seems confused about, worried about, or needs, based on their question. e.g. "Student confused about VAT output tax distinction." or "Student anxious about exam time management." or "Student asked about Gross Income deductions — seems to understand basics." Be specific, name topics.]]'
+      + '\nABOUT EXAMPLES: In normal turns you see only example TITLES, not their full content, so do not invent figures. But you CAN teach an example: if the student wants to work through one, propose [[ACTION:teachExample|node=...]] — confirming it loads that example\u2019s full saved content into the chat so you can walk through it step by step. Or propose [[ACTION:openExamples|node=...]] to open the topic\u2019s Examples tab in the Library. Prefer teachExample when they want you to explain an example, openExamples when they just want to find and read it themselves.';
+    // Pass the large system prompt separately so Claude can cache it.
+    // The user message contains only the question + recent history (changes every turn).
+    // The window must be deep enough that a planning conversation (exam dates,
+    // available time, subject list) does not roll off and get re-asked — that
+    // used to happen after only two exchanges. Depth is bounded by CHARACTERS,
+    // not just turn count, so long replies cannot blow the token budget.
+    const histDepth  = (exampleContext || tutorContext || resourceContext) ? -30 : -40;
+    const HIST_CHARS = 14000;
+    const recent = history.slice(histDepth);
+    // Keep the most recent turns whole, trimming from the OLD end if too long.
+    let used = 0, start = recent.length;
+    for (let i = recent.length - 1; i >= 0; i--) {
+      const len = (recent[i] && recent[i].text ? String(recent[i].text).length : 0) + 10;
+      if (used + len > HIST_CHARS) break;
+      used += len; start = i;
+    }
+    const shown = recent.slice(start);
+    const dropped = history.length - shown.length;
+    const userMsg = 'The student asks: "' + question + '"'
+      + (shown.length
+          ? '\n\nConversation so far'
+            + (dropped > 0 ? ' (' + dropped + ' earlier message(s) not shown — rely on the CONFIRMED FACTS block for those)' : '')
+            + ':\n'
+            + shown.map(h => (h.role === 'user' ? 'Student: ' : 'Coach: ') + h.text).join('\n')
+          : '');
+    const messages = [{ role: 'user', content: userMsg }];
+    let cap = 1100;
+    if (exampleContext) {
+      messages[0].content += '\n\nThe student is working through this specific worked example from their own material. '
+        + 'Teach directly from it — explain the method step by step, reference the actual figures, and after explaining, prompt them to redo it covered-up.\n\n'
+        + exampleContext;
+      cap = 1500;
+    }
+    if (resourceContext) {
+      messages[0].content += '\n\n' + resourceContext
+        + '\n\nRESOURCE MODE — RULES:'
+        + '\n1. Work ONLY from the saved material above for topic-specific facts — never invent content that is not there.'
+        + '\n2. Explain concepts plainly, build summaries on request, and quiz with short active-recall questions drawn from this material.'
+        + '\n3. If the student wants a permanent practice set, propose [[ACTION:compileQuestions|node=' + '...' + ']] with this topic\'s exact title.'
+        + '\n4. If something they ask about is NOT in the material, say so plainly before answering from general knowledge.';
+      cap = 1500;
+    }
+    if (tutorContext) {
+      messages[0].content += '\n\n' + tutorContext
+        + '\n\nSOCRATIC TUTORING MODE — RULES (follow strictly):'
+        + '\n1. NEVER give the final answer outright. The model answer above is for YOUR eyes only — use it to steer, verify the student\'s work, and know where the question is going.'
+        + '\n2. Break the question into micro-steps. On the FIRST turn for a question: briefly explain the overall strategy (what kind of question this is and the plan of attack), then give ONLY the first micro-step and ask the student to attempt it.'
+        + '\n3. ONE micro-step per reply. End every reply with a direct prompt for the student to do that step.'
+        + '\n4. When the student attempts a step: confirm what they got right, correct gently what they got wrong (showing why), then move to the NEXT micro-step.'
+        + '\n5. If the student is stuck, give a nudge or a smaller sub-step — not the answer. If they explicitly give up on a step after trying, reveal just that step, then continue.'
+        + '\n6. When all steps are done, recap the full method in 2-3 lines, confirm the final answer, and tell them to tap "Next question" to continue.'
+        + '\n7. Do not propose [[ACTION:...]] lines while tutoring. Keep the [[SIGNAL:...]] line.';
+      cap = 1500;
+    }
+    return await this._callClaudeWithCache(sys, messages, cap);
+  },
+
+  async directLearning(nodes, opts = {}) {
+    const profile = opts.statedLevel || 'unknown';
+    const global  = opts.globalState || {};
+    // Question-driven = an imported revision-question bank with no real notes
+    // (same heuristic GuidedView uses to shorten its session for these nodes).
+    const isQDriven = n => !!(n.questions || []).length
+      && !((n.definitions||[]).length || (n.tables||[]).length || (n.formulas||[]).length
+        || (n.procedures||[]).length || (n.blocks||[]).length || (n.workedExamples||[]).length
+        || (n.summary||'').trim().length);
+    const evidence = nodes.map(n => {
+      const ratings    = (n.questions || []).flatMap(q => q._perf?.attempts || []);
+      const avgRating  = ratings.length ? (ratings.reduce((a, b) => a + b, 0) / ratings.length).toFixed(1) : 'none';
+      const lastAct    = LearnerMemory.getNodeActivitySummary(n);
+      const weakQs     = LearnerMemory.getWeakQuestionsText(n);
+      const exCount = (n.workedExamples || []).length;
+      return `- "${n.title}" (${n.subject || 'general'}) — mastery ${n.masteryScore}%, ${n.questions?.length || 0} questions, ${n.dueQuestions?.().length || 0} due, reviews ${n.reviewCount || 0}, avg self-rating ${avgRating}/4, profile "${n.learnerProfile || 'college'}"${isQDriven(n) ? ', QUESTION-DRIVEN (imported revision-question bank, no notes)' : ''}${exCount ? ', ' + exCount + ' worked example(s) saved' : ''}${lastAct ? ', last session: "' + lastAct + '"' : ''}${weakQs ? ', struggles: ' + weakQs.replace(/\n/g,'; ') : ''}`;
+    }).join('\n');
+
+    const globalSummary = global.totalSessions
+      ? `\nLEARNER HISTORY: ${global.totalSessions} total sessions. Last studied: ${global.lastStudied ? new Date(global.lastStudied).toLocaleDateString() : 'unknown'}.`
+      : '';
+
+    // Build plan block — same detail level the Coach receives via LearnerContext
+    const pc = opts.planContext;
+    const planSummary = pc
+      ? `\nSTUDY PLAN: "${pc.title}"${pc.daysToExam !== null ? ` — exam in ${pc.daysToExam} day${pc.daysToExam === 1 ? '' : 's'}` : ''}`
+        + (pc.dailyMinutes ? ` — ${pc.dailyMinutes} min/day budgeted` : '')
+        + (pc.progressFraction ? ` — progress: ${pc.progressFraction} tasks done (${pc.progressPct}%)` : '')
+        + (pc.todayTasks?.length
+            ? `\nToday's scheduled tasks: ${pc.todayTasks.join(', ')}`
+            : `\nNo tasks scheduled for today.`)
+      : opts.daysToExam !== null && opts.daysToExam !== undefined
+        ? `\nDays to exam: ${opts.daysToExam} (no study plan set)`
+        : `\nNo exam date or study plan set.`;
+
+    // Past exam papers: hard evidence of what the examiner actually tests.
+    const examBlock = (() => {
+      try {
+        const subs = [...new Set(nodes.map(n => n.subject).filter(Boolean))];
+        const lines = [];
+        for (const s of subs) {
+          const raw = localStorage.getItem('kn_exam_style_' + s.toLowerCase().replace(/\s+/g, '_'));
+          if (!raw) continue;
+          const papers = (JSON.parse(raw).papers || []);
+          if (!papers.length) continue;
+          const topics = [...new Set(papers.flatMap(p => (p.analysis && p.analysis.topicAreas) || []))].slice(0, 12);
+          const types  = [...new Set(papers.flatMap(p => (p.analysis && p.analysis.questionTypes) || []))].slice(0, 8);
+          lines.push('- ' + s + ': ' + papers.length + ' past paper(s) analysed. Examiner topic areas: '
+            + (topics.join(', ') || 'n/a') + '. Question types: ' + (types.join(', ') || 'n/a') + '.');
+        }
+        return lines.length
+          ? '\nPAST EXAM PAPER EVIDENCE (what the examiner actually tests — weight urgency toward low-mastery topics that appear here):\n' + lines.join('\n')
+          : '';
+      } catch (e) { return ''; }
+    })();
+
+    const methods = '"standard" (definitions/formulas/blocks), "cornell" (cue/notes/summary — good for lectures), "outline" (nested hierarchy — good for structured theory), "feynman" (explain-it-simply — good for concepts you struggle to articulate)';
+    const profiles = '"primary", "high", "college", "pro"';
+
+    // Include shared memory so Director sees what Coach recently learned about this student
+    const sharedMemory = (typeof LearnerState !== 'undefined') ? LearnerState.toPromptBlock() : '';
+
+    const prompt =
+`You are the lead tutor and learning director inside a study app. You are given the learner's whole library with hard performance evidence INCLUDING cross-session history. Your job is to EVALUATE them and then DICTATE concrete changes — you decide, don't ask.
+
+Stated level (may be "unknown" — infer from evidence if so): ${profile}${globalSummary}${planSummary}${examBlock}${sharedMemory ? '\n\n' + sharedMemory : ''}
+
+TODAY on the learner's device: ${this._nowContext()}. Use this together with the days-to-exam figure to judge real urgency and pacing.
+
+LIBRARY & EVIDENCE (includes last session activity and struggle patterns):
+${evidence}
+
+Decide, per node, the single best note method from: ${methods}.
+Nodes marked QUESTION-DRIVEN are imported revision-question banks with NO notes: studying them means drilling their own questions (Guided Study adapts to this automatically, and misses are listed under the Mastery tab's "Review in your textbook"). For these, keep noteMethod "standard", never tell the learner to re-read notes that don't exist, and treat drilling + textbook follow-up as their study method. If the learner's whole library is question-driven, their strategy IS question-first practice — direct them accordingly, and push "exam" (the Exam tab's Timed Quiz / AI Exam) once drilling accuracy is strong.
+Decide the best learner profile from: ${profiles} (match it to how they're actually performing, not just the stated level).
+Pick ONE overall study method to push right now: "review" (they're forgetting — spaced repetition), "guided" (shaky understanding — step-by-step), "blank-recall" (decent but passive — active recall), or "exam" (strong — test under pressure).
+Flag the nodes that need urgent attention based on struggle patterns and mastery.
+
+Output ONLY valid JSON:
+{
+  "assessment": "2-3 sentences: your honest read of where this learner is and why, referencing real node names, numbers, and session history",
+  "overallStudyMethod": "review|guided|blank-recall|exam",
+  "studyMethodWhy": "one sentence",
+  "nodeDirectives": [
+    { "title": "exact node title", "noteMethod": "standard|cornell|outline|feynman", "profile": "primary|high|college|pro", "why": "short reason referencing their actual performance", "urgent": true }
+  ],
+  "planGuidance": "2-3 sentences of study-plan direction. If a plan exists, reference today's scheduled tasks and plan progress directly. If behind on plan, say so. If a weak topic needs pulling forward, name it.",
+  "startNodeTitle": "the EXACT title of the single node the learner should begin with right now",
+  "firstAction": "one specific next step the learner should take right now"
+}`;
+
+    // 2500 tokens: at 50 nodes the output JSON needs ~1700 tokens. 1600 caused silent
+    // truncation of nodeDirectives — later nodes simply missing from the evaluation.
+    // 'director' function uses a stronger model than gapAnalysis — cross-topic reasoning
+    // needs more capacity than a simple gap scan. Falls back to gapAnalysis model if unset.
+    const raw = await this._callWithFunction('director', [{ role: 'user', content: prompt }], 2500);
+    return this._parseJSON(raw);
+  },
+
+  async checkAnswer(question, correctAnswer, studentAnswer, subject, node = null) {
+    // If we have the node, use full LearnerContext for source-faithful grading
+    const ctx = node ? LearnerContext.forReviewCard(node, { question, answer: correctAnswer })
+                     : LearnerContext._hardRules();
+    const prompt = ctx
+      + '\n\nGrade this student answer against the model answer and the source material.'
+      + '\nStudent answer: "' + studentAnswer + '"'
+      + '\nSubject: ' + (subject || 'general')
+      + '\n\nIMPORTANT: Mark based on whether the student\'s answer matches what the SOURCE MATERIAL says — not your own knowledge of the topic.'
+      + '\nIf the student gives a correct-sounding answer that contradicts the source, mark it partially correct and quote the source.'
+      + '\n\nOutput ONLY valid JSON: {"correct":true,"score":0,"feedback":"","keyPointsMissed":[]}';
+    const raw = await this._callWithFunction('grading', [{role:'user',content:prompt}], 500);
+    return this._parseJSON(raw);
+  },
+
+  /** Mark a whole exam paper in ONE call instead of one call per question.
+   *  items: [{ question, modelAnswer, studentAnswer, subject }] — returns an
+   *  array of {score, correct, feedback, keyPointsMissed} in the same order.
+   *  Throws on shape mismatch so callers can fall back to per-question grading. */
+  async gradeBatch(items) {
+    const list = items.map((it, i) =>
+      (i + 1) + '. Question: "' + it.question + '"'
+      + '\n   Model answer: "' + (it.modelAnswer || 'none given') + '"'
+      + '\n   Student answer: "' + it.studentAnswer + '"').join('\n\n');
+    const prompt = 'You are marking a student\'s exam paper (' + items.length + ' answers, subject: ' + (items[0]?.subject || 'general') + ').'
+      + '\nGrade EVERY numbered answer against its model answer. Judge CONCEPTUAL UNDERSTANDING, not exact wording:'
+      + '\n- Core idea correct (even informally phrased) → 80-100. Paraphrase of the model answer = full marks.'
+      + '\n- Partial understanding → 50-79 with encouragement on what was right.'
+      + '\n- Core concept missing or wrong → below 50.'
+      + '\nKeep each feedback to 1-2 warm, specific sentences.'
+      + '\nOutput ONLY raw JSON, no fences, one result per numbered item IN ORDER:'
+      + '\n{"results":[{"score":0,"correct":false,"feedback":"","keyPointsMissed":[]}]}'
+      + '\n\nTHE PAPER:\n' + list;
+    const raw = await this._callWithFunction('grading', [{ role: 'user', content: prompt }],
+      Math.min(4000, 150 * items.length + 200));
+    const parsed = this._parseJSON(raw);
+    const results = Array.isArray(parsed) ? parsed : (parsed.results || []);
+    if (!Array.isArray(results) || results.length !== items.length) throw new Error('Batch marking came back malformed.');
+    return results;
+  },
+
+  async gradeImageAnswer(imageBase64, studentAnswer, modelAnswer, subject) {
+    const prompt = 'Grade this answer for ' + subject + '.\nModel: ' + (modelAnswer||'none') + '\nStudent: ' + studentAnswer + '\n\nOutput ONLY valid JSON: {"score":0,"feedback":"","keyPointsMissed":[],"correct":false}';
+    const msgs = imageBase64 && this.supportsVision()
+      ? [{role:'user',content:[{type:'image_url',image_url:{url:'data:image/jpeg;base64,'+imageBase64}},{type:'text',text:prompt}]}]
+      : [{role:'user',content:prompt}];
+    const raw = await this._callWithFunction('grading', msgs, 400);
+    return this._parseJSON(raw);
+  },
+
+  /* ═══════════════════════════════════════════════════════
+     BLOCK PLANNER — the new adaptive core.
+     Given a topic + learner profile, the model returns an
+     ordered list of blocks. The renderer draws whatever it gets.
+  ═══════════════════════════════════════════════════════ */
+  async generateBlocks(topic, profile = 'college', node = null) {
+    const profileGuide = {
+      primary: 'a primary-school child (age 6-11). Explain every concept in the simplest possible words. Use everyday analogies, include the technical term in brackets. Use match games and flashcards alongside prose.',
+      high:    'a high-school student. Use plain language, define every technical term, give one real-world example per concept.',
+      college: 'a college/university student. Use precise academic language. Include technical terms with definitions.',
+      pro:     'a working professional. Be concise. Use industry terminology, surface practical implications and edge cases.',
+    }[profile] || 'a college student.';
+
+    // Build source text from node if available
+    const sourceText = node
+      ? [
+          node.rawOCR || '',
+          node.summary || '',
+          (node.definitions||[]).slice(0,8).map(d => d.term + ': ' + d.description).join('\n'),
+          (node.formulas||[]).slice(0,4).map(f => f.expression + ' — ' + f.description).join('\n'),
+          (node.procedures||[]).slice(0,2).flatMap(p => [p.title, ...(p.steps||[])]).join('\n'),
+        ].filter(Boolean).join('\n\n').slice(0, 5000)
+      : '';
+
+    const sourceConstraint = sourceText
+      ? 'SOURCE MATERIAL (use ONLY this — do not add facts from outside knowledge):\n---\n' + sourceText + '\n---\n\n'
+        + 'FAITHFULNESS RULE: Every definition, formula, procedure step, and fact in your blocks must be directly supported by the source material above. Do not add explanations, examples, or values not present in the source.\n\n'
+      : '';
+
+    const prompt =
+`${LearnerContext._hardRules()}
+
+You are an adaptive learning designer. Restructure the material for "${topic}" shaped for ${profileGuide}
+
+${sourceConstraint}Choose the BEST mix of blocks for THIS topic and THIS learner. Block types:
+
+- prose:      {"type":"prose","title":"","html":"explanatory HTML using <b> <code> <em>"}
+- callout:    {"type":"callout","title":"","tone":"tip|warn","html":""}
+- definition: {"type":"definition","title":"","items":[{"term":"","examples":"","description":""}]}
+- formula:    {"type":"formula","title":"","items":[{"expression":"","description":"","constraints":""}]}
+- table:      {"type":"table","title":"","columns":[],"rows":[[]]}
+- procedure:  {"type":"procedure","title":"","appliesTo":"","steps":[""],"notes":""}
+- code:       {"type":"code","title":"","lang":"sql|js","setup":"SQL to create+seed tables (sql only)","code":"starter code"}
+- calc:       {"type":"calc","title":"","resultLabel":"","inputs":[{"key":"x","label":"","default":0}],"formula":"x*2","breakdownSteps":[{"label":"","expr":"x*2"}]}
+- quiz:       {"type":"quiz","title":"","q":"","options":["",""],"answer":0,"fb":"why"}
+- cloze:      {"type":"cloze","title":"","text":"A sentence from the source with the key term written as {{term}}. Use 1-4 blanks. For synonyms use {{net|net amount}}."}
+- match:      {"type":"match","title":"","pairs":[["left","right"]]}
+- flashcards: {"type":"flashcards","title":"","cards":[{"front":"","back":""}]}
+- diagram:    {"type":"diagram","title":"","steps":["a","b","c"]}
+
+RULES:
+- 3 to 6 blocks ordered as a lesson flows.
+- Include at least one active-recall block (cloze or quiz) so the learner tests themselves, not just reads. Prefer cloze for definitions and key terms.
+- Only use information from the source material.
+- Output ONLY a JSON array of blocks. No markdown, no prose.
+
+JSON array:`;
+
+    const raw = await this._callWithFunction('noteProcessing', [{ role: 'user', content: prompt }], 3500);
+    let parsed;
+    try {
+      parsed = this._parseJSON(raw.trim().startsWith('[') ? '{"blocks":' + raw + '}' : raw);
+    } catch(e) {
+      throw new Error('AI returned invalid block data. Try regenerating again.');
+    }
+    const blocks = Array.isArray(parsed) ? parsed : (parsed.blocks || []);
+    if (!blocks.length) throw new Error('AI returned no blocks. Try regenerating again.');
+    return blocks;
+  },
+
+  /* ─── Internal: full structure generation ─── */
+  async _generateFullStructure(ocrText, meta, subjectCategory='general', onProgress=()=>{}) {
+    const detail      = {quick:'Be concise.',standard:'Be thorough.'}[meta.detail||'standard'] || 'Be thorough.';
+    const profileNote = this.profileContext(this._activeProfile || meta.profile || 'college');
+    const hardRules   = LearnerContext._hardRules();
+
+    const subjectGuide = {
+      accounting: 'Extract: T-accounts, debits/credits, formulas, journal entry formats, account types, financial statement items. Create tables for any account comparisons or classifications in the source.',
+      law:        'Extract: section numbers verbatim, legal definitions word-for-word, case names, requirements lists, exceptions and qualifications, procedural steps.',
+      programming:'Extract: syntax rules, function/method signatures, code examples exactly as written, algorithms, data structures, input/output rules.',
+      science:    'Extract: definitions with units, formulas exactly as written, experimental steps, measurements and values from the source.',
+      medicine:   'Extract: anatomical terms, drug names and dosages as written, diagnostic criteria lists, treatment protocol steps.',
+      maths:      'Extract: theorems verbatim, formulas exactly as written with all variable definitions, worked example steps and values.',
+      history:    'Extract: dates, event names, key figures, causes and consequences exactly as described in the source.',
+      language:   'Extract: grammar rules, vocabulary with definitions, conjugation tables, example sentences from the source.',
+      general:    'Extract all definitions, facts, formulas, procedures, and key points exactly as written.',
+    }[subjectCategory] || 'Extract all definitions, facts, formulas, procedures, and key points exactly as written.';
+
+    // ── PASS 1: strict verbatim extraction ──────────────────────────
+    const extractPrompt = hardRules + '\n\n'
+      + 'TASK: You are a transcription system. Extract EVERY piece of information from the source below. Do not stop early. Do not skip anything.\n\n'
+      + 'SUBJECT: ' + (meta.subject||'this subject') + '. CHAPTER: ' + (meta.chapter||'Unspecified') + '.\n'
+      + profileNote + '\n'
+      + 'EXTRACTION RULES FOR ' + (subjectCategory||'general').toUpperCase() + ':\n' + subjectGuide + '\n\n'
+      + 'COMPLETENESS IS THE MOST IMPORTANT RULE:\n'
+      + 'EVERY definition, formula, table, and procedure step in the source MUST appear in the output.\n'
+      + 'If you are running low on space, use shorter descriptions — but NEVER skip an item.\n'
+      + 'A missing item is a worse error than a slightly short description.\n\n'
+      + 'NON-NEGOTIABLE CONSTRAINTS:\n'
+      + '1. Every definition description must be a direct quote or close paraphrase from the source.\n'
+      + '2. Every formula must appear in the source — do not derive or infer formulas not written.\n'
+      + '3. Every procedure step must be taken from the source word-for-word.\n'
+      + '4. Table rows must contain only values that appear in the source.\n'
+      + '5. The summary must only contain points explicitly made in the source.\n'
+      + '6. If a field has nothing in the source, leave it as an empty array. Do NOT fill it.\n'
+      + '7. Common mistakes: only include if explicitly mentioned in the source.\n\n'
+      + 'Output ONLY this JSON (no markdown, no fences).\n'
+      + 'CRITICAL ORDERING: the "blocks" array must list content in the EXACT order it appears in the source — do not regroup or reorder. If the source goes definition, then procedure, then table, the blocks array must follow that same sequence. Each block: {"kind":"prose|definition|formula|procedure|table","ref":"matching title or term"}.\n'
+      + 'Procedures and tables are ordered first to prevent truncation:\n'
+      + '{"title":"","blocks":[{"kind":"","ref":""}],"procedures":[{"title":"","appliesTo":"","steps":[""],"notes":""}],'
+      + '"tables":[{"title":"","columns":[],"rows":[[]]}],'
+      + '"formulas":[{"expression":"","description":"","constraints":""}],'
+      + '"definitions":[{"term":"","examples":"comma-separated examples from source","description":""}],'
+      + '"commonMistakes":[],"summary":""}\n\n'
+      + 'SOURCE MATERIAL:\n---\n' + ocrText.slice(0, 12000) + '\n---\n\n'
+      + 'Respond with ONLY the JSON object starting with {';
+
+    const msgs = [{role:'user', content:extractPrompt}];
+    // Raised token limit — dense notes can easily exceed 4000 tokens
+    const raw  = await this._callWithFunction('noteProcessing', msgs, 6000);
+
+    let extracted;
+    try {
+      extracted = this._parseJSON(raw);
+    } catch(e) {
+      console.warn('JSON parse failed on first attempt, retrying extraction:', e.message);
+      try {
+        const start = raw.indexOf('{');
+        const end   = raw.lastIndexOf('}');
+        if (start !== -1 && end > start) extracted = this._parseJSON(raw.slice(start, end + 1));
+      } catch(e2) { /* fall through to clean fallback */ }
+    }
+
+    if (!extracted) {
+      const cleanSummary = raw
+        .replace(/```json[\s\S]*?```/gi, '')
+        .replace(/```[\s\S]*?```/gi, '')
+        .replace(/^\s*[\[{][\s\S]*[\]}]\s*$/m, '')
+        .replace(/\s+/g, ' ').trim().slice(0, 500);
+      return {
+        title: meta.chapter || meta.subject || 'Untitled',
+        definitions: [], tables: [], formulas: [],
+        procedures: [], commonMistakes: [],
+        summary: cleanSummary || 'Notes could not be fully processed. Try scanning again.',
+      };
+    }
+
+    // ── PASS 2: faithfulness check — FLAG only, never delete ────────
+    // Changed: Pass 2 no longer removes content. It only flags items that appear
+    // to be outside the source. Removing in Pass 2 was silently dropping
+    // legitimate content that was phrased differently from the OCR.
+    const hasContent = (extracted.definitions?.length || extracted.formulas?.length ||
+                        extracted.procedures?.length || extracted.tables?.length);
+    if (hasContent && ocrText.length > 200) {
+      onProgress(2, 'Checking faithfulness to source…');
+      try {
+        const checkPrompt =
+          'Check if this extraction added anything NOT in the source.\n\n'
+          + 'SOURCE:\n---\n' + ocrText.slice(0, 6000) + '\n---\n\n'
+          + 'EXTRACTION:\n' + JSON.stringify({
+              definitions: (extracted.definitions||[]).slice(0, 15),
+              formulas:    (extracted.formulas||[]).slice(0, 8),
+              procedures:  (extracted.procedures||[]).slice(0, 5),
+            }) + '\n\n'
+          + 'For each item: is it supported by the source (KEEP) or clearly invented (FLAG)?\n'
+          + 'If unsure, KEEP it. Only FLAG items that clearly do not appear in the source at all.\n'
+          + 'Do NOT flag items just because wording differs from source.\n'
+          + 'Output ONLY: {"flagged":[{"type":"definition|formula|procedure","term_or_title":"","reason":"one line"}]}\n'
+          + 'If nothing flagged: {"flagged":[]}\n\nJSON:';
+
+        const checkRaw = await this._callWithFunction('noteProcessing',
+          [{role:'user', content:checkPrompt}], 800);
+        const checked  = this._parseJSON(checkRaw);
+
+        // Store flags for visibility — but KEEP all extracted content
+        if (checked?.flagged?.length) {
+          extracted._faithfulnessFlags = checked.flagged;
+          console.info('[AIService] Faithfulness flags (content kept):', checked.flagged);
+        }
+      } catch(e) {
+        console.warn('[AIService] Faithfulness check failed, using raw extraction:', e.message);
+      }
+    }
+    return extracted;
+  },
+
+  async _generateQuestions(notes, meta, subjectCategory='general') {
+    // Load past exam style if available
+    const examKey = 'kn_exam_style_' + (meta.subject||'').toLowerCase().replace(/\s+/g,'_');
+    let examStyleNote = '';
+    try {
+      const stored = JSON.parse(localStorage.getItem(examKey) || '{"papers":[]}');
+      if (stored.papers?.length) {
+        const latest = stored.papers[stored.papers.length - 1];
+        const a = latest.analysis;
+        examStyleNote = '\n\nPAST EXAM STYLE for this subject: Question types: ' + (a.questionTypes||[]).join(', ')
+          + '. Mark pattern: ' + (a.markPattern||'') + '. Style: ' + (a.style||'')
+          + '. Generate questions in the same style and difficulty as this exam.';
+      }
+    } catch {}
+    const nr = meta.detail==='quick'?3:5;
+    const na = meta.detail==='quick'?2:3;
+    const qProfileNote = this.profileContext(this._activeProfile || meta.profile || 'college');
+    const hardRules = LearnerContext._hardRules();
+
+    const questionStyle = {
+      accounting: 'For recall: ask students to define terms, state rules, give formulas. For application: give a transaction scenario and ask them to journalise, calculate, or classify it.',
+      law:        'For recall: ask for definitions of legal terms, section numbers, requirements. For application: give a factual scenario and ask whether a rule applies and why.',
+      programming:'For recall: ask for syntax, what a function/method does, data type differences. For application: give a coding problem or buggy code and ask them to solve/fix it.',
+      science:    'For recall: ask for definitions, units, laws. For application: give a problem with numbers to calculate, or describe an experiment outcome.',
+      medicine:   'For recall: ask for anatomical terms, drug classes, diagnostic criteria. For application: give a patient case and ask for diagnosis or treatment.',
+      maths:      'For recall: ask for theorem statements, formula definitions. For application: give a numerical problem to solve step by step.',
+      general:    'Mix recall (definitions, key points) with application (scenarios, problem-solving).',
+    }[subjectCategory] || 'Mix recall (definitions, key points) with application (scenarios, problem-solving).';
+
+    const prompt = hardRules + '\n\nYou are an exam question writer. Your ONLY job is to write questions whose answers are directly and explicitly stated in the SOURCE MATERIAL below.\n\n'
+      + 'SUBJECT: ' + (meta.subject||'academic study') + '. ' + qProfileNote + '\n'
+      + 'Question style: ' + questionStyle + '\n'
+      + 'Generate exactly ' + nr + ' recall questions and ' + na + ' application questions.\n\n'
+      + 'STRICT RULES:\n'
+      + '1. Every question answer must be a direct quote or close paraphrase from the source — not from your own knowledge.\n'
+      + '2. Before writing each question, find the exact sentence or value in the source that answers it. If you cannot find it, do not write the question.\n'
+      + '3. For application questions: use only values, scenarios, and examples that appear in the source.\n'
+      + '4. CRITICAL — Data-dependent questions: If an application question asks the student to calculate, compute, or analyse using specific figures (e.g. from a financial statement, a table, or a dataset), you MUST include all the necessary data/figures directly in the question text itself. The student has no other way to access the data during practice. Example: instead of "Using Tuscany Dealers\' statement, calculate gross profit %", write "Tuscany Dealers had revenue of R450,000 and cost of sales of R270,000. Calculate the gross profit percentage." Never ask a calculation question that references data without including that data.\n'
+      + '5. Do NOT write questions testing knowledge that is not in the source.\n'
+      + '6. If the source has fewer facts than the requested question count, write fewer questions — quality over quantity.\n\n'
+      + 'Output ONLY raw JSON (no markdown, no fences):\n'
+      + '{"recall":[{"question":"","answer":"","accept":["2-4 short acceptable variants of the answer: key term alone, common abbreviation, symbol/formula form"]}],"application":[{"question":"","answer":""}]}'
+      + examStyleNote
+      + '\n\nSOURCE MATERIAL:\n' + JSON.stringify({
+          title:       notes.title,
+          definitions: (notes.definitions||[]).slice(0,12),
+          formulas:    (notes.formulas||[]).slice(0,6),
+          procedures:  (notes.procedures||[]).slice(0,4),
+          tables:      (notes.tables||[]).slice(0,4),
+          summary:     notes.summary,
+        })
+      + '\n\nRespond with ONLY the JSON object starting with {"recall":';
+    const msgs = [{role:'user', content:prompt}];
+    const raw = await this._callWithFunction('questionGen', msgs, 2500);
+    try {
+      return this._parseJSON(raw);
+    } catch(e) {
+      console.warn('Questions JSON failed, returning empty:', e.message);
+      return { recall: [], application: [] };
+    }
+  },
+
+  /* ─── Template rewriting: AI restructures content into chosen method ─── */
+  async rewriteAsTemplate(node, templateId) {
+    const ctx = LearnerContext.forNoteGeneration(node);
+    if (!ctx.includes('SOURCE MATERIAL')) throw new Error('No source content to rewrite.');
+
+    const subject = node.subject || 'this subject';
+    const title   = node.title || 'this topic';
+
+    if (templateId === 'cornell') {
+      const prompt = ctx
+        + '\n\nRestructure the SOURCE MATERIAL above into Cornell format for: "' + title + '" (' + subject + ').'
+        + '\n\nCornell format has 3 parts:'
+        + '\n- CUES: Short keywords, questions, and prompts (left column). One cue per key concept.'
+        + '\n- NOTES: Detailed explanations from the source (right column). Must match the cues.'
+        + '\n- SUMMARY: 3-4 sentences that capture the topic in plain language using only source content.'
+        + '\n\nOutput ONLY raw JSON: {"cues":"","notes":"","summary":""}';
+      const msgs = [{role:'user',content:prompt}];
+      const raw = await this._callWithFunction('restructure', msgs, 2000);
+      return { type:'cornell', data: this._parseJSON(raw) };
+
+    } else if (templateId === 'outline') {
+      const prompt = ctx
+        + '\n\nRestructure the SOURCE MATERIAL above into a hierarchical outline for: "' + title + '" (' + subject + ').'
+        + '\nOutline format: numbered main sections (1., 2., 3.) with lettered sub-points (a., b., c.) and details (i., ii.).'
+        + '\nUse ONLY content from the source. Where source is thin, reflect that honestly.'
+        + '\n\nOutput ONLY raw JSON: {"outline":"<the full numbered outline as plain text, use \\n for line breaks>"}';
+      const msgs = [{role:'user',content:prompt}];
+      const raw = await this._callWithFunction('restructure', msgs, 2000);
+      return { type:'outline', data: this._parseJSON(raw) };
+
+    } else if (templateId === 'feynman') {
+      const prompt = ctx
+        + '\n\nRestructure the SOURCE MATERIAL above into a Feynman explanation for: "' + title + '" (' + subject + ').'
+        + '\nFeynman format: explain the topic as if teaching a complete beginner. Use simple language and analogies drawn from source examples.'
+        + ' Then identify the gaps — the parts hard to explain simply (these are what to study more).'
+        + '\nBase the explanation ONLY on the source. Quote directly where uncertain.'
+        + '\n\nOutput ONLY raw JSON: {"explanation":"","analogies":"","gaps":"","keyTakeaway":""}';
+      const msgs = [{role:'user',content:prompt}];
+      const raw = await this._callWithFunction('restructure', msgs, 2000);
+      return { type:'feynman', data: this._parseJSON(raw) };
+    }
+
+    throw new Error('Unknown template: ' + templateId);
+  },
+
+  async _extractSingleImageText(base64, mediaType='image/jpeg') {
+    // Claude has a 5MB image limit — always resize to fit before sending
+    const safeBase64 = await this._resizeImageForClaude(base64, mediaType);
+    const msgs = [{role:'user',content:[
+      {type:'image_url',image_url:{url:'data:image/jpeg;base64,'+safeBase64}},
+      {type:'text',text:'You are an OCR system. Extract ALL text from this image EXACTLY as it appears — word for word, character for character. Do NOT interpret, summarise, correct, or add anything. Do NOT use your own knowledge. Do NOT wrap the output in JSON or code fences. Output ONLY the raw extracted text, preserving all numbers, formulas, tables, and formatting.'}
+    ]}];
+    return await this._callWithFunction('ocr', msgs, 3000);
+  },
+
+  /** Resize image to stay under Claude 5MB limit — maintains readability for OCR */
+  _resizeImageForClaude(base64, mediaType='image/jpeg') {
+    return new Promise((resolve) => {
+      const img = new Image();
+      img.onload = () => {
+        const canvas = document.createElement('canvas');
+        // Max 2000px on longest side — enough for clear text OCR
+        const MAX = 2000;
+        let w = img.width, h = img.height;
+        if (w > MAX || h > MAX) {
+          if (w > h) { h = Math.round(h * MAX / w); w = MAX; }
+          else       { w = Math.round(w * MAX / h); h = MAX; }
+        }
+        canvas.width = w; canvas.height = h;
+        canvas.getContext('2d').drawImage(img, 0, 0, w, h);
+        // Try quality 0.92 first, reduce only if still over 4MB
+        let quality = 0.92;
+        let result = canvas.toDataURL('image/jpeg', quality).split(',')[1];
+        while (result.length > 4000000 && quality > 0.5) {
+          quality -= 0.1;
+          result = canvas.toDataURL('image/jpeg', quality).split(',')[1];
+        }
+        resolve(result);
+      };
+      img.onerror = () => resolve(base64);
+      img.src = 'data:' + mediaType + ';base64,' + base64;
+    });
+  },
+
+  async _extractMultiPageText(base64Images, mediaTypes=[]) {
+    // Resize all images in parallel first
+    const resized = await Promise.all(
+      base64Images.map((b64, i) => this._resizeImageForClaude(b64, mediaTypes[i] || 'image/jpeg'))
+    );
+
+    // For 3 or fewer pages: send all in one request (fastest)
+    if (resized.length <= 3) {
+      const content = [
+        ...resized.map((b64,i) => [
+          {type:'text', text:'[Page '+(i+1)+' of '+resized.length+']'},
+          {type:'image_url', image_url:{url:'data:image/jpeg;base64,'+b64}},
+        ]).flat(),
+        {type:'text', text:'Extract all text from ALL pages in order. Mark page breaks with [PAGE BREAK]. Do NOT wrap the output in JSON or code fences. Output ONLY extracted text:'},
+      ];
+      return await this._callWithFunction('ocr', [{role:'user',content}], 6000);
+    }
+
+    // For 4+ pages: extract all pages in parallel (much faster than sequential)
+    const pageTexts = await Promise.all(
+      resized.map((b64, i) => this._callWithFunction('ocr', [{role:'user',content:[
+        {type:'image_url', image_url:{url:'data:image/jpeg;base64,'+b64}},
+        {type:'text', text:'Extract ALL text from this page exactly as it appears. Do NOT wrap the output in JSON or code fences. Output ONLY the extracted text.'}
+      ]}], 2000))
+    );
+
+    return pageTexts.join('\n\n[PAGE BREAK]\n\n');
+  },
+
+  /* ═══════════════════════════════════════════════════════
+     HTTP LAYER — routes to correct provider + model
+  ═══════════════════════════════════════════════════════ */
+
+  /** Main entry: call with a function name so correct model is selected */
+  async _callWithFunction(fn, messages, maxTokens=1000) {
+    // Managed-AI build: AI is gated behind an active subscription. Check the
+    // local entitlement hint first so we show the paywall instantly instead of
+    // making a request the server would reject with 402. (The proxy re-verifies.)
+    if (typeof AppConfig !== 'undefined' && AppConfig.MANAGED_ONLY
+        && typeof Paywall !== 'undefined' && !Paywall.isEntitled()) {
+      try { Paywall.show('Subscribe to use the AI study features.'); } catch (e) {}
+      const err = new Error('Subscription required to use AI.'); err.code = 'SUBSCRIPTION_REQUIRED'; throw err;
+    }
+    if (!this.hasApiKey()) throw new Error('No API key configured. Go to Settings → Configure AI.');
+
+    // JSON-producing functions
+    const jsonFunctions = ['noteProcessing','questionGen','grading','examGeneration','restructure','gapAnalysis','slideGen','director'];
+    const isJson = jsonFunctions.includes(fn);
+
+    // One attempt against whichever provider path is active.
+    const attempt = async () => {
+      // 1) Server proxy (owner's key) takes priority when deployed — zero user config.
+      if (this._proxyAvailable) {
+        return await this._callProxy(messages, maxTokens, isJson);
+      }
+      // 2) Bring-your-own-key paths.
+      const provider = this._providers[this._activeProvider];
+      if (provider?.isOpenRouter) {
+        return await this._callOpenRouter(messages, maxTokens, this._getModelForFunction(fn), isJson);
+      }
+      return await this._callDirect(messages, maxTokens, isJson);
+    };
+
+    // Retry transient failures (rate limits, timeouts, 5xx, flaky network)
+    // with exponential backoff. Without this a single 429 during a bulk
+    // import permanently drops whatever was being processed (e.g. worked
+    // examples, which are the last calls per node and most likely to hit it).
+    const backoffs = [800, 2000, 4500];
+    let result;
+    for (let tryNum = 0; ; tryNum++) {
+      try {
+        result = await attempt();
+        break;
+      } catch (e) {
+        const msg = (e && e.message) || '';
+        // Don't retry permanent failures — auth, missing key, credits, config.
+        const permanent = /api key|invalid key|not configured|insufficient credits|unauthoriz|\b401\b|\b402\b|unknown provider|no source/i.test(msg);
+        if (permanent || tryNum >= backoffs.length) throw e;
+        await this._delay(backoffs[tryNum]);
+      }
+    }
+
+    // For non-JSON functions (chat, tutoring etc.), strip any JSON wrapping the AI adds
+    if (!isJson && typeof result === 'string') {
+      result = this._stripJsonWrapper(result);
+    }
+    return result;
+  },
+
+  /**
+   * Call the deployed serverless proxy. The proxy injects the owner's
+   * ANTHROPIC_API_KEY server-side, so nothing sensitive is sent from the
+   * browser. Payload is Anthropic-native (built by _buildClaudePayload).
+   */
+  async _callProxy(messages, maxTokens, jsonMode=false) {
+    const payload = this._buildClaudePayload(messages, maxTokens, jsonMode);
+    // Identify the subscriber so the proxy can verify entitlement + meter usage.
+    const headers = { 'Content-Type': 'application/json' };
+    try { if (typeof Paywall !== 'undefined') headers['x-app-user-id'] = Paywall.userId(); } catch (e) {}
+    try { if (typeof AppConfig !== 'undefined' && AppConfig.PROXY_APP_TOKEN) headers['x-app-token'] = AppConfig.PROXY_APP_TOKEN; } catch (e) {}
+    const res = await this._fetchWithTimeout(this._proxyEndpoint, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(payload),
+    }, this._timeoutFor(maxTokens));
+    const d = await res.json().catch(() => ({}));
+    if (!res.ok || d.error) {
+      const msg = d.error?.message || res.statusText || 'Proxy request failed';
+      // 402 = the server says this user has no active subscription. The proxy is
+      // the authority (the client flag is only a hint), so surface the paywall.
+      if (res.status === 402) {
+        try { if (typeof Paywall !== 'undefined') { Paywall._entitled = false; Paywall.show && Paywall.show('Your subscription isn’t active. Subscribe to keep using AI.'); } } catch (e) {}
+        const err = new Error('Subscription required to use AI.'); err.code = 'SUBSCRIPTION_REQUIRED'; throw err;
+      }
+      if (res.status === 429) throw new Error(msg || 'Rate limit reached. Wait a moment and try again.');
+      // If the proxy lost its key mid-session, fall back to BYO mode for future calls.
+      if (/api key not (set|configured)|config error/i.test(msg)) {
+        this._proxyAvailable = false;
+        throw new Error('Server AI is unavailable. Configure your own key in Settings → Configure AI.');
+      }
+      throw new Error(msg);
+    }
+    return (d.content || []).filter(b => b.type === 'text').map(b => b.text).join('\n').trim();
+  },
+
+  /** Strip JSON fences and extract plain text if AI wrapped response in JSON */
+  _stripJsonWrapper(text) {
+    if (!text) return text;
+    let t = text.trim();
+    // Strip markdown fences
+    t = t.replace(/^```(?:json|text)?\s*/i, '').replace(/\s*```\s*$/i, '').trim();
+    // If it looks like a JSON object with a text field, extract it
+    if (t.startsWith('{') && t.includes('"')) {
+      try {
+        const obj = JSON.parse(t);
+        const val = obj.response || obj.text || obj.message || obj.explanation || obj.answer || obj.content;
+        if (val && typeof val === 'string') t = val;
+      } catch(e) {
+        // Not valid JSON — strip outer braces/quotes if present
+        const m = t.match(/^[{]\s*"[^"]+?":\s*"([\s\S]*?)"\s*[}]$/);
+        if (m) t = m[1];
+      }
+    }
+    // Convert escaped \n to real newlines
+    t = t.replace(/\\n/g, '\n');
+    return t;
+  },
+
+  async _callDirect(messages, maxTokens, jsonMode=false) {
+    switch(this._activeProvider) {
+      case 'claude':  return this._callClaude(messages, maxTokens, jsonMode);
+      case 'openai':  return this._callOpenAI(messages, maxTokens);
+      case 'gemini':  return this._callGemini(messages, maxTokens);
+      case 'custom':  return this._callCustom(messages, maxTokens);
+      default: throw new Error('Unknown provider.');
+    }
+  },
+
+  /**
+   * Legacy entry for backwards compat. Delegates to _callWithFunction so it
+   * inherits proxy routing, provider selection, and JSON handling. Treated as a
+   * plain-text ('chat') call. New code should call _callWithFunction directly.
+   */
+  async _call(messages, maxTokens=1000) {
+    return this._callWithFunction('chat', messages, maxTokens);
+  },
+
+  /** Build the OpenRouter (OpenAI-format) message array, including the shared
+   *  source-fidelity system prompt. Sync + pure, so it can be unit-tested. */
+  _buildOpenRouterMessages(messages, jsonMode=false) {
+    const normalized = messages.map(m => {
+      if (typeof m.content === 'string') return {role:m.role, content:m.content};
+      const content = m.content.map(c => {
+        if (c.type === 'text')  return {type:'text', text:c.text};
+        if (c.type === 'image') return {type:'image_url', image_url:{url:'data:'+c.source.media_type+';base64,'+c.source.data}};
+        if (c.type === 'image_url') return c;  // already correct format
+        return {type:'text', text:JSON.stringify(c)};
+      });
+      return {role:m.role, content};
+    });
+    // Prepend the shared guardrail so OpenRouter/Gemini get the same
+    // "use ONLY the source material" rule as the Claude paths.
+    return [{ role:'system', content:this._systemPrompt(jsonMode) }, ...normalized];
+  },
+
+  /** Human-readable current date/time + timezone from the device clock.
+   *  Shared by the coach and the Director so both reason about "now". */
+  _nowContext() {
+    const now = new Date();
+    const str = now.toLocaleString(undefined, { weekday:'long', year:'numeric', month:'long', day:'numeric', hour:'2-digit', minute:'2-digit' });
+    let tz = ''; try { tz = Intl.DateTimeFormat().resolvedOptions().timeZone || ''; } catch {}
+    return str + (tz ? ' (' + tz + ')' : '');
+  },
+
+  /** Heavier generations (lectures, slide decks, full nodes) legitimately take
+   *  longer than a quick classify. Scale the request timeout with the requested
+   *  token budget, clamped to a sane 45s–180s band, so short calls still fail
+   *  fast on a stalled network while long ones get the headroom they need. */
+  _timeoutFor(maxTokens) {
+    const ms = 30000 + (maxTokens || 1000) * 22;   // ~22ms/token of headroom
+    return Math.min(Math.max(ms, 45000), 180000);
+  },
+
+  /** Fetch with AbortController timeout — prevents indefinite hangs on
+   *  mobile networks where stalled connections never reject.
+   *  Default 45s is generous but bounded. */
+  async _fetchWithTimeout(url, options, ms = 45000) {
+    // On Android (Capacitor), use native HTTP to bypass WebView CORS restrictions.
+    // The CapacitorHttp plugin is compiled into the app and handles HTTPS natively.
+    if (typeof window !== 'undefined' &&
+        window.Capacitor &&
+        typeof window.Capacitor.nativePromise === 'function' &&
+        window.Capacitor.getPlatform && window.Capacitor.getPlatform() === 'android') {
+      try {
+        const headers = {};
+        if (options && options.headers) {
+          const h = (options.headers instanceof Headers)
+            ? options.headers
+            : new Headers(options.headers);
+          h.forEach((v, k) => { headers[k] = v; });
+        }
+        const result = await window.Capacitor.nativePromise('CapacitorHttp', 'request', {
+          url,
+          method:         (options && options.method) || 'GET',
+          headers,
+          data:           (options && options.body) || undefined,
+          connectTimeout: ms,
+          readTimeout:    ms,
+        });
+        const payload = result.data;
+        return {
+          ok:      result.status >= 200 && result.status < 300,
+          status:  result.status,
+          headers: new Headers(result.headers || {}),
+          json:    async () => (typeof payload === 'string' ? JSON.parse(payload) : payload),
+          text:    async () => (typeof payload === 'string' ? payload : JSON.stringify(payload)),
+        };
+      } catch (e) {
+        throw new Error((e && e.message) ? e.message : 'Native HTTP request failed. Check your connection and API key.');
+      }
+    }
+    // Browser / desktop fallback — standard fetch with abort timeout
+    const ctrl  = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), ms);
+    try {
+      return await fetch(url, { ...options, signal: ctrl.signal });
+    } catch (e) {
+      if (e.name === 'AbortError') {
+        throw new Error('Request timed out after ' + (ms / 1000) + 's. Check your connection and try again.');
+      }
+      throw e;
+    } finally {
+      clearTimeout(timer);
+    }
+  },
+
+  async _callOpenRouter(messages, maxTokens, model, jsonMode=false) {
+    const cfg = this._config.openrouter;
+    const withSystem = this._buildOpenRouterMessages(messages, jsonMode);
+
+    const res = await this._fetchWithTimeout('https://openrouter.ai/api/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type':    'application/json',
+        'Authorization':   'Bearer ' + cfg.key,
+        'HTTP-Referer':    'https://knowledgenode.app',
+        'X-Title':         'KnowledgeNode Study App',
+      },
+      body: JSON.stringify({
+        model,
+        max_tokens: maxTokens,
+        messages:   withSystem,
+      }),
+    }, this._timeoutFor(maxTokens));
+
+    if (!res.ok) {
+      const e = await res.json().catch(()=>({}));
+      const msg = e.error?.message || res.statusText;
+      // Helpful error messages for common issues
+      if (res.status === 401) throw new Error('Invalid OpenRouter API key. Check Settings → Configure AI.');
+      if (res.status === 402) throw new Error('OpenRouter account has insufficient credits. Top up at openrouter.ai/credits.');
+      if (res.status === 429) throw new Error('Rate limit reached. Wait a moment and try again.');
+      throw new Error('OpenRouter ' + res.status + ': ' + msg);
+    }
+
+    const d = await res.json();
+    const text = d.choices?.[0]?.message?.content?.trim() || '';
+    if (!text) throw new Error('OpenRouter returned an empty response. Try again.');
+    return text;
+  },
+
+  /**
+   * Build an Anthropic-native /v1/messages payload from internal messages.
+   * Shared by direct-Claude calls and the server proxy so both behave identically.
+   */
+  /** The source-fidelity system prompt, shared across every provider path so
+   *  the "use ONLY the source material" guardrail is applied uniformly. */
+  _systemPrompt(jsonMode = false) {
+    const _profile = this._activeProfile || 'college';
+    return "You are a study assistant inside KnowledgeNode. Your most important rule: ONLY use information explicitly stated in the SOURCE MATERIAL provided. "
+      + "NEVER add facts, definitions, examples, or explanations from your own training data. "
+      + "NEVER assume, infer, or extrapolate beyond what is written in the source. "
+      + "If the source does not contain enough information to answer something, say exactly: 'This is not covered in the provided source material.' "
+      + "If unsure whether something is in the source, quote the exact sentence that supports it. "
+      + "A wrong answer based on invented facts is always worse than admitting the source does not cover it. "
+      + "Be precise, honest, and grounded only in what the student has actually studied. "
+      + this.profileContext(_profile)
+      + (jsonMode ? " CRITICAL: Output ONLY raw JSON. No markdown, no ```json fences, no explanation. Start with { or [ and end with } or ]." : "");
+  },
+
+  _buildClaudePayload(messages, maxTokens, jsonMode=false, model=null) {
+    const SYS = this._systemPrompt(jsonMode);
+
+    // Convert image_url format to Anthropic native format
+    const _supportedMime = ['image/jpeg','image/png','image/gif','image/webp'];
+    const claudeMsgs = messages.map(m => {
+      if (typeof m.content === 'string') return m;
+      const parts = m.content.map(c => {
+        if (c.type === 'image_url') {
+          const [meta, data] = c.image_url.url.split(',');
+          let mediaType = meta.split(':')[1].split(';')[0];
+          if (!_supportedMime.includes(mediaType)) mediaType = 'image/jpeg';
+          return {type:'image', source:{type:'base64', media_type:mediaType, data}};
+        }
+        return c;
+      });
+      return {role:m.role, content:parts};
+    });
+
+    return {
+      model: model || (this._config.claude || {}).model || 'claude-sonnet-5',
+      max_tokens: maxTokens,
+      system: SYS,
+      messages: claudeMsgs,
+    };
+  },
+
+  /** Call Claude directly with prompt caching on the system prompt.
+   *  Only activates when the active provider is Claude (Anthropic Direct) —
+   *  other providers don't support the cache_control extension.
+   *  The `systemPrompt` is marked ephemeral and cached for 5 minutes;
+   *  subsequent calls with the same system prefix pay ~10% of normal input cost.
+   *  Falls back to a regular _callWithFunction call for non-Claude providers. */
+  async _callClaudeWithCache(systemPrompt, messages, maxTokens) {
+    // Only Claude supports Anthropic's prompt caching
+    if (this._activeProvider !== 'claude' && this._activeProvider !== 'proxy') {
+      // For other providers, prepend system to first user message as before
+      const augmented = messages.map((m, i) => i === 0
+        ? { ...m, content: systemPrompt + '\n\n' + m.content }
+        : m);
+      return await this._callWithFunction('chat', augmented, maxTokens);
+    }
+
+    const cfg   = this._config.claude || {};
+    const model = cfg.model || 'claude-sonnet-5';
+
+    const payload = {
+      model,
+      max_tokens: maxTokens,
+      // System prompt as a structured block with cache_control.
+      // Anthropic caches this for 5 min; reads cost 90% less than normal input.
+      system: [{ type: 'text', text: systemPrompt, cache_control: { type: 'ephemeral' } }],
+      messages,
+    };
+
+    const endpoint = cfg.key
+      ? 'https://api.anthropic.com/v1/messages'
+      : this._proxyEndpoint;
+
+    const headers = {
+      'Content-Type':      'application/json',
+      'anthropic-version': '2023-06-01',
+      'anthropic-beta':    'prompt-caching-2024-07-31',
+    };
+    if (cfg.key) {
+      headers['x-api-key']                             = cfg.key;
+      headers['anthropic-dangerous-direct-browser-access'] = 'true';
+    }
+
+    const res = await this._fetchWithTimeout(endpoint, {
+      method: 'POST', headers, body: JSON.stringify(payload),
+    }, this._timeoutFor(maxTokens));
+
+    if (!res.ok) {
+      const e = await res.json().catch(() => ({}));
+      const msg = e.error?.message || res.statusText;
+      if (res.status === 401) throw new Error('Invalid API key. Check Settings.');
+      if (res.status === 429) throw new Error('Rate limit reached. Wait a moment and try again.');
+      throw new Error('Claude ' + res.status + ': ' + msg);
+    }
+
+    const d = await res.json();
+    if (d.error) throw new Error(d.error.message || 'API error');
+    return d.content.filter(b => b.type === 'text').map(b => b.text).join('\n').trim();
+  },
+
+  async _callClaude(messages, maxTokens, jsonMode=false) {
+    const cfg = this._config.claude || {};
+    const payload = this._buildClaudePayload(messages, maxTokens, jsonMode, cfg.model);
+
+    const res = await this._fetchWithTimeout('https://api.anthropic.com/v1/messages', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': cfg.key,
+          'anthropic-version': '2023-06-01',
+          'anthropic-dangerous-direct-browser-access': 'true',
+        },
+        body: JSON.stringify(payload),
+      }, this._timeoutFor(maxTokens));
+
+    if (!res.ok) {
+      const e = await res.json().catch(()=>({}));
+      const msg = e.error?.message || res.statusText;
+      if (res.status === 401) throw new Error('Invalid API key. Check Settings.');
+      if (res.status === 429) throw new Error('Rate limit reached. Wait a moment and try again.');
+      throw new Error('Claude ' + res.status + ': ' + msg);
+    }
+
+    const d = await res.json();
+    if (d.error) throw new Error(d.error.message || 'API error');
+    return d.content.filter(b => b.type === 'text').map(b => b.text).join('\n').trim();
+  },
+
+  async _callOpenAI(messages, maxTokens) {
+    const cfg = this._config.openai;
+    const res = await this._fetchWithTimeout('https://api.openai.com/v1/chat/completions', {
+      method:'POST',
+      headers:{'Content-Type':'application/json','Authorization':'Bearer '+cfg.key},
+      body:JSON.stringify({model:cfg.model||'gpt-5-mini',max_tokens:maxTokens,messages}),
+    }, this._timeoutFor(maxTokens));
+    if (!res.ok) { const e=await res.json().catch(()=>({})); throw new Error('OpenAI '+res.status+': '+(e.error?.message||res.statusText)); }
+    const d = await res.json();
+    return d.choices[0]?.message?.content?.trim()||'';
+  },
+
+  async _callGemini(messages, maxTokens) {
+    const cfg   = this._config.gemini;
+    const model = cfg.model||'gemini-3.5-flash';
+    const url   = 'https://generativelanguage.googleapis.com/v1beta/models/'+model+':generateContent?key='+cfg.key;
+    const parts = [];
+    for (const msg of messages) {
+      if (typeof msg.content==='string') { parts.push({text:msg.content}); continue; }
+      for (const c of msg.content) {
+        if (c.type==='text') parts.push({text:c.text});
+        if (c.type==='image_url') {
+          const p = c.image_url.url.split(',');
+          const mt= p[0].split(':')[1].split(';')[0];
+          parts.push({inline_data:{mime_type:mt, data:p[1]}});
+        }
+      }
+    }
+    const res = await this._fetchWithTimeout(url,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({contents:[{parts}],generationConfig:{maxOutputTokens:maxTokens}})}, this._timeoutFor(maxTokens));
+    if (!res.ok) { const e=await res.json().catch(()=>({})); throw new Error('Gemini '+res.status+': '+(e.error?.message||res.statusText)); }
+    const d = await res.json();
+    return d.candidates?.[0]?.content?.parts?.[0]?.text?.trim()||'';
+  },
+
+  async _callCustom(messages, maxTokens) {
+    const cfg = this._config.custom;
+    if (!cfg.customEndpoint) throw new Error('Custom endpoint URL not configured.');
+    // Notes + the API key are POSTed to this URL, so refuse plaintext HTTP to any
+    // remote host — http is tolerated only for a local dev model (e.g. Ollama).
+    let u;
+    try { u = new URL(cfg.customEndpoint); } catch (e) { throw new Error('Custom endpoint URL is invalid.'); }
+    const isLocal = /^(localhost|127\.0\.0\.1|\[::1\])$/.test(u.hostname);
+    if (u.protocol !== 'https:' && !(u.protocol === 'http:' && isLocal)) {
+      throw new Error('Custom endpoint must use HTTPS (plain http is allowed only for localhost).');
+    }
+    const oaiMsgs = messages.map(m=>({role:m.role,content:typeof m.content==='string'?m.content:m.content.map(c=>c.text||'').join('\n')}));
+    const res = await this._fetchWithTimeout(cfg.customEndpoint,{method:'POST',headers:{'Content-Type':'application/json','Authorization':'Bearer '+(cfg.key||'none')},body:JSON.stringify({model:cfg.model||'local-model',max_tokens:maxTokens,messages:oaiMsgs})}, this._timeoutFor(maxTokens));
+    if (!res.ok) throw new Error('Custom API '+res.status+': '+res.statusText);
+    const d = await res.json();
+    return (d.choices?.[0]?.message?.content||d.content?.[0]?.text||'').trim();
+  },
+
+  _parseJSON(raw) {
+    if (!raw || !raw.trim()) throw new Error('AI returned empty response. Try again.');
+    let clean = raw.trim();
+    // Strip ALL variations of markdown code fences aggressively
+    clean = clean.replace(/^[\s\S]*?```(?:json)?\s*/i, '').replace(/\s*```[\s\S]*$/i, '').trim();
+    // If that made it empty, use original
+    if (!clean) clean = raw.trim();
+    // Strip any leading prose before first { or [
+    const fi = Math.min(
+      clean.indexOf('{') === -1 ? Infinity : clean.indexOf('{'),
+      clean.indexOf('[') === -1 ? Infinity : clean.indexOf('[')
+    );
+    if (fi > 0 && fi < Infinity) clean = clean.slice(fi);
+    // Strip trailing prose after last } or ]
+    const li = Math.max(clean.lastIndexOf('}'), clean.lastIndexOf(']'));
+    if (li !== -1 && li < clean.length - 1) clean = clean.slice(0, li + 1);
+    // Attempt 1: direct parse
+    try { return JSON.parse(clean); } catch {}
+    // Attempt 2: greedy object
+    const obj = clean.match(/\{[\s\S]*\}/);
+    if (obj) try { return JSON.parse(obj[0]); } catch {}
+    // Attempt 3: greedy array
+    const arr = clean.match(/\[[\s\S]*\]/);
+    if (arr) try { return JSON.parse(arr[0]); } catch {}
+    // Attempt 4: binary search for the longest valid parseable prefix.
+    // Bracket-counting was wrong — it counts brackets inside string values,
+    // producing a validly-parsing but semantically corrupted object.
+    // Binary search always returns a structurally correct (if truncated) result.
+    try {
+      let lo = 1, hi = clean.length, best = null;
+      while (lo <= hi) {
+        const mid = (lo + hi) >> 1;
+        try { best = JSON.parse(clean.slice(0, mid)); lo = mid + 1; }
+        catch { hi = mid - 1; }
+      }
+      if (best !== null) return best;
+    } catch {}
+    // Attempt 5: repair truncation. A token-limit cutoff leaves valid JSON that
+    // simply stops partway (a common bulk-import failure mode), which the prefix
+    // search above can't recover because no prefix is itself valid. Close any
+    // dangling string and the unclosed brackets, then parse.
+    try {
+      const repaired = this._closeTruncatedJSON(clean);
+      if (repaired) return JSON.parse(repaired);
+    } catch {}
+    throw new Error('AI returned invalid JSON. Try again.');
+  },
+
+  /** Close an open string and any unclosed {}/[] in a truncated JSON string.
+   *  Pure + synchronous so it can be unit-tested. Returns a candidate string. */
+  _closeTruncatedJSON(s) {
+    const scan = (str) => {
+      const stack = []; let inStr = false, esc = false;
+      for (let i = 0; i < str.length; i++) {
+        const ch = str[i];
+        if (inStr) {
+          if (esc) esc = false;
+          else if (ch === '\\') esc = true;
+          else if (ch === '"') inStr = false;
+          continue;
+        }
+        if (ch === '"') inStr = true;
+        else if (ch === '{' || ch === '[') stack.push(ch);
+        else if (ch === '}' || ch === ']') stack.pop();
+      }
+      return { stack, inStr };
+    };
+    const close = (str, st) => {
+      let out = str;
+      if (st.inStr) out += '"';        // close a string cut mid-value
+      out = out.replace(/,\s*$/, '');  // drop a dangling comma
+      for (let i = st.stack.length - 1; i >= 0; i--) out += st.stack[i] === '{' ? '}' : ']';
+      return out;
+    };
+    let st = scan(s);
+    let candidate = close(s, st);
+    try { JSON.parse(candidate); return candidate; } catch {}
+    // Retry once after dropping a trailing key that never got a value
+    // (e.g. {"a":1,"b": or {"a":1,"b").
+    const trimmed = s.replace(/[,{]\s*"[^"]*"\s*:?\s*$/, m => (m.trim()[0] === '{' ? '{' : ''));
+    st = scan(trimmed);
+    return close(trimmed, st);
+  },
+
+  async mockProcess(meta, onProgress=()=>{}) {
+    const steps=[[1,'Reading…'],[2,'Structuring…'],[3,'Questions…'],[4,'Building…']];
+    for(const[s,l]of steps){onProgress(s,l);await this._delay(500);}
+    const Q=(t,q,a)=>({id:KnowledgeNode._generateQuestionId(),type:t,question:q,answer:a});
+    return {rawOCR:'[Demo]',title:"Newton's Laws of Motion",definitions:[{term:'Force',examples:'Push, Pull, Gravity, Friction',description:'Push or pull causing change in motion. Measured in Newtons (N).'},{term:'Mass',examples:'1 kg of water, 70 kg person',description:'Amount of matter in kg. Determines resistance to acceleration.'},{term:'Inertia',examples:'Car skidding, book staying on table',description:'Tendency to resist changes in motion. Proportional to mass.'}],tables:[{id:'tbl_demo',title:"Newton's Laws Summary",columns:['Law','Statement','Formula'],rows:[['First','Object at rest stays at rest','F_net = 0'],['Second','Net force = mass × acceleration','F = ma'],['Third','Equal and opposite reaction','F₁ = −F₂']]}],formulas:[{expression:'F = ma',description:"Newton's Second Law",constraints:'Constant mass. F in N, m in kg, a in m/s².'}],procedures:[{id:'proc_demo',title:'Solving Force Problems',appliesTo:'Any Newton\'s Law calculation',steps:['Draw a free-body diagram.','Choose coordinate system.','Resolve forces into components.','Apply ΣF = ma.','Solve for the unknown.','Verify units.'],notes:'Always draw the diagram first. Missing a force is the #1 mistake.'}],commonMistakes:['Confusing mass (kg) with weight (N).','Missing forces in diagram.'],summary:"Newton's Three Laws are the foundation of classical mechanics. F=ma is the most applied equation.",questions:[Q('recall',"State Newton's Second Law.","F = ma. Net force equals mass times acceleration."),Q('recall','SI unit of force?','Newton (N). 1 N = 1 kg·m/s².'),Q('recall','What is inertia?','Resistance to changes in motion. Proportional to mass.'),Q('application','5 kg block, 20 N net force. Acceleration?','a = F/m = 20/5 = 4 m/s².'),Q('application','1000 kg rocket needs 15 m/s². Thrust?','F = 1000×15 = 15,000 N.')],processingStatus:'ready'};
+  },
+
+  _delay: ms => new Promise(r=>setTimeout(r,ms)),
+};

--- a/knowledgenode/www/js/ai/AIService.js
+++ b/knowledgenode/www/js/ai/AIService.js
@@ -768,8 +768,9 @@ const AIService = {
           + '\nIf they have not studied today and it fits the conversation, you may gently note that one small session keeps the streak alive — but never guilt-trip, and do not bring it up every turn.';
       }
     } catch {}
+    // The CONFIRMED FACTS block now rides inside LearnerContext.forSession(),
+    // so every AI surface shares it — not just this one.
     const sys = ctx
-      + ((typeof CoachFacts !== 'undefined') ? CoachFacts.block() : '')
       + '\n\nCURRENT DATE & TIME on the student\'s device: ' + this._nowContext() + '.'
       + '\nUse this to gauge urgency against any exam date, to frame what is due today, and to fit suggestions to the time of day (e.g. a shorter recall-focused session late at night). It is context for better advice only — do NOT comment on the time, the day, or tell them to rest/sleep unless they raise it themselves.'
       + streakLine

--- a/knowledgenode/www/js/ai/CoachEngine.js
+++ b/knowledgenode/www/js/ai/CoachEngine.js
@@ -1,0 +1,227 @@
+/**
+ * CoachEngine.js — THE single brain behind every coaching/tutoring surface.
+ *
+ * The Study Coach chat and the Socratic Tutor overlay are VIEWS over this one
+ * engine: one conversation history, one mode state machine, one AI pathway
+ * (AIService.studyCoach), one shared memory (LearnerState signals the Director
+ * reads). Whatever view the student is in, it is the same entity.
+ *
+ * Mode state machine (exactly one active at a time):
+ *   { kind:'advise' }                          — default coaching
+ *   { kind:'tutor',    nodeId, i }             — Socratic tutoring through a
+ *                                                Revision Questions node
+ *   { kind:'resource', nodeId }                — studying a source-material
+ *                                                node's saved content
+ *   { kind:'example',  nodeId, example }       — tutoring a worked example
+ *                                                (Socratic Tutor overlay)
+ *
+ * Node-graph integration:
+ *   resourceContext()        — reads an EXISTING node's full saved material
+ *                              (no re-upload) into the conversation
+ *   compileQuestionsNode(id) — programmatically builds a linked Revision
+ *                              Questions node from a source node
+ *   recordOutcome(gotIt)     — programmatically updates the active Revision
+ *                              Questions node (SRS rating + struggle log)
+ */
+const CoachEngine = {
+  history: [],                 // the ONE conversation, shared by every view
+  mode: { kind: 'advise' },
+  HKEY: 'kn_coach_history',
+  HMAX: 60,                    // messages kept on disk
+
+  /* ─── persistence: the conversation survives closing the app ───
+     Without this, reopening the app wiped the whole conversation and the coach
+     re-asked everything it had already been told. */
+  loadHistory() {
+    try {
+      const raw = JSON.parse(localStorage.getItem(this.HKEY) || 'null');
+      if (Array.isArray(raw)) {
+        this.history = raw
+          .filter(m => m && typeof m.text === 'string' && (m.role === 'user' || m.role === 'coach'))
+          .slice(-this.HMAX);
+      }
+    } catch (e) { /* corrupt or unavailable — start fresh */ }
+    return this.history;
+  },
+
+  saveHistory() {
+    try { localStorage.setItem(this.HKEY, JSON.stringify(this.history.slice(-this.HMAX))); }
+    catch (e) { /* quota / private mode — memory still works for this session */ }
+  },
+
+  /** Wipe the conversation AND the durable facts (a real "start over"). */
+  resetMemory() {
+    this.history = [];
+    this.mode = { kind: 'advise' };
+    try { localStorage.removeItem(this.HKEY); } catch (e) {}
+    try { if (typeof CoachFacts !== 'undefined') CoachFacts.clear(); } catch (e) {}
+  },
+
+  /* ─── mode transitions (entering any mode leaves the previous one) ─── */
+  startTutor(nodeId)   { this.mode = { kind: 'tutor', nodeId, i: 0 }; },
+  startResource(nodeId){ this.mode = { kind: 'resource', nodeId }; },
+  startExample(node, example) { this.mode = { kind: 'example', nodeId: node.id, example }; },
+  end()                { this.mode = { kind: 'advise' }; },
+
+  /* ─── one AI turn — every view calls THIS (the user message is already in
+     history; the coach reply is pushed and returned) ─── */
+  async turn(question, opts = {}) {
+    const exampleContext  = opts.exampleContext
+      || (this.mode.kind === 'example' ? this.exampleContext() : null);
+    const tutorContext    = (!opts.exampleContext && this.mode.kind === 'tutor')
+      ? this.tutorContext() : null;
+    const resourceContext = (this.mode.kind === 'resource') ? this.resourceContext() : null;
+
+    // Failed-call notices are shown in the log but never sent back as context.
+    const sendable = this.history.filter(h => h && !h.error);
+    const answer = await AIService.studyCoach(question, sendable, exampleContext, tutorContext, resourceContext);
+    if (!answer || !String(answer).trim()) throw new Error('empty');
+    const { clean, signal } = this.extractSignal(answer);
+    const entry = { role: 'coach', text: clean };
+    this.history.push(entry);
+    // Cap history to prevent unbounded growth; keep the opening message.
+    if (this.history.length > 50) this.history = [this.history[0], ...this.history.slice(-49)];
+    this.saveHistory();
+    // Shared memory: the Director reads these signals before its next
+    // evaluation — every surface feeds the same brain.
+    try {
+      if (typeof LearnerState !== 'undefined') {
+        LearnerState.saveCoachExchange({
+          question, signal: signal || null,
+          insight: signal || clean.slice(0, 200),
+        });
+      }
+    } catch (e) { /* optional */ }
+    return entry;
+  },
+
+  /** Strip the hidden memory lines out of a reply. [[SIGNAL:...]] feeds the
+   *  Director; [[FACT: key = value]] lines are absorbed into durable memory so
+   *  the coach stops re-asking things the student already answered. Neither is
+   *  ever shown to the student. */
+  extractSignal(raw) {
+    const str    = String(raw || '');
+    const match  = str.match(/\[\[SIGNAL:([^\]]+)\]\]/);
+    const signal = match ? match[1].trim() : null;
+    let clean    = str.replace(/\n?\[\[SIGNAL:[^\]]*\]\]\n?/g, '').trimEnd();
+    try {
+      if (typeof CoachFacts !== 'undefined') clean = CoachFacts.absorb(clean);
+      else clean = clean.replace(/\n?\[\[FACT:[^\]]*\]\]\n?/gi, '\n').trimEnd();
+    } catch (e) {
+      clean = clean.replace(/\n?\[\[FACT:[^\]]*\]\]\n?/gi, '\n').trimEnd();
+    }
+    return { clean, signal };
+  },
+
+  /* ─── per-mode context builders (rebuilt fresh every turn so the engine
+     never loses its subject mid-conversation) ─── */
+
+  tutorContext() {
+    if (this.mode.kind !== 'tutor') return null;
+    const node = nodeStore.get(this.mode.nodeId);
+    const qs = node ? (node.questions || []) : [];
+    const q  = qs[this.mode.i];
+    if (!node || !q) return null;
+    return 'SOCRATIC TUTORING MODE — ACTIVE'
+      + '\nTopic: "' + node.title + '" (' + (node.subject || 'general') + ')'
+      + '\nQuestion ' + (this.mode.i + 1) + ' of ' + qs.length + ':'
+      + '\n"""\n' + q.question + '\n"""'
+      + (q.answer ? '\nModel answer (NEVER reveal outright — for steering and checking only):\n"""\n' + q.answer + '\n"""'
+                  : '\nNo model answer was captured for this question — tutor from the strategy and check the student\'s reasoning step by step.');
+  },
+
+  resourceContext() {
+    if (this.mode.kind !== 'resource') return null;
+    const node = nodeStore.get(this.mode.nodeId);
+    if (!node) return null;
+    const src = (typeof LearnerContext !== 'undefined' && LearnerContext._buildSourceText)
+      ? LearnerContext._buildSourceText(node, 6000)
+      : (node.summary || node.userNotes || node.rawOCR || '');
+    return 'RESOURCE MODE — ACTIVE'
+      + '\nThe student is studying their saved topic "' + node.title + '" (' + (node.subject || 'general') + ') with you — its full saved material is below. They did NOT re-upload anything; this is read straight from their library.'
+      + '\nFULL SAVED MATERIAL:\n"""\n' + src + '\n"""';
+  },
+
+  exampleContext() {
+    if (this.mode.kind !== 'example' || !this.mode.example) return null;
+    const node = nodeStore.get(this.mode.nodeId);
+    if (!node) return null;
+    const ctx = (typeof LearnerContext !== 'undefined' && LearnerContext.forSocraticTutor)
+      ? LearnerContext.forSocraticTutor(node, this.mode.example)
+      : 'WORKED EXAMPLE: ' + (this.mode.example.title || '') + '\n' + (this.mode.example.question || '');
+    let examStyle = '';
+    try {
+      const k = 'kn_exam_style_' + (node.subject || '').toLowerCase().replace(/\s+/g, '_');
+      const d = JSON.parse(localStorage.getItem(k) || 'null');
+      if (d?.papers?.length) {
+        const p = d.papers[d.papers.length - 1];
+        examStyle = '\nThe student\'s exam style: ' + (p.analysis?.style || '') + ' — types: ' + (p.analysis?.questionTypes || []).join(', ');
+      }
+    } catch (e) {}
+    return ctx + examStyle
+      + '\n\nYou are having a REAL CONVERSATION with the student about the worked example above — read what they actually say each turn and respond to THAT. If they attempt an answer, mark it kindly and specifically. If they are stuck, hint or simplify — never hand over the full answer unprompted. Teach only from their material; outside-knowledge methods only when asked, flagged "this isn\'t in your notes". Be concise and warm; plain text only, maths in plain symbols.'
+      + '\nYou MAY end with these control tags on their own lines (hidden from the student):'
+      + '\n[[CHIPS: short tap option | another | another]]  (2-4 genuinely useful next-tap suggestions for THIS moment)'
+      + '\n[[PHASE: n]]  (n = 1-5: 1 orient, 2 understand, 3 practise, 4 exam-style, 5 wrapping up)'
+      + '\n[[DONE]]  (only when the student has clearly succeeded and wants to stop)';
+  },
+
+  /* ─── node-graph operations ─── */
+
+  /** Advance the tutor to the next question; returns false when the set is done. */
+  tutorAdvance() {
+    if (this.mode.kind !== 'tutor') return false;
+    const node = nodeStore.get(this.mode.nodeId);
+    const qs = node ? (node.questions || []) : [];
+    if (this.mode.i + 1 >= qs.length) { this.end(); return false; }
+    this.mode.i++;
+    return true;
+  },
+
+  /** Programmatic UPDATE of the active Revision Questions node: record how the
+   *  student did on the current question — feeds SRS scheduling, mastery, and
+   *  the "Review in your textbook" list. */
+  recordOutcome(gotIt) {
+    if (this.mode.kind !== 'tutor') return false;
+    const node = nodeStore.get(this.mode.nodeId);
+    const q = node ? (node.questions || [])[this.mode.i] : null;
+    if (!node || !q) return false;
+    try {
+      node.recordRating(q.id, gotIt ? 3 : 1);
+      if (!gotIt && typeof LearnerMemory !== 'undefined') LearnerMemory.recordStruggle(node, q, 1);
+      nodeStore.save(node);
+      return true;
+    } catch (e) { console.warn('[CoachEngine] recordOutcome failed:', e); return false; }
+  },
+
+  /** Programmatically compile a linked Revision Questions node from an
+   *  EXISTING source node's saved material — no re-upload, no manual steps. */
+  async compileQuestionsNode(sourceNodeId) {
+    const src = nodeStore.get(sourceNodeId);
+    if (!src) throw new Error('Topic not found.');
+    const notes = {
+      title:       src.title,
+      definitions: src.definitions || [],
+      formulas:    src.formulas    || [],
+      procedures:  src.procedures  || [],
+      tables:      src.tables      || [],
+      summary:     src.summary || (src.userNotes || src.rawOCR || '').slice(0, 500),
+    };
+    const meta  = { subject: src.subject, chapter: src.chapter, detail: 'standard', profile: src.learnerProfile };
+    const qData = await AIService._generateQuestions(notes, meta, src.subjectCategory || 'general');
+    const questions = [
+      ...(qData.recall || []).map(q => ({ id: KnowledgeNode._generateQuestionId(), type: 'recall', question: q.question, answer: q.answer, accept: Array.isArray(q.accept) ? q.accept.filter(a => typeof a === 'string').slice(0, 6) : [] })),
+      ...(qData.application || []).map(q => ({ id: KnowledgeNode._generateQuestionId(), type: 'application', question: q.question, answer: q.answer })),
+    ];
+    if (!questions.length) throw new Error('No questions came back — try again.');
+    const qNode = new KnowledgeNode({
+      subject: src.subject, chapter: src.chapter,
+      title: src.title + ' — Revision Questions',
+      questions, linkedSourceId: src.id, processingStatus: 'ready',
+    });
+    nodeStore.save(qNode);
+    try { if (typeof StreakTracker !== 'undefined') StreakTracker.recordActivity(); } catch (e) {}
+    return qNode;
+  },
+};
+if (typeof window !== 'undefined') window.CoachEngine = CoachEngine;

--- a/knowledgenode/www/js/ai/LearnerContext.js
+++ b/knowledgenode/www/js/ai/LearnerContext.js
@@ -1,0 +1,427 @@
+/**
+ * LearnerContext.js — Central AI context layer
+ *
+ * One source of truth that every AI feature draws from.
+ * Instead of each tab/feature building its own context string
+ * from scratch, they all call LearnerContext.forNode(node) or
+ * LearnerContext.forSession() and get a consistent, complete
+ * picture of the learner and the material.
+ *
+ * WHAT IT KNOWS:
+ *   Per node  — full source material, learner profile, mastery,
+ *               weak questions, session history, exam style
+ *   Global    — overall weak topics, study streak, due count,
+ *               cross-node patterns
+ *
+ * HARD RULES enforced in every context string:
+ *   1. AI must only use source material — never outside knowledge
+ *   2. Profile changes language/style — never content volume
+ *   3. Worked examples stay faithful to source
+ *   4. Questions mirror uploaded exam style where available
+ */
+
+const LearnerContext = {
+  _sessionCache: null, // TTL cache — rebuilt at most every 10s
+
+  /* ─────────────────────────────────────────────────────────
+     NODE CONTEXT
+     Complete context for one node — used by Notes, Questions,
+     Examples, Review (per card), Guided Study, Socratic Tutor
+  ───────────────────────────────────────────────────────── */
+  forNode(node, options = {}) {
+    if (!node) return '';
+
+    const {
+      includeSource    = true,   // full definitions, tables, procedures
+      includeWeakness  = true,   // which questions the learner struggles with
+      includeHistory   = true,   // past session summaries
+      includeExamStyle = true,   // uploaded exam paper patterns
+      maxSourceChars   = 6000,   // keep prompts from bloating
+    } = options;
+
+    const parts = [];
+
+    // ── 1. Hard rules — injected first so model sees them immediately ──
+    parts.push(this._hardRules());
+
+    // ── 2. Learner profile ──
+    parts.push(AIService.profileContext(node.learnerProfile || 'college'));
+
+    // ── 3. Node identity ──
+    parts.push(
+      `TOPIC: "${node.title}"`,
+      `SUBJECT: ${node.subject || 'General'}`,
+      node.chapter ? `CHAPTER: ${node.chapter}` : '',
+    );
+
+    // ── 4. Full source material ──
+    if (includeSource) {
+      const source = this._buildSourceText(node, maxSourceChars);
+      if (source) parts.push('SOURCE MATERIAL (use only this — do not add outside knowledge):\n' + source);
+    }
+
+    // ── 5. Learner weakness on this node ──
+    if (includeWeakness) {
+      const weak = LearnerMemory.getWeakQuestionsText(node);
+      if (weak) parts.push('LEARNER STRUGGLES WITH:\n' + weak);
+
+      const mastery = node.masteryScore ?? null;
+      if (mastery !== null) {
+        parts.push(`CURRENT MASTERY: ${mastery}% — ${this._masteryLabel(mastery)}`);
+      }
+    }
+
+    // ── 5b. Past AI corrections — must always be included ──
+    if (typeof AICorrections !== 'undefined') {
+      const corrections = AICorrections.forPrompt(node);
+      if (corrections) parts.push(corrections);
+    }
+
+    // ── 6. Session history — use activitySummary first, then log ──
+    if (includeHistory) {
+      const latest = LearnerMemory.getNodeActivitySummary(node);
+      if (latest) parts.push('LAST ACTIVITY: ' + latest);
+
+      const history = this._sessionHistory(node, 3);
+      if (history) parts.push('RECENT STUDY SESSIONS:\n' + history);
+    }
+
+    // ── 7. Exam style for this subject ──
+    if (includeExamStyle) {
+      const examStyle = this._examStyle(node.subject);
+      if (examStyle) parts.push('EXAM STYLE FOR THIS SUBJECT:\n' + examStyle);
+    }
+
+    return parts.filter(Boolean).join('\n\n');
+  },
+
+  /* ─────────────────────────────────────────────────────────
+     SESSION CONTEXT
+     Cross-node context — used by Review, Study Plan,
+     AI Director, Gap Analysis
+  ───────────────────────────────────────────────────────── */
+  forSession(options = {}) {
+    const { maxNodes = 10 } = options;
+    const parts = [];
+
+    parts.push(this._hardRules());
+
+    try {
+      const allNodes = nodeStore.getAll();
+      if (!allNodes.length) return '';
+
+      // Overall learner stats
+      const stats        = nodeStore.getStats();
+      const dueNodes     = nodeStore.getDueNodes().slice(0, maxNodes);
+      const weakNodes    = allNodes
+        .filter(n => (n.masteryScore ?? 100) < 60)
+        .sort((a, b) => (a.masteryScore ?? 100) - (b.masteryScore ?? 100))
+        .slice(0, maxNodes);
+      const strongNodes  = allNodes
+        .filter(n => (n.masteryScore ?? 0) >= 80)
+        .slice(0, 5);
+
+      parts.push(
+        `LEARNER OVERVIEW:\n`
+        + `- Total nodes: ${stats.total}\n`
+        + `- Overall mastery: ${stats.mastery}%\n`
+        + `- Questions due today: ${stats.due}`
+      );
+
+      if (weakNodes.length) {
+        parts.push(
+          'WEAK TOPICS (needs most attention):\n'
+          + weakNodes.map(n =>
+              `- "${n.title}" (${n.subject || 'general'}) — `
+              + `mastery ${n.masteryScore ?? 0}%, `
+              + `${n.dueQuestions?.().length || 0} due`
+            ).join('\n')
+        );
+      }
+
+      if (dueNodes.length) {
+        parts.push(
+          'DUE FOR REVIEW TODAY:\n'
+          + dueNodes.map(n => `- "${n.title}" (${n.subject || 'general'})`).join('\n')
+        );
+      }
+
+      if (strongNodes.length) {
+        parts.push(
+          'STRONG TOPICS (well understood):\n'
+          + strongNodes.map(n => `- "${n.title}" — mastery ${n.masteryScore}%`).join('\n')
+        );
+      }
+
+      // Worked examples the learner has saved (titles + counts only, to stay
+      // cheap on tokens). This lets the coach actually point to specific
+      // examples instead of telling the student to go hunt manually.
+      const withExamples = allNodes
+        .filter(n => Array.isArray(n.workedExamples) && n.workedExamples.length)
+        .slice(0, maxNodes);
+      if (withExamples.length) {
+        const totalEx = allNodes.reduce((s, n) => s + (n.workedExamples?.length || 0), 0);
+        parts.push(
+          `WORKED EXAMPLES AVAILABLE (${totalEx} total — you CAN see these):\n`
+          + withExamples.map(n =>
+              `- "${n.title}": `
+              + n.workedExamples.slice(0, 6).map(ex => `"${ex.title || 'Untitled example'}"`).join(', ')
+            ).join('\n')
+          + '\nWhen the student asks about examples, reference these by name and topic. '
+          + 'They live in each topic\u2019s Examples tab in the Library, and Guided Study walks through them.'
+        );
+      } else {
+        parts.push(
+          'WORKED EXAMPLES: The student has not saved any worked examples yet. '
+          + 'They can add them by scanning a solved example into a topic (it lands in that topic\u2019s Examples tab).'
+        );
+      }
+
+      // Study plan (if one exists)
+      try {
+        const plan = (typeof PlanStore !== 'undefined') ? PlanStore.getActive() : null;
+        if (plan) {
+          const daysLeft = plan.examDate
+            ? Math.ceil((new Date(plan.examDate) - new Date()) / 86400000)
+            : null;
+          const todayStr = new Date().toISOString().slice(0, 10);
+          const todaySessions = (plan.sessions || []).filter(s => s.date === todayStr);
+          parts.push(
+            'STUDY PLAN: "' + plan.title + '"'
+            + (plan.examDate ? ' — exam/target date: ' + plan.examDate
+               + (daysLeft !== null ? ' (' + daysLeft + ' days away)' : '') : '')
+            + '\nDaily study time: ' + (plan.dailyMinutes || '?') + ' min/day'
+            + (todaySessions.length
+                ? "\nToday's scheduled sessions: "
+                  + todaySessions.map(s => '"' + s.nodeTitle + '" (' + (s.durationMinutes || '?') + ' min)').join(', ')
+                : '\nNo sessions scheduled for today.')
+            + '\nOverall plan progress: '
+            + (plan.sessions || []).filter(s => s.completed).length
+            + '/' + (plan.sessions || []).length + ' sessions completed.'
+          );
+        } else {
+          parts.push('STUDY PLAN: No active study plan. The student can create one in the Study Plan tab.');
+        }
+      } catch (e) { /* plan access is optional */ }
+
+      // Shared learner memory — Director decisions, recent Coach topics, inferred profile.
+      // Both the Director and Coach write here; both read here. One source of truth.
+      try {
+        const sharedBlock = (typeof LearnerState !== 'undefined') ? LearnerState.toPromptBlock() : '';
+        if (sharedBlock) parts.push(sharedBlock);
+      } catch(e) { /* optional */ }
+
+    } catch(e) {
+      console.warn('[LearnerContext] forSession error:', e);
+    }
+
+    const _ctx = parts.filter(Boolean).join('\n\n');
+    this._sessionCache = { ctx: _ctx, at: Date.now() };
+    return _ctx;
+  },
+
+  /* ─────────────────────────────────────────────────────────
+     SPECIALISED BUILDERS
+     Thin wrappers used by specific features
+  ───────────────────────────────────────────────────────── */
+
+  /** For Review cards — lightweight, only what's needed per question */
+  forReviewCard(node, question) {
+    return this.forNode(node, {
+      includeSource:    true,
+      includeWeakness:  true,
+      includeHistory:   false,  // not needed per-card
+      includeExamStyle: false,
+      maxSourceChars:   3000,
+    }) + '\n\nCURRENT QUESTION:\n'
+      + `Q: "${question.question}"\n`
+      + `Model answer: "${question.answer}"`;
+  },
+
+  /** For question generation — needs full source + exam style */
+  forQuestionGen(node) {
+    return this.forNode(node, {
+      includeSource:    true,
+      includeWeakness:  true,
+      includeHistory:   false,
+      includeExamStyle: true,
+      maxSourceChars:   6000,
+    });
+  },
+
+  /** For Socratic tutor — needs source + history + weakness */
+  forSocraticTutor(node, workedExample) {
+    const base = this.forNode(node, {
+      includeSource:    true,
+      includeWeakness:  true,
+      includeHistory:   true,
+      includeExamStyle: false,
+      maxSourceChars:   4000,
+    });
+
+    if (!workedExample) return base;
+
+    return base + '\n\n'
+      + `WORKED EXAMPLE — "${workedExample.title}":\n`
+      + `Q: ${workedExample.question}\n`
+      + `Solution: ${workedExample.solution}`
+      + (workedExample.steps?.length
+          ? '\nSteps:\n' + workedExample.steps.map((s, i) => `${i+1}. ${s}`).join('\n')
+          : '');
+  },
+
+  /** For Guided Study — full context, all sections */
+  forGuidedStudy(node) {
+    return this.forNode(node, {
+      includeSource:    true,
+      includeWeakness:  true,
+      includeHistory:   true,
+      includeExamStyle: true,
+      maxSourceChars:   6000,
+    });
+  },
+
+  /** For note generation / restructure — source faithful, no weakness needed */
+  forNoteGeneration(node, meta = {}) {
+    return this.forNode(node, {
+      includeSource:    true,
+      includeWeakness:  false,
+      includeHistory:   false,
+      includeExamStyle: false,
+      maxSourceChars:   8000,
+    });
+  },
+
+  /* ─────────────────────────────────────────────────────────
+     PRIVATE HELPERS
+  ───────────────────────────────────────────────────────── */
+
+  /** Hard rules injected into every single prompt */
+  _hardRules() {
+    return [
+      'ABSOLUTE RULES — follow these in every response:',
+      '1. SOURCE ONLY: Use ONLY information from the SOURCE MATERIAL provided. Never add facts, examples, or explanations from outside knowledge.',
+      '2. COMPLETENESS: Never skip or summarise away content from the source. Volume must be preserved.',
+      '3. PROFILE: Only the language and explanation style changes per learner level — never the content.',
+      '4. EXAMPLES: Worked examples must be drawn from the source material. Do not invent scenarios.',
+      '5. PLAIN TEXT: Reply in plain conversational text unless JSON is explicitly requested.',
+    ].join('\n');
+  },
+
+  /** Builds a complete source text string from all content in a node */
+  _buildSourceText(node, maxChars = 6000) {
+    const sections = [];
+
+    // Blocks (new format) — most complete source
+    if (node.blocks?.length) {
+      node.blocks.forEach(b => {
+        switch (b.type) {
+          case 'prose':
+            if (b.html) sections.push(b.title ? `## ${b.title}\n${b.html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim()}` : b.html.replace(/<[^>]+>/g, ' ').trim());
+            break;
+          case 'definition':
+            if (b.items?.length) {
+              sections.push((b.title ? `## ${b.title}\n` : '') + b.items.map(d => `${d.term}: ${d.description}${d.examples ? ' (e.g. ' + d.examples + ')' : ''}`).join('\n'));
+            }
+            break;
+          case 'table':
+            if (b.columns?.length && b.rows?.length) {
+              sections.push((b.title ? `## ${b.title}\n` : '') + [b.columns.join(' | '), ...b.rows.map(r => r.join(' | '))].join('\n'));
+            }
+            break;
+          case 'formula':
+            if (b.items?.length) {
+              sections.push((b.title ? `## ${b.title}\n` : '') + b.items.map(f => `${f.expression}: ${f.description}${f.constraints ? ' [' + f.constraints + ']' : ''}`).join('\n'));
+            }
+            break;
+          case 'procedure':
+            if (b.steps?.length) {
+              sections.push((b.title ? `## ${b.title}\n` : '') + b.steps.map((s, i) => `${i+1}. ${s}`).join('\n'));
+            }
+            break;
+          case 'callout':
+            if (b.html) sections.push(b.html.replace(/<[^>]+>/g, ' ').trim());
+            break;
+        }
+      });
+    }
+
+    // Legacy fields — fallback for older nodes
+    if (!sections.length) {
+      if (node.definitions?.length) {
+        sections.push('DEFINITIONS:\n' + node.definitions.map(d => `${d.term}: ${d.description}${d.examples ? ' (e.g. ' + d.examples + ')' : ''}`).join('\n'));
+      }
+      if (node.formulas?.length) {
+        sections.push('FORMULAS:\n' + node.formulas.map(f => `${f.expression}: ${f.description}`).join('\n'));
+      }
+      if (node.procedures?.length) {
+        sections.push('PROCEDURES:\n' + node.procedures.map(p => `${p.title}:\n` + p.steps.map((s, i) => `${i+1}. ${s}`).join('\n')).join('\n\n'));
+      }
+      if (node.tables?.length) {
+        sections.push('TABLES:\n' + node.tables.map(t => `${t.title}:\n` + [t.columns.join(' | '), ...t.rows.map(r => r.join(' | '))].join('\n')).join('\n\n'));
+      }
+      if (node.summary) sections.push('SUMMARY:\n' + node.summary);
+    }
+
+    // Raw OCR as last resort
+    if (!sections.length && node.rawOCR) {
+      sections.push('RAW SOURCE:\n' + node.rawOCR);
+    }
+
+    // The learner's own typed notes ("My Notes") are authored content and must
+    // count as source material — otherwise a node whose content lives here reads
+    // as empty and generators report "No source material provided."
+    if (node.userNotes && node.userNotes.trim()) {
+      sections.push('MY NOTES:\n' + node.userNotes.trim());
+    }
+
+    return sections.join('\n\n').slice(0, maxChars);
+  },
+
+  /** Returns a short string describing which questions the learner struggles with */
+  _weakQuestions(node) {
+    if (!node.questions?.length || !node.srsState) return '';
+    const weak = node.questions.filter(q => {
+      const s = node.srsState[q.id];
+      return s && (s.easeFactor < 2.2 || s.interval <= 1);
+    });
+    if (!weak.length) return '';
+    return weak.slice(0, 5).map(q => `- "${q.question}"`).join('\n');
+  },
+
+  /** Returns mastery label */
+  _masteryLabel(score) {
+    if (score >= 90) return 'excellent';
+    if (score >= 70) return 'good, some gaps';
+    if (score >= 50) return 'developing';
+    return 'needs significant work';
+  },
+
+  /** Returns last N session summaries as a string */
+  _sessionHistory(node, n = 3) {
+    const log = (node.sessionLog || []).slice(-n);
+    if (!log.length) return '';
+    return log.map(s => `- ${s.date}: ${s.summary}`).join('\n');
+  },
+
+  /** Returns exam style patterns for a subject from localStorage */
+  _examStyle(subject) {
+    if (!subject) return '';
+    try {
+      const key    = 'kn_exam_style_' + subject.toLowerCase().replace(/\s+/g, '_');
+      const stored = JSON.parse(localStorage.getItem(key) || '{"papers":[]}');
+      if (!stored.papers?.length) return '';
+      const latest = stored.papers[stored.papers.length - 1];
+      const a      = latest.analysis;
+      if (!a) return '';
+      const parts = [];
+      if (a.questionTypes?.length)  parts.push('Question types: ' + a.questionTypes.join(', '));
+      if (a.markAllocation)         parts.push('Mark allocation: ' + a.markAllocation);
+      if (a.keyThemes?.length)      parts.push('Key themes: ' + a.keyThemes.join(', '));
+      if (a.difficulty)             parts.push('Difficulty: ' + a.difficulty);
+      return parts.join('\n');
+    } catch(e) {
+      return '';
+    }
+  },
+};

--- a/knowledgenode/www/js/ai/LearnerContext.js
+++ b/knowledgenode/www/js/ai/LearnerContext.js
@@ -106,9 +106,19 @@ const LearnerContext = {
 
     parts.push(this._hardRules());
 
+    // Durable facts the student has stated (exam dates, time available, subjects,
+    // strategy) go in FIRST and unconditionally. They are not derived from the
+    // library, so they must survive an empty or not-yet-loaded node store — and
+    // they must never be lost to a failure further down. This is the memory every
+    // AI surface shares, so nothing the student has explained is asked twice.
+    try {
+      const factBlock = (typeof CoachFacts !== 'undefined') ? CoachFacts.block() : '';
+      if (factBlock) parts.push(factBlock);
+    } catch (e) { /* optional */ }
+
     try {
       const allNodes = nodeStore.getAll();
-      if (!allNodes.length) return '';
+      if (!allNodes.length) return parts.filter(Boolean).join('\n\n');
 
       // Overall learner stats
       const stats        = nodeStore.getStats();
@@ -210,6 +220,7 @@ const LearnerContext = {
         const sharedBlock = (typeof LearnerState !== 'undefined') ? LearnerState.toPromptBlock() : '';
         if (sharedBlock) parts.push(sharedBlock);
       } catch(e) { /* optional */ }
+
 
     } catch(e) {
       console.warn('[LearnerContext] forSession error:', e);

--- a/knowledgenode/www/js/ai/LearnerMemory.js
+++ b/knowledgenode/www/js/ai/LearnerMemory.js
@@ -1,0 +1,310 @@
+/**
+ * LearnerMemory.js — Writeback layer
+ *
+ * Every time the learner does something meaningful, a feature calls
+ * LearnerMemory.record(...). This writes a structured event to the node
+ * and updates the global learner state so the NEXT feature that opens
+ * knows exactly what happened before.
+ *
+ * EVENT TYPES:
+ *   review        — completed a review session (per node)
+ *   guided        — completed a guided study step or full session
+ *   tutor         — completed a Socratic tutor session
+ *   struggle      — rated a specific question Again/Hard
+ *   mastered      — rated a specific question Good/Easy consistently
+ *   note_opened   — opened a node's notes (lightweight, tracks recency)
+ *
+ * WHAT GETS WRITTEN:
+ *   node.sessionLog[]     — chronological event log per node (existing)
+ *   node.weakQuestions[]  — current list of question IDs being struggled with
+ *   node.lastActivity     — timestamp of last interaction
+ *   node.activitySummary  — one-line plain-English summary for AI context
+ *   localStorage (global) — cross-node learner state
+ */
+
+const LearnerMemory = {
+
+  /* ─────────────────────────────────────────────────────────
+     PUBLIC API — called by features after each interaction
+  ───────────────────────────────────────────────────────── */
+
+  /**
+   * Record a completed review session.
+   * Called by ReviewView._showComplete()
+   *
+   * @param {object} node      — the node reviewed
+   * @param {object} stats     — { again, hard, good, easy, score }
+   * @param {string[]} hardQIds — question IDs rated Again or Hard
+   */
+  recordReview(node, stats, hardQIds = []) {
+    const { again = 0, hard = 0, good = 0, easy = 0, score = 0 } = stats;
+    const total = again + hard + good + easy;
+    if (!total) return;
+
+    const performance = score >= 80 ? 'strong' : score >= 50 ? 'moderate' : 'struggling';
+    const summary = `Review: ${total} cards — ${score}% (Easy ${easy}, Good ${good}, Hard ${hard}, Again ${again}). Performance: ${performance}.`;
+
+    this._writeToNode(node, {
+      type:    'review',
+      score,
+      total,
+      stats:   { again, hard, good, easy },
+      hardQIds,
+      summary,
+    });
+
+    // Update weak questions list
+    this._updateWeakQuestions(node, hardQIds, ['good', 'easy'], stats);
+
+    // Update activity summary — this is what other features read first
+    node.activitySummary = summary;
+    node.lastActivity    = Date.now();
+
+    nodeStore.save(node);
+    this._writeGlobal(node);
+  },
+
+  /**
+   * Record completion of a Guided Study session.
+   * Called by GuidedView when session ends.
+   *
+   * @param {object} node
+   * @param {object} result — { stepsCompleted, recallScore, questionsAnswered }
+   */
+  recordGuidedSession(node, result = {}) {
+    const { stepsCompleted = 0, recallScore = null, questionsAnswered = 0 } = result;
+    const summary = `Guided study: ${stepsCompleted} steps completed`
+      + (recallScore !== null ? `, recall score ${recallScore}%` : '')
+      + (questionsAnswered ? `, answered ${questionsAnswered} questions` : '') + '.';
+
+    this._writeToNode(node, {
+      type: 'guided',
+      stepsCompleted,
+      recallScore,
+      questionsAnswered,
+      summary,
+    });
+
+    node.activitySummary = summary;
+    node.lastActivity    = Date.now();
+    nodeStore.save(node);
+    this._writeGlobal(node);
+  },
+
+  /**
+   * Record a Socratic tutor session.
+   * Called by SocraticTutor when session ends.
+   *
+   * @param {object} node
+   * @param {string} exampleTitle
+   * @param {string} aiSummary — the AI-generated summary of the session
+   */
+  recordTutorSession(node, exampleTitle, aiSummary) {
+    const summary = `Tutor session on "${exampleTitle}": ${aiSummary}`;
+
+    this._writeToNode(node, {
+      type:    'tutor',
+      example: exampleTitle,
+      summary,
+    });
+
+    node.activitySummary = summary;
+    node.lastActivity    = Date.now();
+    nodeStore.save(node);
+    this._writeGlobal(node);
+  },
+
+  /**
+   * Record that a question was struggled with (Again/Hard).
+   * Called per-card by ReviewView._rate()
+   *
+   * @param {object} node
+   * @param {object} question
+   * @param {number} rating  — 1=Again, 2=Hard
+   */
+  recordStruggle(node, question, rating) {
+    if (rating > 2) return; // Only Again/Hard counts as struggle
+
+    if (!node.weakQuestions) node.weakQuestions = [];
+    const already = node.weakQuestions.find(w => w.id === question.id);
+    if (already) {
+      already.count   = (already.count || 1) + 1;
+      already.lastAt  = Date.now();
+      already.rating  = rating;
+    } else {
+      node.weakQuestions.push({
+        id:     question.id,
+        text:   question.question,
+        count:  1,
+        rating,
+        lastAt: Date.now(),
+      });
+    }
+
+    // Keep only the 10 most recent struggles
+    node.weakQuestions = node.weakQuestions
+      .sort((a, b) => b.lastAt - a.lastAt)
+      .slice(0, 10);
+
+    // Don't save here — ReviewView saves after recordRating(); avoid double-save
+  },
+
+  /**
+   * Record that a note was opened — lightweight recency tracking.
+   * Called by NodeDetailView.open()
+   *
+   * @param {object} node
+   */
+  recordNoteOpened(node) {
+    node.lastActivity = Date.now();
+    // Don't trigger a full save — just update the timestamp silently
+    try {
+      const all = JSON.parse(localStorage.getItem('kn_nodes_v1') || '{}');
+      if (all[node.id]) {
+        all[node.id].lastActivity = node.lastActivity;
+        localStorage.setItem('kn_nodes_v1', JSON.stringify(all));
+      }
+    } catch(e) { /* non-critical */ }
+  },
+
+  /* ─────────────────────────────────────────────────────────
+     GLOBAL STATE
+     Cross-node learner state — read by LearnerContext.forSession()
+  ───────────────────────────────────────────────────────── */
+
+  /**
+   * Read the global learner state.
+   * Returns { recentNodes, overallTrend, totalSessions, lastStudied }
+   */
+  getGlobalState() {
+    try {
+      return JSON.parse(localStorage.getItem('kn_learner_state') || '{}');
+    } catch(e) {
+      return {};
+    }
+  },
+
+  /* ─────────────────────────────────────────────────────────
+     CONTEXT HELPERS — read by LearnerContext
+  ───────────────────────────────────────────────────────── */
+
+  /**
+   * Returns a short plain-English summary of what the learner
+   * last did with a specific node. Used by LearnerContext to
+   * tell the AI what happened before.
+   *
+   * @param {object} node
+   * @returns {string}
+   */
+  getNodeActivitySummary(node) {
+    const clean = (s) => {
+      if (!s || typeof s !== 'string') return '';
+      const t = s.trim();
+      // Reject AI error blobs / raw JSON that were mistakenly cached as a summary.
+      if (/^[`\s]*\{/.test(t) || /"error"\s*:/i.test(t)
+          || /no source material/i.test(t) || /cannot complete summary/i.test(t)
+          || /please provide the source/i.test(t)) {
+        return '';
+      }
+      return t;
+    };
+
+    const direct = clean(node.activitySummary);
+    if (direct) return direct;
+
+    // Fall back to last session log entry
+    const log = (node.sessionLog || []).slice(-1)[0];
+    if (log) return clean(log.summary);
+
+    return '';
+  },
+
+  /**
+   * Returns the current weak questions for a node as a readable string.
+   * Used by LearnerContext._weakQuestions()
+   *
+   * @param {object} node
+   * @returns {string}
+   */
+  getWeakQuestionsText(node) {
+    const weak = node.weakQuestions || [];
+    if (!weak.length) return '';
+    return weak
+      .slice(0, 5)
+      .map(w => `- "${w.text}" (struggled ${w.count}x)`)
+      .join('\n');
+  },
+
+  /* ─────────────────────────────────────────────────────────
+     PRIVATE HELPERS
+  ───────────────────────────────────────────────────────── */
+
+  /** Write a structured event to node.sessionLog */
+  _writeToNode(node, event) {
+    if (!node.sessionLog) node.sessionLog = [];
+    node.sessionLog.push({
+      date:    new Date().toLocaleDateString(),
+      ts:      Date.now(),
+      ...event,
+    });
+    // Keep log bounded — last 30 events
+    if (node.sessionLog.length > 30) {
+      node.sessionLog = node.sessionLog.slice(-30);
+    }
+  },
+
+  /** Update node.weakQuestions based on a session's hard/easy question IDs */
+  _updateWeakQuestions(node, hardQIds, goodRatings, stats) {
+    if (!node.weakQuestions) node.weakQuestions = [];
+
+    // Questions answered well — reduce their struggle count
+    const goodQIds = (node.questions || [])
+      .filter(q => {
+        const s = node.srsState?.[q.id];
+        return s && s.easeFactor >= 2.5 && s.interval >= 3;
+      })
+      .map(q => q.id);
+
+    node.weakQuestions = node.weakQuestions
+      .filter(w => !goodQIds.includes(w.id)) // remove mastered questions
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 10);
+  },
+
+  /** Write a summary of this node's state to the global learner state */
+  _writeGlobal(node) {
+    try {
+      const state = this.getGlobalState();
+      if (!state.recentNodes) state.recentNodes = [];
+
+      // Update or add this node's entry
+      const existing = state.recentNodes.findIndex(n => n.id === node.id);
+      const entry = {
+        id:      node.id,
+        title:   node.title,
+        subject: node.subject,
+        mastery: node.masteryScore ?? 0,
+        lastAt:  Date.now(),
+        summary: node.activitySummary || '',
+      };
+
+      if (existing >= 0) {
+        state.recentNodes[existing] = entry;
+      } else {
+        state.recentNodes.unshift(entry);
+      }
+
+      // Keep only the 20 most recently active nodes
+      state.recentNodes = state.recentNodes
+        .sort((a, b) => b.lastAt - a.lastAt)
+        .slice(0, 20);
+
+      state.lastStudied    = Date.now();
+      state.totalSessions  = (state.totalSessions || 0) + 1;
+
+      localStorage.setItem('kn_learner_state', JSON.stringify(state));
+    } catch(e) {
+      console.warn('[LearnerMemory] Failed to write global state:', e);
+    }
+  },
+};

--- a/knowledgenode/www/js/app.js
+++ b/knowledgenode/www/js/app.js
@@ -1,0 +1,503 @@
+/**
+ * app.js v5 — Fixed routing, mobile more menu, detail tab bar, theme toggle
+ */
+const App = {
+  _currentView: 'upload',
+  _initialized: false,
+
+  init() {
+    // Small wrapper so one failing subsystem can't abort the whole init()
+    // (which previously left navigation unbound — "nav buttons don't work").
+    const safe = (fn, label) => {
+      try { fn(); }
+      catch (e) {
+        console.error('[init] ' + label + ' failed:', e);
+        try {
+          const b = document.getElementById('kn-error-banner');
+          if (b) { b.style.display = 'block'; b.textContent += '[init] ' + label + ' failed: ' + (e && e.message || e) + '\n'; }
+        } catch (_) {}
+      }
+    };
+
+    // ── Bind navigation FIRST ──────────────────────────────────────────────
+    // Wire nav before any view init runs, so even if a later subsystem throws,
+    // the tabs always work.
+    this._bindNavigation();
+
+    // Migrate old kn_last_directive → LearnerState on first run
+    if (typeof LearnerState !== 'undefined') safe(() => LearnerState.migrate(), 'LearnerState.migrate');
+
+    // SERVICE WORKER DISABLED — a broken SW from an earlier build (v63-27 had
+    // non-existent files in its precache list) can get stuck controlling the page
+    // and serve stale/broken assets, making the app appear dead. Actively
+    // unregister any installed SW and clear its caches so files always load fresh.
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.getRegistrations().then(regs => {
+        regs.forEach(r => r.unregister());
+      }).catch(()=>{});
+      if (typeof caches !== 'undefined') {
+        caches.keys().then(keys => keys.forEach(k => caches.delete(k))).catch(()=>{});
+      }
+    }
+
+    // Data-safety guard: weekly backup auto-save (Android) or nudge (browser).
+    setTimeout(() => { try { BackupGuard.check(); } catch (e) {} }, 4000);
+
+    // Init views — each isolated so one failure can't break the rest or nav.
+    safe(() => UploadView.init(), 'UploadView');
+    safe(() => GuidedView.init(), 'GuidedView');
+    safe(() => LibraryView.init(), 'LibraryView');
+    safe(() => NodeDetailView.init(), 'NodeDetailView');
+    safe(() => ReviewView.init(), 'ReviewView');
+    safe(() => Dashboard.init(), 'Dashboard');
+    safe(() => StudyPlanView.init(), 'StudyPlanView');
+    safe(() => StudySession.requestNotifications(), 'StudySession.requestNotifications');
+    safe(() => StreakTracker.render(), 'StreakTracker.render');
+
+    // Theme toggle — ThemeToggle.js removed, inlined here
+    safe(() => {
+      const _tkey = 'kn_theme';
+      const _apply = t => {
+        document.documentElement.classList.toggle('light-theme', t === 'light');
+        const icon = t === 'dark' ? '☀' : '🌙';
+        document.querySelectorAll('[data-theme-toggle]').forEach(b => {
+          const iconEl = b.querySelector('[data-theme-icon]');
+          if (iconEl) iconEl.textContent = icon;   // preserve any label markup
+          else        b.textContent = icon;          // icon-only buttons (e.g. header)
+          b.title = t === 'dark' ? 'Switch to light mode' : 'Switch to dark mode';
+        });
+      };
+      window.ThemeToggle = { toggle() {
+        const next = document.documentElement.classList.contains('light-theme') ? 'dark' : 'light';
+        _apply(next); localStorage.setItem(_tkey, next);
+      }};
+      _apply(localStorage.getItem(_tkey) || 'dark');
+      document.querySelectorAll('[data-theme-toggle]').forEach(b =>
+        b.addEventListener('click', () => ThemeToggle.toggle()));
+    }, 'ThemeToggle');
+
+    // Study Color mode — additive accent palettes on top of dark/light.
+    // Fully independent of ThemeToggle above; picking nothing leaves the
+    // app exactly as it always was (default amber).
+    safe(() => {
+      const AKEY = 'kn_accent_theme';
+      const ACCENTS = ['default', 'focus', 'growth', 'energy'];
+      const _applyAccent = a => {
+        ACCENTS.forEach(x => { if (x !== 'default') document.documentElement.classList.remove('accent-' + x); });
+        if (a && a !== 'default') document.documentElement.classList.add('accent-' + a);
+      };
+      window.AccentTheme = {
+        ACCENTS,
+        get() { return localStorage.getItem(AKEY) || 'default'; },
+        set(a) {
+          const v = ACCENTS.includes(a) ? a : 'default';
+          _applyAccent(v);
+          try { localStorage.setItem(AKEY, v); } catch (e) {}
+        },
+      };
+      _applyAccent(AccentTheme.get());
+    }, 'AccentTheme');
+
+    safe(() => SelectToAction.init(), 'SelectToAction');
+
+    // Remaining (non-navigation) UI bindings — isolated so a missing element
+    // can't break init.
+    safe(() => this._bindChrome(), 'chrome bindings');
+
+    safe(() => {
+      // When any node changes, invalidate the LearnerContext session cache.
+      nodeStore.addEventListener('change', () => {
+        if (typeof LearnerContext !== 'undefined') LearnerContext._sessionCache = null;
+      });
+      // Store changes — debounced UI refresh.
+      let _uiRefreshTimer;
+      nodeStore.addEventListener('change', () => {
+        clearTimeout(_uiRefreshTimer);
+        _uiRefreshTimer = setTimeout(() => {
+          this.updateSidebarStats();
+          if (this._currentView === 'library')   LibraryView.refresh();
+          if (this._currentView === 'guided')    GuidedView.refresh();
+          if (this._currentView === 'review')    ReviewView.refresh();
+          if (this._currentView === 'dashboard') Dashboard.refresh();
+          if (this._currentView === 'studyplan') StudyPlanView.refresh();
+        }, 350);
+      });
+    }, 'nodeStore listeners');
+
+    safe(() => AIService.loadConfig(), 'AIService.loadConfig');
+    safe(() => { if (typeof Paywall !== 'undefined') Paywall.init(); }, 'Paywall.init');
+    safe(() => this._checkApiKey(), '_checkApiKey');
+    safe(() => this.updateSidebarStats(), 'updateSidebarStats');
+
+    // Enable autocorrect, spell-check and text prediction on all text inputs —
+    // Android's WebView doesn't activate these by default. A MutationObserver
+    // covers dynamically-created inputs (modals, question boxes, chat, etc.).
+    safe(() => {
+      const patchInputs = () => {
+        document.querySelectorAll(
+          'textarea:not([data-ime]),input[type="text"]:not([data-ime]),input:not([type]):not([data-ime])'
+        ).forEach(el => {
+          el.dataset.ime = '1';
+          if (!el.hasAttribute('autocorrect'))   el.setAttribute('autocorrect', 'on');
+          if (!el.hasAttribute('autocapitalize')) el.setAttribute('autocapitalize', 'sentences');
+          if (!el.hasAttribute('spellcheck'))    el.setAttribute('spellcheck', 'true');
+          // Gboard/Samsung keyboards hide the prediction strip when a field
+          // looks like a form field with autofill disabled — say it isn't.
+          if (!el.hasAttribute('autocomplete'))  el.setAttribute('autocomplete', 'on');
+          if (!el.hasAttribute('inputmode') && el.tagName === 'TEXTAREA') el.setAttribute('inputmode', 'text');
+        });
+      };
+      patchInputs();
+      new MutationObserver(patchInputs).observe(document.body, { childList: true, subtree: true });
+    }, 'ime patch');
+
+    // Data safety reminder — shown once every 7 days if the user has nodes
+    // but hasn't exported recently. Prevents silent data loss.
+    safe(() => {
+      const WEEK = 7 * 24 * 60 * 60 * 1000;
+      const lastReminder = parseInt(localStorage.getItem('kn_last_backup_reminder') || '0', 10);
+      const hasNodes = nodeStore.getAll().length > 0;
+      if (hasNodes && Date.now() - lastReminder > WEEK) {
+        setTimeout(() => {
+          localStorage.setItem('kn_last_backup_reminder', String(Date.now()));
+          Toast.info('💾 Back up your nodes — go to Settings → Export All Nodes or Settings → Backups → Download. Uninstalling the app deletes everything.', 8000);
+        }, 3000);
+      }
+    }, 'backup reminder');
+
+    // Smart start view — reduce friction for returning users
+    safe(() => {
+      const lastView   = localStorage.getItem('kn_last_view');
+      const lastNodeId = localStorage.getItem('kn_last_node');
+      if (lastView === 'node-detail' && lastNodeId && nodeStore.get(lastNodeId)) {
+        this.navigateTo('node-detail');
+        NodeDetailView.open(lastNodeId);
+      } else {
+        this.navigateTo(this._smartStartView(lastView));
+      }
+    }, 'smart start view');
+
+    // Mark init complete — the on-screen failsafe relies on this flag to decide
+    // whether navigation got bound. (Do NOT use _currentView for this; it's
+    // preset in the object literal and is always truthy.)
+    this._initialized = true;
+
+    setTimeout(() => { try { Onboarding.checkFirstLaunch(); } catch (e) {} }, 600);
+  },
+
+  /** Bind all navigation handlers. Runs first in init() so tabs always work,
+   *  even if a later subsystem throws. Idempotent via a guard flag per element. */
+  _bindNavigation() {
+    const bind = (el, fn) => {
+      if (!el || el._navBound) return;
+      el._navBound = true;
+      el.addEventListener('click', fn);
+    };
+
+    // Desktop sidebar nav
+    document.querySelectorAll('.nav-item').forEach(btn =>
+      bind(btn, () => this.navigateTo(btn.dataset.view)));
+
+    // Mobile bottom nav
+    document.querySelectorAll('.mobile-nav-btn').forEach(btn =>
+      bind(btn, () => {
+        const view = btn.dataset.view;
+        if (view === 'more-menu') { this._toggleMoreMenu(); }
+        else { this._closeMoreMenu(); this.navigateTo(view); }
+      }));
+
+    // More menu items
+    document.querySelectorAll('.more-menu-item[data-view]').forEach(btn =>
+      bind(btn, () => { this._closeMoreMenu(); this.navigateTo(btn.dataset.view); }));
+
+    bind(document.getElementById('more-menu-close'), () => this._closeMoreMenu());
+  },
+
+  /** Non-navigation chrome (sidebar collapse, modals, detail topbar, etc.).
+   *  Each binding individually guarded so a missing element can't abort. */
+  _bindChrome() {
+    const on = (id, ev, fn) => { const el = document.getElementById(id); if (el) el.addEventListener(ev, fn); };
+
+    on('sidebar-toggle', 'click', () => {
+      const s = document.getElementById('sidebar');
+      if (!s) return;
+      const c = s.classList.toggle('collapsed');
+      const t = document.getElementById('sidebar-toggle');
+      if (t) t.textContent = c ? '▶' : '◀';
+    });
+
+    on('ai-settings-sidebar-btn', 'click', () => SettingsPanel.open());
+    on('ai-director-btn', 'click', () => AIDirector.run());
+    on('more-menu-aidirector', 'click', () => { this._closeMoreMenu(); AIDirector.run(); });
+    on('more-menu-coach', 'click', () => { this._closeMoreMenu(); StudyCoach.open(); });
+    on('start-timer-btn', 'click', () => { StudySession.requestNotifications(); StudySession.open(); });
+    on('more-menu-settings', 'click', () => { this._closeMoreMenu(); SettingsPanel.open(); });
+    on('more-menu-guide', 'click', () => { this._closeMoreMenu(); Guide.open(); });
+    on('more-menu-timer', 'click', () => { this._closeMoreMenu(); StudySession.open(); });
+
+    // Node detail topbar buttons
+    on('detail-back', 'click', () => this.navigateTo('library'));
+    on('detail-export-btn', 'click', () =>
+      NodeDetailView._currentNode && PrintExport.showNodeExportMenu(NodeDetailView._currentNode));
+    on('detail-print-btn', 'click', () =>
+      NodeDetailView._currentNode && PrintExport.printNode(NodeDetailView._currentNode));
+    on('detail-learn-btn', 'click', () => {
+      try {
+        const node = NodeDetailView._currentNode;
+        if (!node) { Toast.info('Open a node first.'); return; }
+        LearnPanel.open(node);
+      } catch (e) {
+        Toast.error('Error: ' + e.message);
+        console.error('LearnPanel error:', e);
+      }
+    });
+
+    // Node detail tab buttons (mobile + desktop)
+    document.querySelectorAll('.detail-tab-btn, .detail-nav-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('.detail-tab-btn').forEach(b => b.classList.toggle('active', b === btn || b.dataset.section === btn.dataset.section));
+        document.querySelectorAll('.detail-nav-btn').forEach(b => b.classList.toggle('active', b === btn || b.dataset.section === btn.dataset.section));
+        NodeDetailView._currentSection = btn.dataset.section;
+        NodeDetailView._editMode = false;
+        NodeDetailView._renderSection();
+      });
+    });
+
+    // Modal close
+    on('modal-close', 'click', () => Modal.close());
+    on('modal-overlay', 'click', e => {
+      if (e.target === document.getElementById('modal-overlay')) Modal.close();
+    });
+
+    // Plan header button
+    on('new-plan-header-btn', 'click', () => StudyPlanBuilder.open());
+
+    // Competency view back button
+    on('competency-back', 'click', () => this.navigateTo('studyplan'));
+  },
+
+  /** What's actually on screen right now — a plain top-level view, OR a
+   *  specific node/competency sub-view that bypasses the normal view switch.
+   *  Used to build a real back-history stack (see _maybePush/goBack below). */
+  _currentDescriptor() {
+    if (document.getElementById('view-node-detail')?.classList.contains('active')
+        && typeof NodeDetailView !== 'undefined' && NodeDetailView._currentNode) {
+      return { type: 'node', id: NodeDetailView._currentNode.id, section: NodeDetailView._currentSection || 'notes' };
+    }
+    if (document.getElementById('view-competency')?.classList.contains('active')
+        && typeof CompetencyView !== 'undefined') {
+      return { type: 'competency', subject: CompetencyView._subject, mode: CompetencyView._mode };
+    }
+    return { type: 'view', view: this._currentView };
+  },
+
+  /** Push the CURRENT screen onto the back stack before navigating away from
+   *  it, so the phone's back button can return to it later — mirrors the
+   *  overlay stack (KNNav) but for full-page navigation. No-ops during a
+   *  goBack() replay, and skips pushing a no-op (already-there) transition. */
+  _maybePush(target) {
+    if (this._restoring) return;
+    const cur = this._currentDescriptor();
+    const same = cur.type === target.type && (
+      cur.type === 'node'       ? (cur.id === target.id && (cur.section || 'notes') === (target.section || 'notes')) :
+      cur.type === 'competency' ? (cur.subject === target.subject && cur.mode === target.mode) :
+      cur.view === target.view
+    );
+    if (same) return;
+    this._backStack = this._backStack || [];
+    this._backStack.push(cur);
+    if (this._backStack.length > 40) this._backStack.shift(); // cap growth
+  },
+
+  /** Phone back button, main-navigation case: pop the last screen and
+   *  restore it exactly (a top-level view, a specific node, or a specific
+   *  competency report) — not a fixed "always go to library" shortcut. */
+  goBack() {
+    if (!this._backStack || !this._backStack.length) return false;
+    const d = this._backStack.pop();
+    this._restoring = true;
+    try {
+      if (d.type === 'node' && typeof nodeStore !== 'undefined' && nodeStore.get(d.id)) {
+        NodeDetailView.open(d.id, d.section);
+      } else if (d.type === 'competency' && typeof CompetencyView !== 'undefined') {
+        CompetencyView.open(d.subject, d.mode);
+      } else {
+        this.navigateTo(d.view || 'library');
+      }
+    } catch (e) { console.warn('[App] goBack restore failed:', e); }
+    this._restoring = false;
+    return true;
+  },
+
+  navigateTo(view) {
+    this._maybePush({ type: 'view', view });
+    this._currentView = view;
+    // Reset guided session state when navigating away, so the next visit
+    // shows the filter/start screen rather than resuming mid-session.
+    if (view !== 'guided' && typeof GuidedView !== 'undefined') {
+      GuidedView._inSession = false;
+    }
+    // Save lecture position before stopping speech, so it can resume later
+    if (typeof LectureMode !== 'undefined' && LectureMode._savePosition) {
+      try { LectureMode._savePosition(); } catch(e) {}
+    }
+    // Stop any active speech when navigating
+    if (window.speechSynthesis) window.speechSynthesis.cancel();
+    SpeechPill.hide();
+    // Persist view — now includes node-detail
+    localStorage.setItem('kn_last_view', view);
+    // Clear last node when leaving node-detail
+    if (view !== 'node-detail') localStorage.removeItem('kn_last_node');
+    // Clean up AI floater when leaving node detail
+    if (view !== 'node-detail') document.getElementById('ai-floater')?.remove();
+    document.querySelectorAll('.view').forEach(v => v.classList.remove('active'));
+    document.querySelectorAll('.nav-item').forEach(b => b.classList.toggle('active', b.dataset.view === view));
+    document.querySelectorAll('.mobile-nav-btn').forEach(b => b.classList.toggle('active', b.dataset.view === view));
+    const el = document.getElementById(`view-${view}`);
+    if (el) el.classList.add('active');
+    switch (view) {
+      case 'guided':    GuidedView.refresh();    break;
+      case 'library':   LibraryView.refresh();   break;
+      case 'review':    ReviewView.refresh();     break;
+      case 'dashboard': Dashboard.refresh();      break;
+      case 'studyplan': StudyPlanView.refresh();  break;
+      case 'competency': CompetencyView.refresh(); break;
+    }
+    const mc = document.getElementById('main-content');
+    if (mc) mc.scrollTop = 0;
+    window.scrollTo(0, 0);
+  },
+
+  showView(viewId) {
+    document.querySelectorAll('.view').forEach(v => v.classList.remove('active'));
+    document.getElementById(`view-${viewId}`)?.classList.add('active');
+  },
+
+  updateSidebarStats() {
+    const s = nodeStore.getStats();
+    document.getElementById('stat-nodes').textContent   = s.total;
+    document.getElementById('stat-mastery').textContent = s.mastery + '%';
+    document.getElementById('stat-due').textContent     = s.due;
+  },
+
+  _toggleMoreMenu() {
+    const panel = document.getElementById('more-menu-panel');
+    if (!panel) return;
+    if (panel.classList.contains('hidden')) {
+      panel.classList.remove('hidden');
+      if (typeof KNNav !== 'undefined')
+        this._moreKnBackId = KNNav.register(() => this._closeMoreMenu());
+    } else {
+      this._closeMoreMenu();
+    }
+  },
+  _closeMoreMenu() {
+    document.getElementById('more-menu-panel')?.classList.add('hidden');
+    if (this._moreKnBackId && typeof KNNav !== 'undefined') {
+      KNNav.unregister(this._moreKnBackId);
+      this._moreKnBackId = null;
+    }
+  },
+
+  _checkApiKey() {
+    // Re-run automatically once async proxy detection completes.
+    document.addEventListener('kn-proxy-detected', () => {
+      document.getElementById('api-key-banner')?.remove();
+      const mc = document.getElementById('main-content');
+      if (mc) mc.style.paddingTop = '';
+    }, { once: true });
+
+    if (AIService.hasApiKey()) return;
+    // Detection may still be in flight; give it a brief moment before showing the banner.
+    setTimeout(() => {
+      if (AIService.hasApiKey() || document.getElementById('api-key-banner')) return;
+      this._showApiKeyBanner();
+    }, 1200);
+  },
+
+  /** Pick the most valuable screen for this user right now.
+   *  New users → upload. Returning + due cards → review. Otherwise → resume or guided. */
+  _smartStartView(lastView) {
+    const stats = nodeStore.getStats();
+    // New user with no content — always upload first
+    if (!stats.total) return 'upload';
+    // Was somewhere useful — resume it (but not upload, which is a task not a view)
+    if (lastView && !['upload', 'node-detail'].includes(lastView)) return lastView;
+    // Has due cards — review is the highest-value action
+    if (stats.due > 0) return 'review';
+    // Nodes exist but nothing due — start a guided session
+    return 'guided';
+  },
+
+  _showApiKeyBanner() {
+    const banner = document.createElement('div');
+    banner.id = 'api-key-banner';
+    banner.innerHTML = `
+      <span>⬡ Demo mode — <strong style="color:var(--accent)">no AI configured</strong>.</span>
+      <div style="display:flex;gap:8px;flex-shrink:0;">
+        <button id="banner-configure-btn" style="padding:6px 14px;background:var(--accent);color:#060709;border:none;border-radius:var(--radius-sm);font-family:var(--font-ui);font-size:12px;font-weight:700;cursor:pointer;white-space:nowrap;">Configure AI</button>
+        <button id="banner-dismiss-btn" style="padding:6px 10px;background:transparent;color:var(--text-muted);border:1px solid var(--border);border-radius:var(--radius-sm);font-size:12px;cursor:pointer;">✕</button>
+      </div>`;
+    document.body.prepend(banner);
+    document.getElementById('banner-configure-btn').addEventListener('click', () => AISettingsModal.open());
+    document.getElementById('banner-dismiss-btn').addEventListener('click', () => {
+      banner.remove();
+      document.getElementById('main-content').style.paddingTop = '';
+    });
+    document.getElementById('main-content').style.paddingTop = '46px';
+  },
+};
+
+// Emergency SW reset: add ?reset=1 to URL to unregister SW and reload clean
+if (location.search.includes('reset=1') && 'serviceWorker' in navigator) {
+  navigator.serviceWorker.getRegistrations().then(regs => {
+    Promise.all(regs.map(r => r.unregister())).then(() => {
+      caches.keys().then(keys => Promise.all(keys.map(k => caches.delete(k)))).then(() => {
+        location.replace(location.pathname);
+      });
+    });
+  });
+} else {
+  // If the DOM is already parsed (scripts at end of body often run after
+  // DOMContentLoaded has fired), init immediately. Otherwise wait for the event.
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => App.init());
+  } else {
+    App.init();
+  }
+}
+
+// ── Cross-tab sync ────────────────────────────────────────────────────────
+// When another tab saves nodes, reload the store and refresh the current view.
+window.addEventListener('storage', e => {
+  if (e.key === 'kn_nodes_v1' && e.newValue) {
+    try {
+      nodeStore._load();
+      App.updateSidebarStats();
+      const view = App._currentView;
+      if (view === 'library')    LibraryView.refresh();
+      if (view === 'review')     ReviewView.refresh();
+      if (view === 'dashboard')  Dashboard.refresh?.();
+      if (view === 'studyplan')  StudyPlanView.refresh?.();
+    } catch(e2) {
+      console.warn('[App] Cross-tab sync failed:', e2);
+    }
+  }
+});
+
+// ── Visibility change — reload if data may have changed ──────────────────
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'hidden') {
+    // Tab is being backgrounded — save lecture position so it can resume
+    if (typeof LectureMode !== 'undefined' && LectureMode._savePosition) {
+      try { LectureMode._savePosition(); } catch(e) {}
+    }
+  }
+  if (document.visibilityState === 'visible') {
+    try {
+      nodeStore._load();
+      App.updateSidebarStats();
+    } catch(e) {}
+  }
+});
+

--- a/knowledgenode/www/js/core/AppConfig.js
+++ b/knowledgenode/www/js/core/AppConfig.js
@@ -1,0 +1,31 @@
+/**
+ * AppConfig.js — build-time switches for the public, managed-AI release.
+ *
+ * In this build, AI features are provided by the app's server proxy and gated
+ * behind a Google Play subscription (verified by RevenueCat). Users do NOT bring
+ * their own key.
+ */
+const AppConfig = {
+  // When true, every AI action requires an active subscription. The BYO-key
+  // settings UI is hidden (see AISettingsModal) so the only way in is to subscribe.
+  MANAGED_ONLY: false,
+
+  // Must match the entitlement identifier you create in RevenueCat
+  // (RevenueCat → Entitlements) AND the REVENUECAT_ENTITLEMENT_ID env on the proxy.
+  ENTITLEMENT_ID: 'premium',
+
+  // RevenueCat PUBLIC SDK key for Android (RevenueCat → Project → API keys →
+  // "Public app-specific" / starts with "goog_"). NOT the secret key — the secret
+  // lives only on the proxy as REVENUECAT_SECRET_KEY.
+  REVENUECAT_PUBLIC_SDK_KEY: 'goog_REPLACE_ME',
+
+  // Optional shared secret. If you set PROXY_APP_TOKEN on the proxy, put the same
+  // value here so the app sends it as the x-app-token header.
+  PROXY_APP_TOKEN: '',
+
+  // REQUIRED for the installed Android app: the absolute URL of your deployed
+  // proxy (where /api/claude-proxy lives), e.g. 'https://your-app.vercel.app'.
+  // Leave '' only for the web build that is served from the same origin as the proxy.
+  PROXY_BASE_URL: '',
+};
+if (typeof window !== 'undefined') window.AppConfig = AppConfig;

--- a/knowledgenode/www/js/core/AppFeatures.js
+++ b/knowledgenode/www/js/core/AppFeatures.js
@@ -1,0 +1,110 @@
+/**
+ * AppFeatures.js — Single source of truth for what the app can do.
+ *
+ * KEEP THIS UP TO DATE when you add a new feature.
+ * The study coach reads this automatically — no other changes needed.
+ *
+ * Each entry:
+ *   name        — short display name
+ *   where       — where to find it in the app
+ *   what        — one sentence: what it does for the student
+ *   coachTip    — optional: how the coach should recommend it
+ */
+const AppFeatures = [
+  {
+    name: 'Guided Study',
+    where: 'Study tab → select a topic',
+    what: 'A 6-step walkthrough: orient, check prior knowledge, read notes, blank-recall, practice questions, reflect. ADAPTIVE: topics that are pure revision-question banks (no notes) automatically get a shortened question-first session — orient, drill every question, reflect — instead of notes pages.',
+    coachTip: 'Best for first-time study of a topic or revisiting something weak. For question-bank topics, it IS the drill — recommend it as the way to practice imported revision questions.',
+  },
+  {
+    name: 'Lecture Slides',
+    where: 'Study tab → select a topic → tap "Lecture" or "Slides"',
+    what: 'AI generates a full slide deck with bullet points and narration for the topic. Can be played automatically (auto-advances with narration) or presented full-screen.',
+    coachTip: 'Good for visual learners or when the student wants a structured overview before diving into notes.',
+  },
+  {
+    name: 'Review / Spaced Repetition',
+    where: 'Review tab',
+    what: 'Flashcard-style review of all topics. Cards are scheduled automatically — weak cards come back sooner. Modes: Today (due reviews blended with a PACED batch of new cards — a big upload is dripped in at a sustainable daily limit, not dumped all at once), All, and Weak Spots (the questions you keep getting wrong, hardest first, across the whole library). LEECH BREAKER: a card failed several times stops being re-drilled and the app offers to understand the concept instead of grinding a blank.',
+    coachTip: 'Best for consolidation and exam prep. Do the "Today" session daily — it mixes review with a healthy number of new cards so nothing floods you. If a student keeps failing the same question, tell them that\'s a signal to LEARN the concept (open the topic / use the tutor), not to drill it harder — the app flags these automatically.',
+  },
+  {
+    name: 'Library',
+    where: 'Library tab',
+    what: 'All topics with their notes, examples, questions, and mastery scores. Each topic has tabs: Notes, Examples, Questions, Mastery.',
+    coachTip: 'Where the student reads and manages their source material.',
+  },
+  {
+    name: 'Worked Examples',
+    where: 'Library → topic → Examples tab',
+    what: 'Solved accounting examples the student has scanned in. Can be read directly or taught step-by-step by the coach.',
+    coachTip: 'For accounting, studying a worked example then redoing it covered-up is one of the most effective techniques.',
+  },
+  {
+    name: 'Add / Scan Content',
+    where: 'Add tab (+ button)',
+    what: 'Scan photos of handbook pages or upload PDFs. AI extracts the content into structured notes. ADAPTIVE: uploads are classified automatically — worked examples are offered to the Examples tab, and question sheets are detected and offered as verbatim practice-question imports instead of being rewritten into notes.',
+  },
+  {
+    name: 'Study Plan',
+    where: 'Study Plan tab or Dashboard → Create Study Plan',
+    what: 'Creates a day-by-day study schedule based on exam date, daily available time, and topic difficulty. Tracks session completion.',
+    coachTip: 'If the student has an exam date, building a plan removes the daily "what should I study?" decision.',
+  },
+  {
+    name: 'AI Study Coach (this)',
+    where: 'More menu → Talk to your coach',
+    what: 'Conversational coach that sees the whole library — topics, mastery, examples, plan. Advises on study strategy, technique, and what to prioritise. The coach and the worked-example tutor are ONE unified engine (same conversation, same memory) in different views. It can pivot modes on request: SOCRATIC TUTORING ("tutor me through my revision questions" — strategy first, micro-steps, no final answers given away, with Got-it/Struggled self-marking that updates mastery); RESOURCE MODE ("study my Gross Income topic with me" — loads that topic\'s full saved material into the chat, no re-upload, for explanations, summaries, and recall quizzing); and it can BUILD a linked Revision Questions topic from any existing topic\'s material ("make revision questions from my notes"). MEMORY: the conversation is saved on-device and survives closing the app, and stable facts the student states (exam dates, how much time they have each day, which subjects they are taking, work schedule, their study strategy) are remembered permanently and re-read on every reply — so the coach does not ask for the same information twice, and a correction replaces the old value.',
+  },
+  {
+    name: 'Understanding Check',
+    where: 'Study tab → topic → Check step',
+    what: 'AI asks questions about the topic and evaluates your answers, giving feedback on gaps.',
+  },
+  {
+    name: 'PowerPoint Export',
+    where: 'Study tab → topic → Lecture Slides → ↓ PowerPoint',
+    what: 'Downloads the generated slide deck as a real .pptx file.',
+  },
+  {
+    name: 'Revision Questions Upload',
+    where: 'Add tab → 📚 Revision Questions',
+    what: 'Photograph EVERY page of a revision worksheet at once (questions, answer keys, solutions — multiple photos in one go). AI extracts every question and its answer exactly as written — nothing rewritten — into a topic as real, gradeable questions tracked by spaced repetition. Handles multiple-choice (options kept, letter-only answer keys expanded to full text) and long scenario questions (split per required part with the scenario data included).',
+    coachTip: 'For students who study by working through revision questions: upload the worksheet, then drill it via Guided Study or Review. Misses surface under "Review in your textbook".',
+  },
+  {
+    name: 'Past Exam Paper Upload',
+    where: 'Add tab → 📝 Past Exam Paper',
+    what: 'Upload all pages of a real past paper (with memo if available). Extracts EVERY question and model answer into a topic as practicable questions, AND learns the exam\'s style (question types, mark patterns) so future AI-generated questions match the real exam.',
+    coachTip: 'The highest-value upload before an exam — the examiner\'s real questions become drillable material.',
+  },
+  {
+    name: 'Exam Mode',
+    where: 'Exam tab (sidebar, or More menu on mobile)',
+    what: 'Three formats: Report Card (strengths vs gaps per subject), Timed Quiz (mock exam with countdown), and AI Exam (open answers graded with feedback). Pulls from every topic\'s question bank — including imported revision questions and past-paper questions. SMART SELECTION: the questions aren\'t random — the paper weights toward what the student keeps getting wrong, what\'s due for review, and subjects with analysed past papers, while keeping breadth across topics and varying each attempt. INTERACTIVE MATCHING: multiple-choice questions render as tappable choices, and a full match-and-pair set is reassembled into one interactive two-column table (Column A items ↔ Column B options) — tap an item then its match, and every pair is marked instantly on-device for free, no AI credits.',
+    coachTip: 'Recommend a Timed Quiz when a student is strong on content but hasn\'t practiced under pressure. Each attempt targets their weak spots and exam-relevant topics, so re-taking it is genuinely useful, not repetitive.',
+  },
+  {
+    name: 'Past Paper Drill',
+    where: 'Progress (Dashboard) → 📝 button on a subject card',
+    what: 'Replays the authentic questions extracted from that subject\'s uploaded past papers one at a time: answer, reveal the model answer, self-mark. Works offline, costs no AI credits.',
+  },
+  {
+    name: 'Review in your textbook',
+    where: 'Library → topic → Mastery tab',
+    what: 'Lists the questions the student has answered wrong (Again/Hard), worst-missed first, with the model answers — a concrete list of exactly what to go re-read in the textbook.',
+    coachTip: 'When a student asks "what should I focus on?", this list is the evidence-based answer for that topic.',
+  },
+  {
+    name: 'Exam Readiness',
+    where: 'Progress (Dashboard) — top card',
+    what: 'An evidence-based readiness score computed on-device (no AI cost) from four signals: coverage (how much material is started), mastery, retention (are reviews overdue/decayed), and exam-fit (do high-mastery topics match the examiner\'s past-paper topics). Shows a prioritised "do these next" list — the fewest, highest-impact moves to get exam-ready fastest — each tappable to jump straight to the topic or task.',
+    coachTip: 'When a student asks "am I ready?" or "where should I focus?", the Progress tab\'s Exam Readiness card is the evidence-based answer, and its top action is the single highest-leverage next move.',
+  },
+  {
+    name: 'Study Colors',
+    where: 'Settings → Study Color',
+    what: 'Switches the app accent between research-informed color modes: Focus blue (math/logic work), Growth green (long marathons, easiest on the eyes), Energy orange (alertness for flashcards/exam prep), plus the default amber. Independent of dark/light mode.',
+  },
+];

--- a/knowledgenode/www/js/core/AppFeatures.js
+++ b/knowledgenode/www/js/core/AppFeatures.js
@@ -26,7 +26,7 @@ const AppFeatures = [
   {
     name: 'Review / Spaced Repetition',
     where: 'Review tab',
-    what: 'Flashcard-style review of all topics. Cards are scheduled automatically — weak cards come back sooner. Modes: Today (due reviews blended with a PACED batch of new cards — a big upload is dripped in at a sustainable daily limit, not dumped all at once), All, and Weak Spots (the questions you keep getting wrong, hardest first, across the whole library). LEECH BREAKER: a card failed several times stops being re-drilled and the app offers to understand the concept instead of grinding a blank.',
+    what: 'Flashcard-style review of all topics. Cards are scheduled automatically — weak cards come back sooner. Review holds SHORT recall questions only: a full multi-step calculation cannot be answered between two flashcards, so those are routed to Exam Mode instead and review stays fast. Modes: Today (due reviews blended with a PACED batch of new cards — a big upload is dripped in at a sustainable daily limit, not dumped all at once), All, and Weak Spots (the questions you keep getting wrong, hardest first, across the whole library). LEECH BREAKER: a card failed several times stops being re-drilled and the app offers to understand the concept instead of grinding a blank.',
     coachTip: 'Best for consolidation and exam prep. Do the "Today" session daily — it mixes review with a healthy number of new cards so nothing floods you. If a student keeps failing the same question, tell them that\'s a signal to LEARN the concept (open the topic / use the tutor), not to drill it harder — the app flags these automatically.',
   },
   {

--- a/knowledgenode/www/js/core/BackNav.js
+++ b/knowledgenode/www/js/core/BackNav.js
@@ -1,0 +1,40 @@
+/**
+ * BackNav.js — drives the phone/browser back button through KNNav.
+ *
+ * A sentinel history entry sits under the app. Pressing back pops it and we
+ * ask KNNav.back() to close the top-most thing: a registered overlay (modals,
+ * More sheet), any [data-kn-overlay] element (tutor, learn panel, bulk
+ * import, guide, onboarding…), or step back a view (node detail → library).
+ * Handled → re-arm the sentinel; nothing ours → let the browser leave.
+ *
+ * ⚠ The sentinel must be pushed DURING a user gesture: Chrome/Samsung
+ * Internet skip history entries created without user activation ("history
+ * manipulation intervention"), so a load-time pushState is ignored by the
+ * phone's back button. We arm on the first touch/keypress instead, and
+ * re-arm inside the popstate handler (a back press IS a user gesture).
+ */
+const BackNav = {
+  _armed: false,
+
+  init() {
+    const arm = () => this._arm();
+    document.addEventListener('pointerdown', arm, { passive: true, capture: true });
+    document.addEventListener('touchstart',  arm, { passive: true, capture: true });
+    document.addEventListener('keydown',     arm, true);
+
+    window.addEventListener('popstate', () => {
+      this._armed = false;
+      let handled = false;
+      try { handled = (typeof KNNav !== 'undefined') && KNNav.back(); } catch (e) {}
+      if (handled) this._arm();                      // back press = user gesture
+      else { try { history.back(); } catch (e) {} }  // nothing ours — really go back
+    });
+  },
+
+  _arm() {
+    if (this._armed) return;
+    this._armed = true;
+    try { history.pushState({ knSentinel: true }, ''); } catch (e) { this._armed = false; }
+  },
+};
+if (typeof window !== 'undefined') { window.BackNav = BackNav; BackNav.init(); }

--- a/knowledgenode/www/js/core/BackupGuard.js
+++ b/knowledgenode/www/js/core/BackupGuard.js
@@ -1,0 +1,73 @@
+/**
+ * BackupGuard.js — keeps a user's data safe OFF the device.
+ *
+ * Everything lives in browser storage; the in-app snapshots live in the SAME
+ * browser, so a lost phone or cleared site-data wipes both. This guard makes
+ * sure a real backup file leaves the browser regularly:
+ *
+ *  - Android build (native save bridge present): silently auto-saves a full
+ *    backup to Downloads once a week. No nagging.
+ *  - Browser / local-server: shows a dismissible banner when the last saved
+ *    backup file is > 7 days old (snoozable for 3 days).
+ *
+ * "Fresh" is stamped by BackupVault.markFileBackup(), called wherever a full
+ * backup actually reaches a file (vault download, Export-All JSON).
+ */
+const BackupGuard = {
+  NUDGE_AFTER_DAYS: 7,
+  SNOOZE_DAYS: 3,
+  _SNOOZE_KEY: 'kn_backup_nudge_snooze',
+
+  async check() {
+    try {
+      if (typeof nodeStore === 'undefined' || typeof BackupVault === 'undefined') return;
+      const nodes = nodeStore.getAll().length;
+      if (nodes === 0) return;
+      const age = BackupVault.fileBackupAgeDays();
+      // Never backed up: give new users grace until they have something worth saving
+      if (age === Infinity && nodes < 3) return;
+      if (age < this.NUDGE_AFTER_DAYS) return;
+
+      const native = !!(window.KnowledgeNodeFiles && window.KnowledgeNodeFiles.saveToDownloads);
+      if (native) {
+        const rec = await BackupVault.snapshot('auto');
+        BackupVault.download(rec);                       // silent native save + stamps freshness
+        if (window.Toast) Toast.info('Weekly backup saved to Downloads.');
+      } else {
+        this._showBanner(age);
+      }
+    } catch (e) { console.warn('[BackupGuard]', e); }
+  },
+
+  _showBanner(age) {
+    if (Date.now() < parseInt(localStorage.getItem(this._SNOOZE_KEY) || '0', 10)) return;
+    if (document.getElementById('kn-backup-banner')) return;
+    const host = document.getElementById('main-content') || document.body;
+    const el = document.createElement('div');
+    el.id = 'kn-backup-banner';
+    el.style.cssText = 'margin:12px 16px;padding:12px 14px;background:var(--accent-soft);border:1px solid var(--accent-dim);border-radius:var(--radius-md);display:flex;align-items:center;gap:12px;flex-wrap:wrap;';
+    const msg = age === Infinity
+      ? 'Your notes only live in this browser — save a backup file somewhere safe.'
+      : 'Your last saved backup file is ' + Math.floor(age) + ' days old.';
+    el.innerHTML =
+      '<span style="font-family:var(--font-mono);font-size:12px;color:var(--text-primary);flex:1;min-width:200px;">🛟 ' + msg + '</span>'
+      + '<div style="display:flex;gap:8px;">'
+      + '<button id="kn-backup-now" class="btn-primary" style="padding:8px 14px;font-size:12px;">Download backup</button>'
+      + '<button id="kn-backup-later" class="btn-secondary" style="padding:8px 14px;font-size:12px;">Later</button>'
+      + '</div>';
+    host.prepend(el);
+    document.getElementById('kn-backup-now').addEventListener('click', async () => {
+      try {
+        const rec = await BackupVault.snapshot('manual');
+        BackupVault.download(rec);
+        if (window.Toast) Toast.success('Backup saved — keep it somewhere off this device.');
+      } catch (e) { if (window.Toast) Toast.error('Backup failed: ' + e.message); return; }
+      el.remove();
+    });
+    document.getElementById('kn-backup-later').addEventListener('click', () => {
+      try { localStorage.setItem(this._SNOOZE_KEY, String(Date.now() + this.SNOOZE_DAYS * 86400000)); } catch (e) {}
+      el.remove();
+    });
+  },
+};
+if (typeof window !== 'undefined') window.BackupGuard = BackupGuard;

--- a/knowledgenode/www/js/core/BackupVault.js
+++ b/knowledgenode/www/js/core/BackupVault.js
@@ -1,0 +1,211 @@
+/**
+ * BackupVault.js — versioned, in-app backup store
+ *
+ * Keeps a rolling set of timestamped snapshots INSIDE the app
+ * (IndexedDB), instead of dropping dated files into the device's
+ * Downloads folder. Each snapshot is clearly labelled with an
+ * incrementing number, the app version, a timestamp, the node count
+ * and its size — so picking the right one to restore is unambiguous.
+ *
+ * Why IndexedDB and not localStorage: snapshots can be hundreds of KB
+ * and localStorage (~5MB shared) is already near quota in this app.
+ *
+ * Public API (all async except labelOf / fileNameOf):
+ *   BackupVault.snapshot(reason)   -> record   (take a snapshot now)
+ *   BackupVault.maybeAuto()        -> record|null (time-gated auto snapshot)
+ *   BackupVault.list()             -> [record]  (newest first)
+ *   BackupVault.get(seq)           -> record|null
+ *   BackupVault.remove(seq)        -> void
+ *   BackupVault.clearAll()         -> void
+ *   BackupVault.labelOf(record)    -> "#7 · v63.9 · 13 Jun 2026, 14:32 · 42 nodes · 0.3 MB"
+ *   BackupVault.fileNameOf(record) -> "knowledgenode-v63.9-2026-06-13-1432-42nodes.json"
+ */
+
+const BackupVault = {
+  VERSION:       (typeof window !== 'undefined' && window.APP_VERSION) || '63.9',
+  DB_NAME:       'kn_backup_vault',
+  STORE:         'snapshots',
+  MAX_SNAPSHOTS: 15,                       // keep the most recent N; older ones pruned
+  AUTO_INTERVAL: 6 * 60 * 60 * 1000,       // auto-snapshot at most once / 6h
+  _LAST_AUTO_KEY:'kn_vault_last_auto',
+
+  /* ── low-level db ── */
+  _open() {
+    return new Promise((resolve, reject) => {
+      if (!('indexedDB' in window)) { reject(new Error('IndexedDB unavailable')); return; }
+      const req = indexedDB.open(this.DB_NAME, 1);
+      req.onupgradeneeded = () => {
+        const db = req.result;
+        if (!db.objectStoreNames.contains(this.STORE)) {
+          db.createObjectStore(this.STORE, { keyPath: 'seq', autoIncrement: true });
+        }
+      };
+      req.onsuccess = () => resolve(req.result);
+      req.onerror   = () => reject(req.error || new Error('IndexedDB open failed'));
+    });
+  },
+
+  _tx(mode) {
+    return this._open().then(db => {
+      const tx    = db.transaction(this.STORE, mode);
+      const store = tx.objectStore(this.STORE);
+      return { db, tx, store };
+    });
+  },
+
+  /* ── build the JSON payload for a snapshot (nodes + AI config) ── */
+  _buildPayload() {
+    const nodes = nodeStore.getAll().map(n => n.toJSON());
+    const payload = { _knBackup: 1, version: this.VERSION, exportedAt: Date.now(), nodes };
+    try {
+      if (typeof AIService !== 'undefined' && AIService.exportConfig) {
+        const ai = AIService.exportConfig();
+        if (ai) payload.ai = ai;            // includes provider + API key(s)
+      }
+    } catch (e) { console.warn('[BackupVault] AI config not included:', e); }
+    return JSON.stringify(payload);
+  },
+
+  /* ── take a snapshot of the current data ── */
+  async snapshot(reason = 'manual') {
+    if (typeof nodeStore === 'undefined') throw new Error('No data to back up yet');
+    const json      = this._buildPayload();
+    const nodeCount = nodeStore.getAll().length;
+    let hasKey = false;
+    try { hasKey = !!(typeof AIService !== 'undefined' && AIService.exportConfig && AIService.exportConfig()); } catch {}
+    const record = {
+      ts:        Date.now(),
+      version:   this.VERSION,
+      reason,                              // 'manual' | 'auto' | 'pre-restore' | 'pre-import' | 'pre-purge'
+      nodeCount,
+      hasKey,                              // whether AI config (incl. key) is in this snapshot
+      sizeBytes: json.length,
+      json,
+    };
+    const { store, tx, db } = await this._tx('readwrite');
+    return new Promise((resolve, reject) => {
+      const add = store.add(record);
+      add.onsuccess = () => { record.seq = add.result; };
+      tx.oncomplete = async () => {
+        db.close();
+        try { await this._prune(); } catch {}
+        resolve(record);
+      };
+      tx.onerror = () => reject(tx.error || new Error('Snapshot failed'));
+    });
+  },
+
+  /* ── time-gated auto snapshot (called from the save path) ── */
+  async maybeAuto() {
+    try {
+      if (typeof nodeStore === 'undefined' || nodeStore.getAll().length === 0) return null;
+      const last = parseInt(localStorage.getItem(this._LAST_AUTO_KEY) || '0', 10);
+      if (Date.now() - last < this.AUTO_INTERVAL) return null;
+      localStorage.setItem(this._LAST_AUTO_KEY, String(Date.now()));
+      return await this.snapshot('auto');
+    } catch (e) {
+      console.warn('[BackupVault] auto snapshot skipped:', e);
+      return null;
+    }
+  },
+
+  /* ── list, newest first ── */
+  async list() {
+    try {
+      const { store, db } = await this._tx('readonly');
+      return await new Promise((resolve, reject) => {
+        const req = store.getAll();
+        req.onsuccess = () => { db.close(); resolve((req.result || []).sort((a, b) => b.seq - a.seq)); };
+        req.onerror   = () => { db.close(); reject(req.error); };
+      });
+    } catch (e) {
+      console.warn('[BackupVault] list failed:', e);
+      return [];
+    }
+  },
+
+  async get(seq) {
+    const { store, db } = await this._tx('readonly');
+    return new Promise((resolve, reject) => {
+      const req = store.get(Number(seq));
+      req.onsuccess = () => { db.close(); resolve(req.result || null); };
+      req.onerror   = () => { db.close(); reject(req.error); };
+    });
+  },
+
+  async remove(seq) {
+    const { store, tx, db } = await this._tx('readwrite');
+    store.delete(Number(seq));
+    return new Promise((resolve, reject) => {
+      tx.oncomplete = () => { db.close(); resolve(); };
+      tx.onerror    = () => { db.close(); reject(tx.error); };
+    });
+  },
+
+  async clearAll() {
+    const { store, tx, db } = await this._tx('readwrite');
+    store.clear();
+    return new Promise((resolve, reject) => {
+      tx.oncomplete = () => { db.close(); resolve(); };
+      tx.onerror    = () => { db.close(); reject(tx.error); };
+    });
+  },
+
+  /* ── keep only the newest MAX_SNAPSHOTS ── */
+  async _prune() {
+    const all = await this.list();             // newest first
+    const excess = all.slice(this.MAX_SNAPSHOTS);
+    for (const rec of excess) { try { await this.remove(rec.seq); } catch {} }
+  },
+
+  /* ── display helpers ── */
+  labelOf(rec) {
+    const d  = new Date(rec.ts);
+    const mb = (rec.sizeBytes / (1024 * 1024));
+    const size = mb >= 0.1 ? mb.toFixed(1) + ' MB' : Math.max(1, Math.round(rec.sizeBytes / 1024)) + ' KB';
+    const date = d.toLocaleDateString(undefined, { day: '2-digit', month: 'short', year: 'numeric' });
+    const time = d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+    return `#${rec.seq} · v${rec.version} · ${date}, ${time} · ${rec.nodeCount} node${rec.nodeCount === 1 ? '' : 's'} · ${size}${rec.hasKey ? ' · 🔑 incl. key' : ''}`;
+  },
+
+  reasonLabel(reason) {
+    return { manual: 'Manual', auto: 'Auto', 'pre-restore': 'Safety (before restore)', 'pre-import': 'Safety (before import)', 'pre-purge': 'Safety (before purge)' }[reason] || reason;
+  },
+
+  fileNameOf(rec) {
+    const d = new Date(rec.ts);
+    const p = n => String(n).padStart(2, '0');
+    const stamp = `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}-${p(d.getHours())}${p(d.getMinutes())}`;
+    return `knowledgenode-v${rec.version}-${stamp}-${rec.nodeCount}nodes.json`;
+  },
+
+  /** Trigger a download/share of a specific snapshot with a clear versioned name. */
+  _FILE_KEY: 'kn_last_file_backup',
+  /** Stamp "a full backup reached an actual file just now". */
+  markFileBackup() { try { localStorage.setItem(this._FILE_KEY, String(Date.now())); } catch (e) {} },
+  /** Days since a backup file last left the browser (Infinity = never). */
+  fileBackupAgeDays() {
+    const t = parseInt(localStorage.getItem(this._FILE_KEY) || '0', 10);
+    return t ? (Date.now() - t) / 86400000 : Infinity;
+  },
+
+  download(rec) {
+    this.markFileBackup();
+    const filename = this.fileNameOf(rec);
+    // KNFiles uses the native save bridge on Android (where <a download> /
+    // navigator.share do nothing) and falls back to a link download in browsers.
+    if (window.KNFiles) {
+      KNFiles.save(filename, 'application/json', rec.json);
+      return;
+    }
+    // Legacy fallback
+    const blob = new Blob([rec.json], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a   = document.createElement('a');
+    a.href = url; a.download = filename; a.style.display = 'none';
+    document.body.appendChild(a); a.click();
+    setTimeout(() => { URL.revokeObjectURL(url); a.remove(); }, 1000);
+  },
+};
+
+if (typeof window !== 'undefined') window.BackupVault = BackupVault;

--- a/knowledgenode/www/js/core/CoachFacts.js
+++ b/knowledgenode/www/js/core/CoachFacts.js
@@ -40,8 +40,14 @@ const CoachFacts = {
   },
 
   _write(obj) {
-    try { localStorage.setItem(this.KEY, JSON.stringify(obj)); return true; }
+    try { localStorage.setItem(this.KEY, JSON.stringify(obj)); }
     catch (e) { return false; }
+    // The shared AI context is cached for a few seconds. A fact that just
+    // changed — especially a correction — must reach every AI surface on the
+    // very next call, not once the cache happens to expire, or one part of the
+    // app would keep acting on a value the student has already replaced.
+    try { if (typeof LearnerContext !== 'undefined') LearnerContext._sessionCache = null; } catch (e) {}
+    return true;
   },
 
   /** Every stored fact, most recently stated last. */
@@ -77,7 +83,7 @@ const CoachFacts = {
 
   remove(key) { return this.set(key, ''); },
 
-  clear() { try { localStorage.removeItem(this.KEY); return true; } catch (e) { return false; } },
+  clear() { return this._write({}); },
 
   /**
    * Pull [[FACT: key = value]] lines out of a coach reply.

--- a/knowledgenode/www/js/core/CoachFacts.js
+++ b/knowledgenode/www/js/core/CoachFacts.js
@@ -1,0 +1,122 @@
+/**
+ * CoachFacts.js — durable memory of what the student has actually TOLD the coach.
+ *
+ * The conversation window is finite: older turns roll off, so a fact stated ten
+ * messages ago ("my exam is the first week of December", "I can do 30 minutes
+ * morning and evening", "I'm only doing 4 subjects this year") used to vanish
+ * and the coach would ask for it again. That is infuriating and makes the coach
+ * feel broken.
+ *
+ * Facts are KEYED, stored on-device, and injected into EVERY coach turn's system
+ * prompt, so they never roll off no matter how long the conversation runs and
+ * they survive closing the app. Because they are keyed, a correction OVERWRITES
+ * the old value instead of piling up a contradiction — "scrap August, it's
+ * December" replaces the date rather than adding a second one.
+ *
+ * The coach records them the same proven way it records [[SIGNAL:...]]: by
+ * appending a hidden [[FACT: key = value]] line, so there is no extra AI call
+ * and no extra cost.
+ *
+ * Free, on-device, zero dependencies.
+ */
+const CoachFacts = {
+  KEY: 'kn_coach_facts',
+  MAX: 30,                 // plenty for a study profile; oldest-touched drop first
+
+  /** Canonical key: "Exam date", "exam_date" and "EXAM  DATE" are the same fact. */
+  _norm(key) {
+    return String(key == null ? '' : key)
+      .toLowerCase().trim()
+      .replace(/[^a-z0-9]+/g, '_')
+      .replace(/^_+|_+$/g, '')
+      .slice(0, 48);
+  },
+
+  _read() {
+    try {
+      const raw = JSON.parse(localStorage.getItem(this.KEY) || '{}');
+      return (raw && typeof raw === 'object' && !Array.isArray(raw)) ? raw : {};
+    } catch (e) { return {}; }
+  },
+
+  _write(obj) {
+    try { localStorage.setItem(this.KEY, JSON.stringify(obj)); return true; }
+    catch (e) { return false; }
+  },
+
+  /** Every stored fact, most recently stated last. */
+  all() {
+    return Object.entries(this._read())
+      .map(([key, v]) => ({ key, value: v && v.value, at: (v && v.at) || 0 }))
+      .filter(f => f.value)
+      .sort((a, b) => a.at - b.at);
+  },
+
+  get(key) {
+    const f = this._read()[this._norm(key)];
+    return f ? f.value : null;
+  },
+
+  /** Record (or correct) one fact. Empty value deletes it. */
+  set(key, value) {
+    const k = this._norm(key);
+    if (!k) return false;
+    const val = String(value == null ? '' : value).trim().slice(0, 300);
+    const store = this._read();
+    if (!val) { delete store[k]; return this._write(store); }
+    store[k] = { value: val, at: Date.now() };
+    // Cap: drop the least-recently-stated facts.
+    const keys = Object.keys(store);
+    if (keys.length > this.MAX) {
+      keys.sort((a, b) => (store[a].at || 0) - (store[b].at || 0))
+          .slice(0, keys.length - this.MAX)
+          .forEach(k2 => delete store[k2]);
+    }
+    return this._write(store);
+  },
+
+  remove(key) { return this.set(key, ''); },
+
+  clear() { try { localStorage.removeItem(this.KEY); return true; } catch (e) { return false; } },
+
+  /**
+   * Pull [[FACT: key = value]] lines out of a coach reply.
+   * @returns {{clean:string, facts:{key:string,value:string}[]}}
+   */
+  parse(raw) {
+    const str = String(raw == null ? '' : raw);
+    const facts = [];
+    const re = /\[\[FACT:\s*([^=\]]+?)\s*=\s*([^\]]*?)\s*\]\]/gi;
+    let m;
+    while ((m = re.exec(str))) {
+      const key = this._norm(m[1]);
+      if (key) facts.push({ key, value: String(m[2] || '').trim() });
+    }
+    const clean = str.replace(/\n?\[\[FACT:[^\]]*\]\]\n?/gi, '\n').replace(/\n{3,}/g, '\n\n').trimEnd();
+    return { clean, facts };
+  },
+
+  /** Parse a reply AND persist whatever it recorded. Returns the cleaned text. */
+  absorb(raw) {
+    const { clean, facts } = this.parse(raw);
+    facts.forEach(f => this.set(f.key, f.value));
+    return clean;
+  },
+
+  /** The block injected into every coach system prompt. '' when nothing known. */
+  block() {
+    const list = this.all();
+    if (!list.length) return '';
+    const label = k => k.replace(/_/g, ' ');
+    return '\n\nCONFIRMED FACTS THE STUDENT HAS ALREADY TOLD YOU'
+      + ' (durable memory — these came from earlier in this conversation and are still true):\n'
+      + list.map(f => '- ' + label(f.key) + ': ' + f.value).join('\n')
+      + '\nTREAT THIS BLOCK AS AUTHORITATIVE. Never ask the student for anything already answered here —'
+      + ' asking again makes you look like you were not listening. If a fact here conflicts with the app'
+      + ' data above (for example a stale or deleted study plan), the fact here WINS, because the student'
+      + ' said it directly; you may briefly note the mismatch, but do not re-interrogate them.'
+      + ' If the student corrects one of these, re-record it with the same key so the correction replaces it.';
+  },
+};
+if (typeof window !== 'undefined') window.CoachFacts = CoachFacts;
+if (typeof module !== 'undefined' && module.exports) module.exports = CoachFacts;

--- a/knowledgenode/www/js/core/ExamReadiness.js
+++ b/knowledgenode/www/js/core/ExamReadiness.js
@@ -1,0 +1,200 @@
+/**
+ * ExamReadiness.js — evidence-based "how ready am I, and what should I do
+ * next?" — computed entirely on-device (no API calls) from data the app
+ * already stores.
+ *
+ * Readiness is NOT just average mastery. A student can show 80% mastery while
+ * half their topics are untouched, or while their reviews have gone stale. The
+ * score blends four signals, each 0..1:
+ *
+ *   coverage   — how much of the material has genuinely been started (a topic
+ *                with no questions, or whose questions were never reviewed,
+ *                counts as not-yet-covered). You cannot be "ready" on material
+ *                you have not begun.
+ *   mastery    — average mastery across topics (the durable, spaced-review
+ *                signal from computeMastery()).
+ *   retention  — of the cards that are scheduled, how many are NOT overdue.
+ *                Overdue cards have likely decayed, so a pile of overdue work
+ *                lowers real readiness even if stored mastery looks high.
+ *   alignment  — when past papers have been analysed, how well the topics the
+ *                examiner actually tests are covered by high-mastery nodes.
+ *                Absent past papers, this signal is omitted (not penalised).
+ *
+ * The engine also returns a PRIORITISED action list — the fewest, highest-
+ * leverage moves to raise readiness fastest — each with an estimated lift so
+ * the UI can order and justify them.
+ */
+const ExamReadiness = {
+  _MASTERED: 70,          // a topic at/above this is "solid"
+  _STARTED_REPS: 1,       // a question with >=1 review counts as started
+
+  /** Full assessment. `nodes` = ready KnowledgeNodes; `plan` optional (for
+   *  the exam countdown only — readiness is computed with or without it). */
+  assess(nodes, plan) {
+    const ready = (nodes || []).filter(n => n && (n.processingStatus === 'ready' || n.processingStatus === undefined));
+    const daysToExam = (plan && (plan.daysRemaining != null ? plan.daysRemaining
+                        : (typeof plan.daysUntilExam === 'function' ? plan.daysUntilExam() : plan.daysUntilExam))) ?? null;
+
+    if (!ready.length) {
+      return { score: 0, band: this._band(0), daysToExam, hasData: false,
+        signals: { coverage: 0, mastery: 0, retention: 1, alignment: null },
+        actions: [{ text: 'Add your first topic — upload notes or revision questions to start.', lift: 0, kind: 'add' }] };
+    }
+
+    const now = Date.now();
+    let started = 0, masterySum = 0, dueTotal = 0, dueOverdue = 0, weakLoad = 0;
+    const unstarted = [], overdueTopics = [], weakTopics = [];
+
+    ready.forEach(n => {
+      const qs = n.questions || [];
+      const reviewed = qs.filter(q => { const s = n.srsState && n.srsState[q.id]; return s && (s.repetitions || 0) >= this._STARTED_REPS; });
+      const isStarted = reviewed.length > 0;
+      if (isStarted) started++; else unstarted.push(n);
+      masterySum += (n.masteryScore || 0);
+
+      let topicOverdue = 0;
+      qs.forEach(q => {
+        const s = n.srsState && n.srsState[q.id];
+        if (s && (s.repetitions || 0) > 0) {
+          dueTotal++;
+          if (s.nextReview && s.nextReview <= now) { dueOverdue++; topicOverdue++; }
+        }
+      });
+      if (topicOverdue > 0) overdueTopics.push({ node: n, count: topicOverdue });
+
+      const weak = (typeof n.missedQuestionsForReview === 'function') ? n.missedQuestionsForReview(50) : [];
+      if (weak.length) { weakLoad += weak.length; weakTopics.push({ node: n, count: weak.length }); }
+    });
+
+    const coverage  = started / ready.length;
+    const mastery   = (masterySum / ready.length) / 100;
+    const retention = dueTotal ? (1 - dueOverdue / dueTotal) : 1;
+    const alignment = this._alignment(ready);
+
+    // Weighted blend. Alignment folds in only when past papers exist.
+    let score, wSum;
+    if (alignment == null) {
+      score = 0.45 * mastery + 0.30 * coverage + 0.25 * retention;
+      wSum  = 1;
+    } else {
+      score = 0.38 * mastery + 0.25 * coverage + 0.20 * retention + 0.17 * alignment;
+      wSum  = 1;
+    }
+    const pct = Math.round(Math.min(1, Math.max(0, score / wSum)) * 100);
+
+    return {
+      score: pct, band: this._band(pct), daysToExam, hasData: true,
+      signals: {
+        coverage:  Math.round(coverage * 100),
+        mastery:   Math.round(mastery * 100),
+        retention: Math.round(retention * 100),
+        alignment: alignment == null ? null : Math.round(alignment * 100),
+      },
+      actions: this._actions({ ready, unstarted, overdueTopics, weakTopics, dueOverdue, weakLoad, pct }),
+    };
+  },
+
+  /** Examiner-topic alignment: of the examiner's topic areas across analysed
+   *  past papers, how many are covered by a solid (>= _MASTERED) node in the
+   *  same subject. Returns null when no past papers exist. */
+  _alignment(nodes) {
+    let examTopics = [], anyPaper = false;
+    const subjects = [...new Set(nodes.map(n => n.subject).filter(Boolean))];
+    for (const s of subjects) {
+      try {
+        const raw = localStorage.getItem('kn_exam_style_' + s.toLowerCase().replace(/\s+/g, '_'));
+        if (!raw) continue;
+        const papers = (JSON.parse(raw).papers || []);
+        if (!papers.length) continue;
+        anyPaper = true;
+        papers.forEach(p => (p.analysis && p.analysis.topicAreas || []).forEach(t => examTopics.push({ subject: s.toLowerCase(), topic: String(t).toLowerCase() })));
+      } catch (e) { /* ignore */ }
+    }
+    if (!anyPaper || !examTopics.length) return null;
+    let covered = 0;
+    examTopics.forEach(({ subject, topic }) => {
+      const hit = nodes.some(n => (n.subject || '').toLowerCase() === subject
+        && (n.masteryScore || 0) >= this._MASTERED
+        && ((n.title || '').toLowerCase().includes(topic) || topic.includes((n.title || '').toLowerCase()) || (n.summary || '').toLowerCase().includes(topic)));
+      if (hit) covered++;
+    });
+    return covered / examTopics.length;
+  },
+
+  /** Prioritised, concrete next moves — ordered by estimated readiness lift. */
+  _actions({ ready, unstarted, overdueTopics, weakTopics, dueOverdue, weakLoad, pct }) {
+    const acts = [];
+
+    if (unstarted.length) {
+      const names = unstarted.slice(0, 3).map(n => n.title).join(', ');
+      acts.push({
+        kind: 'start',
+        text: 'Start ' + unstarted.length + ' topic' + (unstarted.length === 1 ? '' : 's') + ' you haven\'t begun' + (names ? ': ' + names + (unstarted.length > 3 ? '…' : '') : '') + '.',
+        lift: Math.round((unstarted.length / ready.length) * 30),
+        nodeId: unstarted[0].id,
+      });
+    }
+    if (dueOverdue > 0) {
+      acts.push({
+        kind: 'review',
+        text: 'Clear ' + dueOverdue + ' overdue review' + (dueOverdue === 1 ? '' : 's') + ' before that knowledge decays.',
+        lift: Math.min(20, dueOverdue),
+      });
+    }
+    // Leeches: cards failed so often that drilling them again is wasted time —
+    // they need concept work, not more testing. High leverage: a persistent
+    // blocker removed is worth more than another ordinary review.
+    const leeches = (typeof LeechDetector !== 'undefined') ? LeechDetector.leeches(ready) : [];
+    if (leeches.length) {
+      acts.push({
+        kind: 'leech',
+        text: leeches.length + ' question' + (leeches.length === 1 ? '' : 's') + ' you keep missing need understanding, not drilling'
+          + ' — start with "' + leeches[0].node.title + '".',
+        lift: Math.min(22, 6 + leeches.length * 3),
+        nodeId: leeches[0].node.id,
+      });
+    }
+    if (weakLoad > 0) {
+      const t = weakTopics.sort((a, b) => b.count - a.count)[0];
+      acts.push({
+        kind: 'drill',
+        text: 'Drill your ' + weakLoad + ' weakest question' + (weakLoad === 1 ? '' : 's')
+          + (t ? ' — start with "' + t.node.title + '"' : '') + ' (see each topic\'s Mastery → "Review in your textbook").',
+        lift: Math.min(18, weakLoad * 2),
+        nodeId: t ? t.node.id : undefined,
+      });
+    }
+    // Lowest-mastery started topic that isn't already flagged as weak/overdue.
+    const flagged = new Set([...overdueTopics, ...weakTopics].map(x => x.node.id));
+    const lowMastery = ready
+      .filter(n => !flagged.has(n.id) && (n.questions || []).some(q => n.srsState && n.srsState[q.id]) && (n.masteryScore || 0) < this._MASTERED)
+      .sort((a, b) => (a.masteryScore || 0) - (b.masteryScore || 0))[0];
+    if (lowMastery) {
+      acts.push({
+        kind: 'strengthen',
+        text: 'Strengthen "' + lowMastery.title + '" — it\'s at ' + (lowMastery.masteryScore || 0) + '% and needs a few more spaced reviews.',
+        lift: Math.round((this._MASTERED - (lowMastery.masteryScore || 0)) / 6),
+        nodeId: lowMastery.id,
+      });
+    }
+
+    if (!acts.length) {
+      acts.push({
+        kind: 'maintain',
+        text: pct >= 85 ? 'You\'re exam-ready. Keep your daily reviews ticking so nothing goes stale.'
+                        : 'Keep going — do today\'s reviews and a short practice session.',
+        lift: 0,
+      });
+    }
+    return acts.sort((a, b) => (b.lift || 0) - (a.lift || 0)).slice(0, 4);
+  },
+
+  _band(pct) {
+    if (pct >= 85) return { key: 'ready',    label: 'Exam ready',    tone: 'good' };
+    if (pct >= 65) return { key: 'ontrack',  label: 'On track',      tone: 'good' };
+    if (pct >= 40) return { key: 'building', label: 'Building up',    tone: 'mid'  };
+    return               { key: 'early',    label: 'Getting started', tone: 'low'  };
+  },
+};
+if (typeof window !== 'undefined') window.ExamReadiness = ExamReadiness;
+if (typeof module !== 'undefined' && module.exports) module.exports = ExamReadiness;

--- a/knowledgenode/www/js/core/ExamReadiness.js
+++ b/knowledgenode/www/js/core/ExamReadiness.js
@@ -148,7 +148,7 @@ const ExamReadiness = {
     if (leeches.length) {
       acts.push({
         kind: 'leech',
-        text: leeches.length + ' question' + (leeches.length === 1 ? '' : 's') + ' you keep missing need understanding, not drilling'
+        text: leeches.length + ' question' + (leeches.length === 1 ? ' you keep missing needs' : 's you keep missing need') + ' understanding, not drilling'
           + ' — start with "' + leeches[0].node.title + '".',
         lift: Math.min(22, 6 + leeches.length * 3),
         nodeId: leeches[0].node.id,

--- a/knowledgenode/www/js/core/KnowledgeNode.js
+++ b/knowledgenode/www/js/core/KnowledgeNode.js
@@ -292,9 +292,24 @@ class KnowledgeNode {
       .map(w => ({ id: w.id, question: w.text, answer: byId[w.id] ? byId[w.id].answer : '', count: w.count || 1 }));
   }
 
+  /** Questions spaced repetition may serve. Full calculations are excluded —
+   *  they cannot be answered between two flashcards, so they live in the exam
+   *  instead. Filtering here keeps every due count in the app honest, rather
+   *  than promising cards the review session would then refuse to show. */
+  reviewableQuestions() {
+    if (typeof QuestionKind === 'undefined') return this.questions;
+    return this.questions.filter(q => QuestionKind.isReviewable(q));
+  }
+
+  /** Questions that are full calculations — exam material, not flashcards. */
+  calculationQuestions() {
+    if (typeof QuestionKind === 'undefined') return [];
+    return this.questions.filter(q => !QuestionKind.isReviewable(q));
+  }
+
   dueQuestions() {
     const now = Date.now();
-    return this.questions.filter(q => {
+    return this.reviewableQuestions().filter(q => {
       const s = this.srsState[q.id];
       // Never reviewed — NOT due yet. Only becomes due after first rating.
       if (!s || s.repetitions === 0) return false;

--- a/knowledgenode/www/js/core/KnowledgeNode.js
+++ b/knowledgenode/www/js/core/KnowledgeNode.js
@@ -1,0 +1,443 @@
+/**
+ * KnowledgeNode.js v2 — Core Data Model
+ * Added: userImages (embedded images in notes), editableNotes fields
+ */
+
+class KnowledgeNode {
+  constructor(data = {}) {
+    this.id        = data.id        || KnowledgeNode._generateId();
+    this.subject   = data.subject   || '';
+    this.chapter   = data.chapter   || '';
+    this.title     = data.title     || 'Untitled Node';
+    this.createdAt = data.createdAt || Date.now();
+    this.updatedAt = data.updatedAt || Date.now();
+
+    this.sourceImages = data.sourceImages || [];
+    this.rawOCR       = data.rawOCR       || '';
+
+    // Structured notes (AI-generated, user-editable)
+    // definitions: [{ term, examples, description }]  (examples is new optional field)
+    this.definitions     = (data.definitions || []).map(d => ({
+      term: d.term || '', examples: d.examples || '', description: d.description || ''
+    }));
+
+    this.formulas        = data.formulas       || [];
+
+    // procedures: [{ id, title, appliesTo, steps:[], notes }]  (new structured format)
+    // Migrate legacy flat string array automatically
+    this.procedures      = (data.procedures || []).map((p, i) => {
+      if (typeof p === 'string') {
+        // Legacy: flat string — wrap in first procedure group or add as step
+        return null; // handled below
+      }
+      return p;
+    }).filter(Boolean);
+
+    // Handle legacy flat procedure strings by grouping into one procedure
+    const legacySteps = (data.procedures || []).filter(p => typeof p === 'string');
+    if (legacySteps.length && !this.procedures.length) {
+      this.procedures = [{
+        id: 'proc_' + Math.random().toString(36).slice(2,8),
+        title: 'Procedure',
+        appliesTo: '',
+        steps: legacySteps,
+        notes: '',
+      }];
+    }
+
+    // AI sometimes returns mistakes as objects ({mistake, fix, …}) instead of
+    // strings — coerce so the renderer never prints "[object Object]".
+    this.commonMistakes  = (data.commonMistakes || []).map(m => {
+      if (typeof m === 'string') return m;
+      if (m && typeof m === 'object') {
+        const main = m.mistake || m.text || m.description || m.error || '';
+        const why  = m.fix || m.correction || m.why || '';
+        return [main, why].filter(Boolean).join(' — ')
+          || Object.values(m).filter(v => typeof v === 'string').join(' — ');
+      }
+      return '';
+    }).filter(Boolean);
+
+    // tables: [{ id, title, columns:[], rows:[[]] }]
+    this.tables = data.tables || [];
+    this.summary         = data.summary        || '';
+    this.sectionOrder    = Array.isArray(data.sectionOrder) ? data.sectionOrder : [];
+
+    // User-added content
+    this.userNotes  = data.userNotes  || '';
+    this.sourceBookmark = data.sourceBookmark || '';  // where the user left off in the physical handbook
+    this.sourcePage = (typeof data.sourcePage === 'number' && data.sourcePage > 0) ? data.sourcePage : null;  // handbook page where this node's content starts
+    // userImages: [{ id, base64, caption, width, responseBlock: { type, content, modelAnswer } }]
+    this.userImages = (data.userImages || []).map(img => ({
+      id: img.id, base64: img.base64 || '', caption: img.caption || '',
+      width: img.width || 50,
+      responseBlock: img.responseBlock || null,  // null = no response block
+    }));
+
+    // Questions (AI-generated + user-added)
+    this.questions       = data.questions      || [];
+
+    // SRS state
+    this.srsState        = data.srsState       || {};
+
+    // Mastery
+    this.masteryScore    = data.masteryScore   || 0;
+    this.reviewCount     = data.reviewCount    || 0;
+    this.lastReviewed    = data.lastReviewed   || null;
+
+    // Subject category (auto-detected by AI or set manually)
+    // Values: 'accounting' | 'law' | 'programming' | 'science' | 'medicine' | 'history' | 'language' | 'maths' | 'general'
+    this.subjectCategory = data.subjectCategory || null;
+
+    // Note template (set by user, AI rewrites content when changed)
+    this.noteTemplate    = data.noteTemplate    || 'standard';
+
+    // Worked examples — uploaded by student for Socratic tutoring
+    // [{ id, title, question, solution, steps:[], images:[], addedAt }]
+    this.workedExamples  = data.workedExamples  || [];
+
+    // Session memory — compact log of study sessions for AI context
+    // [{ date, summary, strengths:[], gaps:[], score }]
+    this.sessionLog      = data.sessionLog      || [];
+    this.aiCorrections   = Array.isArray(data.aiCorrections)  ? data.aiCorrections  : [];
+    this.weakQuestions   = Array.isArray(data.weakQuestions)  ? data.weakQuestions  : [];
+    this.activitySummary = data.activitySummary || '';
+    // Node-graph link: a Revision Questions node compiled FROM a source node
+    // carries that source node's id, so the pair stays connected.
+    this.linkedSourceId  = data.linkedSourceId  || null;
+
+    // Per-profile cached content — stores blocks/notes for each learner level
+    // so switching profiles doesn't require a new API call
+    // { primary: { blocks: [...] }, high: { blocks: [...] }, college: { blocks: [...] }, pro: { blocks: [...] } }
+    this.profileCache    = data.profileCache    || {};
+    this.cornellData     = data.cornellData     || null;
+    this.outlineData     = data.outlineData     || null;
+    this.feynmanData2    = data.feynmanData2    || null;
+
+    // Processing
+    this.processingDetail = data.processingDetail || 'standard';
+    this.processingStatus = data.processingStatus || 'pending';
+    this.processingError  = data.processingError  || null;
+
+    // Note-taking method
+    this.noteMethod          = data.noteMethod          || 'standard';
+    this.feynmanData         = data.feynmanData         || null;
+
+    // Study method data
+    this.understandingAnswers = data.understandingAnswers || null;
+    this.lastRecallGaps       = data.lastRecallGaps       || null;
+
+    // Module outcomes
+    this.moduleOutcomes = data.moduleOutcomes || []; // [{ id, text, achieved }]
+
+    /* ─── BLOCK CANVAS (new core) ─────────────────────────
+       A node is now an ordered list of blocks. Each block:
+         { id, type, ...typeSpecificData }
+       Block types: prose, callout, definition, table, formula,
+         procedure, code, calc, webpreview, quiz, match, diagram, flashcards
+       If a node has no blocks but has legacy fixed fields, we
+       migrate those fields into blocks so nothing is ever lost. */
+    this.learnerProfile = data.learnerProfile || 'college'; // primary|high|college|pro
+    // Cached AI lectures keyed by learner profile, e.g. { college: "script…" }.
+    // Lets us reuse a previously-generated lecture instead of re-calling the AI
+    // until the user explicitly regenerates (or switches profile level).
+    this.lectureCache = (data.lectureCache && typeof data.lectureCache === 'object') ? data.lectureCache : {};
+    // Cached slide-format lectures, keyed by learner profile (separate from prose).
+    this.lectureSlidesCache = (data.lectureSlidesCache && typeof data.lectureSlidesCache === 'object') ? data.lectureSlidesCache : {};
+    this.lecturePosition = (data.lecturePosition && typeof data.lecturePosition === "object") ? data.lecturePosition : {};
+    // Cached first-time guided-study intros, keyed by learner profile. Returning
+    // intros are personalised and never cached.
+    this.introCache = (data.introCache && typeof data.introCache === 'object') ? data.introCache : {};
+    this.introReturnCache = (data.introReturnCache && typeof data.introReturnCache === 'object') ? data.introReturnCache : {};
+    this.ucQuestionCache = Array.isArray(data.ucQuestionCache) ? data.ucQuestionCache : null;
+    this.blocks = Array.isArray(data.blocks) ? data.blocks.map(b => ({ id: b.id || KnowledgeNode._generateBlockId(), ...b })) : [];
+    if (!this.blocks.length && this._hasLegacyContent()) {
+      this.blocks = this._migrateToBlocks();
+    }
+  }
+
+  /* ─── BLOCK HELPERS ─────────────────────────────────── */
+  _hasLegacyContent() {
+    return (this.definitions?.length || this.formulas?.length ||
+            this.procedures?.length || this.tables?.length ||
+            this.commonMistakes?.length || this.summary);
+  }
+
+  /** Convert old fixed-field content into blocks (lossless). */
+  _migrateToBlocks() {
+    const out = [];
+    const mk = (type, data) => out.push({ id: KnowledgeNode._generateBlockId(), type, ...data });
+    if (this.definitions?.length)
+      mk('definition', { title: 'Key Definitions', items: this.definitions });
+    (this.tables || []).forEach(t =>
+      mk('table', { title: t.title || 'Table', columns: t.columns || [], rows: t.rows || [] }));
+    if (this.formulas?.length)
+      mk('formula', { title: 'Formulas & Equations', items: this.formulas });
+    (this.procedures || []).forEach(p =>
+      mk('procedure', { title: p.title || 'Procedure', appliesTo: p.appliesTo || '', steps: p.steps || [], notes: p.notes || '' }));
+    if (this.commonMistakes?.length)
+      mk('callout', { title: 'Common Mistakes', tone: 'warn', html: '<ul>' + this.commonMistakes.map(m => '<li>' + m + '</li>').join('') + '</ul>' });
+    if (this.summary)
+      mk('prose', { title: 'Summary', html: this.summary });
+    return out;
+  }
+
+  /** Add a block, persisting nothing (caller saves). */
+  addBlock(type, data = {}, index = -1) {
+    const block = { id: KnowledgeNode._generateBlockId(), type, ...data };
+    if (index < 0 || index >= this.blocks.length) this.blocks.push(block);
+    else this.blocks.splice(index, 0, block);
+    this.updatedAt = Date.now();
+    return block;
+  }
+  removeBlock(id) {
+    this.blocks = this.blocks.filter(b => b.id !== id);
+    this.updatedAt = Date.now();
+  }
+  moveBlock(id, dir) {
+    const i = this.blocks.findIndex(b => b.id === id);
+    if (i < 0) return;
+    const j = i + dir;
+    if (j < 0 || j >= this.blocks.length) return;
+    [this.blocks[i], this.blocks[j]] = [this.blocks[j], this.blocks[i]];
+    this.updatedAt = Date.now();
+  }
+  updateBlock(id, patch) {
+    const b = this.blocks.find(x => x.id === id);
+    if (b) { Object.assign(b, patch); this.updatedAt = Date.now(); }
+  }
+
+  computeMastery() {
+    const cards = Object.values(this.srsState);
+    if (!cards.length) return 0; // no SRS history → genuinely 0, never stale stored value
+
+    // Mastery blends three signals per card, then averages across cards:
+    //   • durability  — how many successful repetitions (capped at 4 → full credit).
+    //                    A card answered correctly once is NOT mastered; it needs to
+    //                    survive several spaced reviews. This is the main fix: ease
+    //                    alone treated a single "Good" as ~100%.
+    //   • difficulty  — the SM-2 ease factor, normalised (1.3→0, 2.5→~1). A card the
+    //                    learner keeps finding hard scores lower even if repeated.
+    //   • freshness   — a card whose review is badly overdue has likely decayed, so
+    //                    it loses a little credit until re-reviewed.
+    const now = Date.now();
+    const per = cards.map(c => {
+      const reps       = Math.max(0, c.repetitions || 0);
+      const durability = Math.min(1, reps / 4);                 // 0..1, full at 4 reps
+      const difficulty = Math.min(1, Math.max(0, (c.ease - 1.3) / 1.2)); // 0..1
+      // Weight durability more heavily than raw ease — knowing it over time matters most.
+      let score = 0.65 * durability + 0.35 * difficulty;
+      // Decay: if more than one interval overdue, shave up to 20%.
+      if (reps > 0 && c.nextReview && c.interval) {
+        const overdueDays = (now - c.nextReview) / 86400000;
+        if (overdueDays > c.interval) score *= 0.8;
+      }
+      return Math.min(1, Math.max(0, score));
+    });
+
+    const avg = per.reduce((s, v) => s + v, 0) / per.length;
+    return Math.min(100, Math.max(0, Math.round(avg * 100)));
+  }
+
+  /**
+   * What's actually outstanding to reach 100% mastery — for display, not
+   * scoring (computeMastery() above is the source of truth for the number).
+   * Mastery requires each question to survive ~4 spaced, successful reviews
+   * over TIME — it cannot be finished in one sitting, which is the confusion
+   * this breakdown exists to clear up right where the learner sees the %.
+   */
+  masteryBreakdown() {
+    const REPS_FOR_MASTERED = 4;
+    const total = this.questions.length;
+    let notStarted = 0, inProgress = 0, mastered = 0, overdue = 0;
+    const now = Date.now();
+    this.questions.forEach(q => {
+      const s = this.srsState[q.id];
+      const reps = s ? Math.max(0, s.repetitions || 0) : 0;
+      if (!s || reps === 0) { notStarted++; return; }
+      const isOverdue = s.nextReview && s.nextReview <= now;
+      if (isOverdue) overdue++;
+      if (reps >= REPS_FOR_MASTERED && !isOverdue) mastered++;
+      else inProgress++;
+    });
+    return { total, notStarted, inProgress, mastered, overdue, repsNeeded: REPS_FOR_MASTERED };
+  }
+
+  /** One human sentence summarising masteryBreakdown() — used wherever a
+   *  learner sees a mastery % and might reasonably ask "what's left?". */
+  masteryOutstandingText() {
+    const b = this.masteryBreakdown();
+    if (!b.total) return 'No practice questions yet — generate some to start building mastery.';
+    if (b.notStarted === b.total) return 'Not started yet — answer these questions at least once to begin.';
+    const parts = [];
+    if (b.notStarted) parts.push(b.notStarted + ' question' + (b.notStarted===1?'':'s') + ' not answered yet');
+    if (b.overdue)     parts.push(b.overdue + ' overdue for review');
+    if (b.inProgress - b.overdue > 0) parts.push((b.inProgress - b.overdue) + ' still building (need more successful reviews over time)');
+    if (b.mastered === b.total) return 'All ' + b.total + ' questions fully mastered — nice work. Keep up with reviews as they come due to stay there.';
+    return parts.join(' · ') + '. Mastery reaches 100% after each question survives ' + b.repsNeeded + ' spaced, successful reviews — it builds over days, not in one sitting.';
+  }
+
+  /** Questions the learner has struggled with (Again/Hard), worst-missed first —
+   *  the concrete "go re-read the textbook for these" list. Built from the
+   *  existing struggle log in `weakQuestions` (kept up to date by
+   *  LearnerMemory.recordStruggle during Review/Guided sessions), enriched
+   *  with each question's stored answer for display. */
+  missedQuestionsForReview(limit = 10) {
+    const byId = {};
+    this.questions.forEach(q => { byId[q.id] = q; });
+    return (this.weakQuestions || [])
+      .slice()
+      .sort((a, b) => (b.count || 0) - (a.count || 0))
+      .slice(0, limit)
+      .map(w => ({ id: w.id, question: w.text, answer: byId[w.id] ? byId[w.id].answer : '', count: w.count || 1 }));
+  }
+
+  dueQuestions() {
+    const now = Date.now();
+    return this.questions.filter(q => {
+      const s = this.srsState[q.id];
+      // Never reviewed — NOT due yet. Only becomes due after first rating.
+      if (!s || s.repetitions === 0) return false;
+      return s.nextReview <= now;
+    });
+  }
+
+  /** Questions that have never been reviewed — shown as "New" not "Due" */
+  newQuestions() {
+    return this.questions.filter(q => {
+      const s = this.srsState[q.id];
+      return !s || s.repetitions === 0;
+    });
+  }
+
+  recordRating(questionId, rating) {
+    const card = this.srsState[questionId] || SRSCard.initial();
+    this.srsState[questionId] = SpacedRepetition.update(card, rating);
+    this.reviewCount++;
+    this.lastReviewed = Date.now();
+    this.masteryScore = this.computeMastery();
+    this.updatedAt = Date.now();
+  }
+
+  /** Reset all progress — mastery, SRS state, review history, weak questions */
+  resetProgress() {
+    this.srsState      = {};
+    this.masteryScore  = 0;
+    this.reviewCount   = 0;
+    this.lastReviewed  = null;
+    this.weakQuestions = [];
+    this.sessionLog    = [];
+    this.activitySummary = '';
+    this.updatedAt     = Date.now();
+  }
+
+  /** Clear AI-generated content that derives from this node's source/blocks,
+   *  so it regenerates after the content is edited. Call after content edits. */
+  invalidateContentCaches() {
+    this.introCache      = {};    // Prime step intro regenerates
+    this.introReturnCache = {}; // returning-visit intro regenerates too
+    this.profileCache    = {};    // block layouts per level regenerate
+    this.lectureCache    = {};    // lecture script regenerates
+    this.lectureSlidesCache = {}; // slide lecture regenerates too
+    this.ucQuestionCache = null;  // understanding-check questions regenerate
+    // Clear saved lecture playback position (the script will change)
+    try {
+      const all = JSON.parse(localStorage.getItem('kn_lecture_pos') || '{}');
+      Object.keys(all).forEach(k => { if (k.startsWith(this.id + ':')) delete all[k]; });
+      localStorage.setItem('kn_lecture_pos', JSON.stringify(all));
+    } catch(e) { /* best-effort */ }
+    this.updatedAt = Date.now();
+  }
+
+  toJSON() {
+    return {
+      id: this.id, subject: this.subject, chapter: this.chapter,
+      title: this.title, summary: this.summary, userNotes: this.userNotes,
+      sourceBookmark: this.sourceBookmark,
+      sourcePage: this.sourcePage,
+      sectionOrder: this.sectionOrder,
+      rawOCR: this.rawOCR, subjectCategory: this.subjectCategory,
+      noteTemplate: this.noteTemplate, cornellData: this.cornellData,
+      outlineData: this.outlineData, feynmanData2: this.feynmanData2,
+      definitions: this.definitions, tables: this.tables,
+      formulas: this.formulas, procedures: this.procedures,
+      commonMistakes: this.commonMistakes, questions: this.questions,
+      blocks: this.blocks, moduleOutcomes: this.moduleOutcomes,
+      workedExamples: this.workedExamples, sessionLog: this.sessionLog,
+      aiCorrections: this.aiCorrections, weakQuestions: this.weakQuestions,
+      activitySummary: this.activitySummary,
+      linkedSourceId: this.linkedSourceId,
+      profileCache: this.profileCache,
+      lectureCache: this.lectureCache,
+      lectureSlidesCache: this.lectureSlidesCache,
+      lecturePosition: this.lecturePosition,
+      introCache: this.introCache,
+      introReturnCache: this.introReturnCache,
+      ucQuestionCache: this.ucQuestionCache,
+      processingStatus: this.processingStatus, processingDetail: this.processingDetail,
+      learnerProfile: this.learnerProfile, imageAnswers: this.imageAnswers,
+      annotations: this.annotations, imageRefs: this.imageRefs,
+      createdAt: this.createdAt, updatedAt: this.updatedAt,
+      lastStudied: this.lastStudied, masteryScore: this.masteryScore,
+      totalAttempts: this.totalAttempts, correctAttempts: this.correctAttempts,
+      difficulty: this.difficulty, tags: this.tags,
+    };
+  }
+  static fromJSON(o) {
+    const node = new KnowledgeNode(o);
+    // Recompute mastery on load so stored value never drifts from srsState.
+    // Catches drift from concurrent-save races or failed writes in past sessions.
+    if (Object.keys(node.srsState).length) {
+      node.masteryScore = node.computeMastery();
+    }
+    return node;
+  }
+
+  static _generateId() {
+    return 'kn_' + Date.now().toString(36) + '_' + Math.random().toString(36).slice(2,7);
+  }
+  static _generateQuestionId() {
+    return 'q_' + Math.random().toString(36).slice(2,9);
+  }
+  static _generateImageId() {
+    return 'img_' + Math.random().toString(36).slice(2,9);
+  }
+  static _generateBlockId() {
+    return 'blk_' + Math.random().toString(36).slice(2,9);
+  }
+
+  /**
+   * Sanitize source text for display. Some older nodes accidentally stored the
+   * model's JSON-wrapped output in rawOCR (e.g. ```json {"title":...,"body":...}).
+   * This unwraps that to readable text. Safe to call on already-clean text.
+   */
+  static cleanSourceText(raw) {
+    if (!raw || typeof raw !== 'string') return '';
+    let t = raw.trim();
+    // Strip markdown code fences (```json ... ``` or ``` ... ```)
+    t = t.replace(/^```(?:json|text)?\s*/i, '').replace(/\s*```\s*$/i, '').trim();
+    // If it parses as a notes object, pull out the human-readable fields
+    if (t.startsWith('{') || t.startsWith('[')) {
+      try {
+        const obj = JSON.parse(t);
+        const o   = Array.isArray(obj) ? (obj[0] || {}) : obj;
+        const parts = [];
+        if (o.title) parts.push(String(o.title));
+        const bodyVal = o.body || o.text || o.content || o.summary || o.rawOCR;
+        if (bodyVal) parts.push(String(bodyVal));
+        if (parts.length) t = parts.join('\n\n');
+      } catch (e) {
+        // Not valid JSON (often truncated). Best-effort: pull a "body"/"text" field.
+        const m = t.match(/"(?:body|text|content)"\s*:\s*"([\s\S]*?)"\s*[,}]/);
+        if (m) t = m[1];
+      }
+    }
+    // Un-escape literal \n sequences
+    t = t.replace(/\\n/g, '\n').replace(/\\"/g, '"').trim();
+    return t;
+  }
+}
+
+const SRSCard = {
+  initial() { return { ease:2.5, interval:0, repetitions:0, nextReview:Date.now() }; }
+};

--- a/knowledgenode/www/js/core/LearnerState.js
+++ b/knowledgenode/www/js/core/LearnerState.js
@@ -1,0 +1,252 @@
+/**
+ * LearnerState.js — Single shared memory for the Director and Coach.
+ *
+ * Both systems read from and write to this store. Neither has private
+ * memory the other can't see. This is the source of truth for:
+ *
+ *   director   — last Director run: assessment, decisions, urgent nodes
+ *   coach      — recent coach topics and last insight
+ *   profile    — inferred student profile that both systems update
+ *
+ * localStorage key: kn_learner_state_v1
+ */
+const LearnerState = {
+  _key: 'kn_learner_state_v1',
+
+  _defaults() {
+    return {
+      createdAt:   Date.now(),
+      updatedAt:   Date.now(),
+      director:    null,   // set by AIDirector._apply()
+      coach:       null,   // set by StudyCoach after exchanges
+      profile:     null,   // inferred by either system
+      sessionLoad: null,   // { level:'light'|'normal'|'deep', at, reason, deferred:[] }
+    };
+  },
+
+  /** Read the full state object. Always returns a valid object. */
+  get() {
+    try {
+      const raw = localStorage.getItem(this._key);
+      if (!raw) return this._defaults();
+      return { ...this._defaults(), ...JSON.parse(raw) };
+    } catch { return this._defaults(); }
+  },
+
+  /** Merge a patch into the state. Only the keys you pass are changed. */
+  update(patch) {
+    try {
+      const next = { ...this.get(), ...patch, updatedAt: Date.now() };
+      localStorage.setItem(this._key, JSON.stringify(next));
+      return next;
+    } catch(e) {
+      console.warn('[LearnerState] write failed:', e);
+      return this.get();
+    }
+  },
+
+  /**
+   * Set how heavy the next study session should be.
+   * The student controls this — the Coach sets it only after confirming.
+   *   level:  'light' | 'normal' | 'deep'
+   *   reason: short natural-language note (e.g. "hectic work day")
+   * Returns the multiplier callers use to scale session volume.
+   */
+  setSessionLoad(level, reason = '') {
+    const valid = ['light', 'normal', 'deep'];
+    if (!valid.includes(level)) level = 'normal';
+    return this.update({
+      sessionLoad: {
+        level,
+        reason: (reason || '').slice(0, 120),
+        at:     Date.now(),
+      }
+    });
+  },
+
+  /**
+   * Read the current load level. Resets to 'normal' automatically if the
+   * last setting is stale (older than 18h) so a tired Tuesday doesn't
+   * silently shrink your sessions for the rest of the week.
+   */
+  getSessionLoad() {
+    const sl = this.get().sessionLoad;
+    if (!sl || !sl.level) return { level: 'normal', reason: '', stale: true };
+    const ageHours = (Date.now() - (sl.at || 0)) / 3600000;
+    if (ageHours > 18) return { level: 'normal', reason: '', stale: true };
+    return { ...sl, stale: false };
+  },
+
+  /** Volume multiplier for the current load. light=0.4, normal=1, deep=1.8 */
+  loadMultiplier() {
+    const lvl = this.getSessionLoad().level;
+    return lvl === 'light' ? 0.4 : lvl === 'deep' ? 1.8 : 1.0;
+  },
+
+  /**
+   * Defer skipped study-plan tasks so they come back rather than vanish.
+   * Stores task references; PlanEngine.rebalance() pulls these into upcoming days.
+   */
+  deferTasks(taskRefs = []) {
+    if (!taskRefs.length) return this.get();
+    const prev = this.get().sessionLoad || { level: 'normal', at: Date.now() };
+    const deferred = (prev.deferred || []).concat(
+      taskRefs.map(t => ({ ...t, deferredAt: Date.now() }))
+    ).slice(-50); // cap so it can't grow unbounded
+    return this.update({ sessionLoad: { ...prev, deferred } });
+  },
+
+  /** Pull and clear deferred tasks — called on a deep day to draw down backlog. */
+  drainDeferred() {
+    const sl = this.get().sessionLoad;
+    const deferred = (sl && sl.deferred) || [];
+    if (sl) this.update({ sessionLoad: { ...sl, deferred: [] } });
+    return deferred;
+  },
+
+  /** How many tasks are currently deferred (the backlog the student owes). */
+  deferredCount() {
+    const sl = this.get().sessionLoad;
+    return (sl && sl.deferred && sl.deferred.length) || 0;
+  },
+
+  /**
+   * Called by AIDirector when it applies a directive.
+   * Stores the full assessment so the Coach can reference it.
+   */
+  saveDirectorRun({ assessment, overallStudyMethod, studyMethodWhy,
+                    startNodeTitle, urgentNodes, planGuidance, firstAction, reshapedCount }) {
+    return this.update({
+      director: {
+        at:                 Date.now(),
+        assessment:         assessment         || '',
+        overallStudyMethod: overallStudyMethod || '',
+        studyMethodWhy:     studyMethodWhy     || '',
+        startNodeTitle:     startNodeTitle     || null,
+        urgentNodes:        urgentNodes        || [],
+        planGuidance:       planGuidance       || '',
+        firstAction:        firstAction        || '',
+        reshapedCount:      reshapedCount      || 0,
+      }
+    });
+  },
+
+  /**
+   * Called by StudyCoach after a meaningful exchange.
+   * Stores a lightweight record so the Director and future Coach sessions
+   * know what the student has recently discussed and struggled with.
+   */
+  saveCoachExchange({ question, signal, insight }) {
+    const prev   = this.get().coach || {};
+    // Keep last 6 signals — circular buffer of what the student has struggled with.
+    // These are distilled by the AI (e.g. "Student confused about VAT output tax"),
+    // not raw answer slices. The Director reads these before evaluating.
+    const signals = (prev.signals || []).slice(-5);
+    if (signal) signals.push({ at: Date.now(), text: signal.slice(0, 200) });
+    const topics  = (prev.recentTopics || []).slice(-4);
+    topics.push({ at: Date.now(), q: (question || '').slice(0, 120) });
+    return this.update({
+      coach: {
+        lastAt:       Date.now(),
+        lastQuestion: (question || '').slice(0, 200),
+        lastInsight:  (signal || insight || '').slice(0, 300),
+        signals,           // structured signals the Director can act on
+        recentTopics: topics,
+      }
+    });
+  },
+
+  /**
+   * Human-readable summary for prompts.
+   * Both Director and Coach call this to get a shared context block.
+   */
+  toPromptBlock() {
+    const s = this.get();
+    const parts = [];
+
+    if (s.director) {
+      const d = s.director;
+      const daysAgo  = Math.floor((Date.now() - d.at) / 86400000);
+      const when     = daysAgo === 0 ? 'today'
+                     : daysAgo === 1 ? 'yesterday'
+                     : daysAgo + ' days ago';
+      let block = 'AI DIRECTOR LAST RAN: ' + when;
+      if (d.assessment)         block += '\n  Assessment: '         + d.assessment;
+      if (d.overallStudyMethod) block += '\n  Recommended method: ' + d.overallStudyMethod
+                                       + (d.studyMethodWhy ? ' (' + d.studyMethodWhy + ')' : '');
+      if (d.startNodeTitle)     block += '\n  Told student to start with: "' + d.startNodeTitle + '"';
+      if (d.firstAction)       block += '\n  Specific first action given: ' + d.firstAction;
+      if (d.urgentNodes?.length) block += '\n  Flagged urgent: ' + d.urgentNodes.join(', ');
+      if (d.planGuidance)       block += '\n  Plan guidance: ' + d.planGuidance;
+      block += '\n  Reshaped ' + d.reshapedCount + ' topic(s).';
+      parts.push(block);
+    }
+
+    if (s.coach) {
+      const c = s.coach;
+      const daysAgo = Math.floor((Date.now() - c.lastAt) / 86400000);
+      const when    = daysAgo === 0 ? 'today' : daysAgo === 1 ? 'yesterday' : daysAgo + ' days ago';
+      let block = 'COACH LAST USED: ' + when;
+      if (c.lastQuestion) block += '\n  Last question: "' + c.lastQuestion + '"';
+      // Structured signals are AI-distilled (e.g. "Student confused about VAT output tax").
+      // These are far more useful for decisions than raw answer slices.
+      if (c.signals?.length) {
+        const recent = c.signals.slice(-3);
+        block += '\n  What the student has been struggling with (from recent coach exchanges):\n'
+               + recent.map(sig => {
+                   const d = Math.floor((Date.now() - sig.at) / 86400000);
+                   const w = d === 0 ? 'today' : d === 1 ? 'yesterday' : d + 'd ago';
+                   return '    - [' + w + '] ' + sig.text;
+                 }).join('\n');
+      } else if (c.lastInsight) {
+        block += '\n  Last insight: ' + c.lastInsight;
+      }
+      if (c.recentTopics?.length > 1) {
+        block += '\n  Recent topics discussed: '
+               + c.recentTopics.slice(-3).map(t => '"' + t.q + '"').join('; ');
+      }
+      parts.push(block);
+    }
+
+    // Current session-load lever — Director stays AWARE of it but does not act
+    // on it directly; the session builder and PlanEngine do the scaling.
+    const sl = this.getSessionLoad();
+    if (!sl.stale && sl.level && sl.level !== 'normal') {
+      let lb = 'CURRENT SESSION LOAD: ' + sl.level
+        + (sl.level === 'light' ? ' (student asked to keep it lighter today'
+         : sl.level === 'deep'  ? ' (student wants a heavier session today' : ' (');
+      if (sl.reason) lb += ' — "' + sl.reason + '"';
+      lb += ').';
+      const deferred = this.deferredCount();
+      if (deferred > 0) lb += ' ' + deferred + ' task(s) are deferred and owed.';
+      parts.push(lb);
+    }
+
+    return parts.length
+      ? 'SHARED LEARNER MEMORY:\n' + parts.join('\n\n')
+      : '';
+  },
+
+  /** Migrate data from the old kn_last_directive key on first run. */
+  migrate() {
+    try {
+      if (this.get().director) return; // already have data
+      const old = localStorage.getItem('kn_last_directive');
+      if (!old) return;
+      const d = JSON.parse(old);
+      this.update({
+        director: {
+          at:                 d.appliedAt         || Date.now(),
+          assessment:         '',
+          overallStudyMethod: d.overallStudyMethod || '',
+          studyMethodWhy:     '',
+          startNodeTitle:     d.startNodeTitle    || null,
+          urgentNodes:        d.urgentNodes        || [],
+          planGuidance:       d.planGuidance       || '',
+          reshapedCount:      d.reshapedCount      || 0,
+        }
+      });
+      localStorage.removeItem('kn_last_directive');
+    } catch(e) { /* migration is best-effort */ }
+  },
+};

--- a/knowledgenode/www/js/core/LeechDetector.js
+++ b/knowledgenode/www/js/core/LeechDetector.js
@@ -1,0 +1,49 @@
+/**
+ * LeechDetector.js — spots "leech" cards and breaks the grind (on-device, free).
+ *
+ * A leech is a question the learner keeps failing — flashcarding it again and
+ * again wastes time, because the problem is usually that the underlying CONCEPT
+ * isn't understood, not that the fact hasn't been drilled enough. Endlessly
+ * re-testing a blank is the single biggest time-sink in flashcard study.
+ *
+ * This module detects a leech from the existing struggle log (weakQuestions[].
+ * count, maintained by LearnerMemory.recordStruggle) and lets Review intervene:
+ * stop re-queuing the card this session and offer to actually learn it. No new
+ * data, no AI, no network.
+ */
+const LeechDetector = {
+  THRESHOLD: 4,   // failed/struggled this many times → treat as a leech
+
+  /** Struggle count for a specific question on a node (0 if never struggled). */
+  countFor(node, questionId) {
+    const w = (node && node.weakQuestions || []).find(w => w.id === questionId);
+    return w ? (w.count || 0) : 0;
+  },
+
+  /** Is this struggle record (or raw count) at/over the leech threshold? */
+  isLeech(struggleOrCount) {
+    const c = typeof struggleOrCount === 'number'
+      ? struggleOrCount
+      : (struggleOrCount && struggleOrCount.count) || 0;
+    return c >= this.THRESHOLD;
+  },
+
+  /** Has this specific card become a leech? */
+  isLeechCard(node, questionId) {
+    return this.isLeech(this.countFor(node, questionId));
+  },
+
+  /** Every leech across the library, worst-struggled first. */
+  leeches(nodes) {
+    const out = [];
+    (nodes || []).forEach(n => (n.weakQuestions || []).forEach(w => {
+      if (this.isLeech(w)) {
+        const q = (n.questions || []).find(q => q.id === w.id);
+        if (q) out.push({ node: n, question: q, count: w.count || 0 });
+      }
+    }));
+    return out.sort((a, b) => b.count - a.count);
+  },
+};
+if (typeof window !== 'undefined') window.LeechDetector = LeechDetector;
+if (typeof module !== 'undefined' && module.exports) module.exports = LeechDetector;

--- a/knowledgenode/www/js/core/LocalGrader.js
+++ b/knowledgenode/www/js/core/LocalGrader.js
@@ -1,0 +1,107 @@
+/**
+ * LocalGrader.js — free, on-device first pass for answer checking.
+ *
+ * Before spending AI credits (or when offline), the student's answer is
+ * compared against the question's stored acceptable answers. The matcher is
+ * deliberately CONSERVATIVE: it only ever returns 'correct' (high-confidence
+ * match) or 'unknown' — never 'incorrect'. A wrong-looking answer might still
+ * be right in words the matcher can't see, so anything unclear goes to the AI
+ * (online) or to self-marking (offline). Zero dependencies.
+ */
+const LocalGrader = {
+  _STOP: new Set(['the','a','an','of','to','in','on','for','and','or','is','are','was','were',
+    'be','it','its','this','that','as','at','by','with','from','equals','equal']),
+
+  /** Lowercase, strip accents/punctuation, collapse whitespace. */
+  normalize(s) {
+    return String(s == null ? '' : s)
+      .toLowerCase()
+      .normalize('NFD').replace(/[̀-ͯ]/g, '')
+      .replace(/[’'`´]/g, '')
+      .replace(/[^a-z0-9.%\-\s]/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+  },
+
+  _tokens(s) {
+    return this.normalize(s).split(' ').filter(t => t.length > 1 && !this._STOP.has(t));
+  },
+
+  _num(s) {
+    // Collapse thousands separators BEFORE extracting numbers. This app is full
+    // of amounts like "R 100 000" / "R1 385 600" / "100,000"; normalize() turns
+    // commas into spaces, so a space (or comma) sitting between two digits is a
+    // grouping separator, not a boundary between two numbers. Join those digit
+    // groups so "R 100 000" reads as 100000, not [100, 0]. Loop until stable to
+    // handle multi-group amounts ("1 000 000").
+    let t = this.normalize(s), prev;
+    do { prev = t; t = t.replace(/(\d)[ ,](\d)/g, '$1$2'); } while (t !== prev);
+    const m = t.match(/-?\d+(?:\.\d+)?%?/g);
+    return m ? m.map(x => x.endsWith('%') ? parseFloat(x) / 100 : parseFloat(x)) : [];
+  },
+
+  /**
+   * Match a student answer against acceptable answers.
+   * @param {string} student
+   * @param {string[]|string} accepted - model answer + any stored variants
+   * @returns {{verdict:'correct'|'unknown', matched?:string}}
+   */
+  match(student, accepted) {
+    const list = (Array.isArray(accepted) ? accepted : [accepted]).filter(Boolean);
+    const sNorm = this.normalize(student);
+    if (!sNorm) return { verdict: 'unknown' };
+
+    for (const acc of list) {
+      const aNorm = this.normalize(acc);
+      if (!aNorm) continue;
+
+      // 1. Exact match after normalisation
+      if (sNorm === aNorm) return { verdict: 'correct', matched: acc };
+
+      // 2. Short accepted answer (a term) contained whole in the student's answer
+      //    e.g. accepted "asset", student "I think it's an asset"
+      if (aNorm.length <= 40 && (' ' + sNorm + ' ').includes(' ' + aNorm + ' '))
+        return { verdict: 'correct', matched: acc };
+
+      // 3. Pure numeric answers: same numbers in the same order
+      const aNums = this._num(acc), sNums = this._num(student);
+      const aTok = this._tokens(acc);
+      if (aNums.length && aNums.length === sNums.length
+          && aNums.every((n, i) => Math.abs(n - sNums[i]) < 1e-9)
+          && aTok.length <= 2)
+        return { verdict: 'correct', matched: acc };
+
+      // 4. Key-token coverage: every meaningful word of a short accepted answer
+      //    appears in the student's answer (handles reordering: "Assets less
+      //    Liabilities" vs "assets minus liabilities" won't pass — 'less' vs
+      //    'minus' differ — but "owner's equity = assets - liabilities" vs
+      //    "Assets less Liabilities equals owners equity" shares the key nouns).
+      if (aTok.length >= 2 && aTok.length <= 8) {
+        const sSet = new Set(this._tokens(student));
+        if (aTok.every(t => sSet.has(t))) return { verdict: 'correct', matched: acc };
+      }
+
+      // 5. Multiple-choice: imported revision questions store answers as
+      //    "A — full option text". Answering with just that letter — "A",
+      //    "a)", "option A", "it's A" — is a confident match, so drilling
+      //    MCQs never needs an AI call. The accepted answer must have an
+      //    explicit letter+separator shape ("A —", "B)", "C:", "D.") so a
+      //    sentence that merely STARTS with the word "A" can never trigger it.
+      const mcq = String(acc).match(/^\s*\(?([A-Fa-f])\)?\s*[—–\-:.)]\s*\S/);
+      if (mcq) {
+        const sm = sNorm.match(/^(?:i think )?(?:its |the )?(?:answer |option |choice )?(?:is )?([a-f])\.?$/);
+        if (sm && sm[1] === mcq[1].toLowerCase()) return { verdict: 'correct', matched: acc };
+      }
+    }
+    return { verdict: 'unknown' };
+  },
+
+  /** Acceptable-answer list for a question object ({answer, accept?}). */
+  acceptedFor(q) {
+    const out = [q && q.answer];
+    if (q && Array.isArray(q.accept)) out.push(...q.accept.filter(a => typeof a === 'string'));
+    return out.filter(Boolean);
+  },
+};
+if (typeof window !== 'undefined') window.LocalGrader = LocalGrader;
+if (typeof module !== 'undefined' && module.exports) module.exports = LocalGrader;

--- a/knowledgenode/www/js/core/MatchGroup.js
+++ b/knowledgenode/www/js/core/MatchGroup.js
@@ -1,0 +1,84 @@
+/**
+ * MatchGroup.js — reassemble a real "Match & Pair" exercise from the individual
+ * questions an import produced. Free, on-device, zero dependencies.
+ *
+ * A matching worksheet ("Match the items in COLUMN A with those in COLUMN B")
+ * is extracted as ONE question per Column-A item, each carrying the SAME shared
+ * list of lettered Column-B options and its own correct letter as the answer.
+ * Shown one at a time that is just a slow MCQ. detect() groups the siblings
+ * back together — same node, identical option list — so the exam can present
+ * the whole thing as the two-column matching table the student actually sees on
+ * paper, and mark every pair instantly for free (a wrong match is definitively
+ * wrong — no AI needed).
+ */
+const MatchGroup = {
+  _INSTR: /\b(match|column)\b/i,
+
+  _mo() {
+    if (typeof window !== 'undefined' && window.MatchOptions) return window.MatchOptions;
+    if (typeof require !== 'undefined') { try { return require('./MatchOptions.js'); } catch (e) {} }
+    return null;
+  },
+
+  /** Separate the generic "Match … Column …" instruction from the actual
+   *  numbered Column-A prompt, so the instruction shows once (as a heading) and
+   *  each row shows only its own item. */
+  _splitStem(stem) {
+    const lines = String(stem == null ? '' : stem).split('\n').map(s => s.trim()).filter(Boolean);
+    const instr = [], prompt = [];
+    for (const l of lines) {
+      if (this._INSTR.test(l) && prompt.length === 0) instr.push(l);
+      else prompt.push(l);
+    }
+    return { instruction: instr.join(' '), prompt: prompt.join(' ') };
+  },
+
+  /** A stable fingerprint of an option set, so siblings that share it group. */
+  signature(options) {
+    return (options || []).map(o => o.letter + '|' + String(o.text).toLowerCase().replace(/\s+/g, ' ').trim()).join('§');
+  },
+
+  /**
+   * Find matching groups inside one node.
+   * @returns {{key,instruction,options,prompts:{q,prompt,answer}[]}[]}
+   *          Only genuine sets (≥2 items sharing an identical ≥3-option list).
+   */
+  detect(node) {
+    const MO = this._mo();
+    if (!MO || !node || !Array.isArray(node.questions)) return [];
+    const bySig = new Map();
+    for (const it of node.questions) {
+      const p = MO.parse(it.question);
+      if (!p || p.options.length < 3) continue;
+      const sig = this.signature(p.options);
+      const st = this._splitStem(p.stem);
+      if (!bySig.has(sig)) bySig.set(sig, { key: (node.id || 'n') + '::' + sig, instruction: '', options: p.options, prompts: [] });
+      const g = bySig.get(sig);
+      if (!g.instruction && st.instruction) g.instruction = st.instruction;
+      g.prompts.push({ q: it, prompt: st.prompt || it.question, answer: it.answer || '' });
+    }
+    return [...bySig.values()].filter(g => g.prompts.length >= 2);
+  },
+
+  /** The full "LETTER — text" to store when a letter is assigned to a prompt. */
+  answerFor(group, letter) {
+    if (!group) return letter;
+    const o = group.options.find(x => x.letter === String(letter).toUpperCase());
+    return o ? o.raw : String(letter).toUpperCase();
+  },
+
+  /** Which letter is the correct match for a prompt (from its stored answer). */
+  correctLetter(group, answer) {
+    const MO = this._mo();
+    return (MO && MO.letterOf) ? MO.letterOf({ options: group.options }, answer) : null;
+  },
+
+  /** Map a node's question-id → the group it belongs to (for session building). */
+  indexByQuestion(node) {
+    const map = new Map();
+    for (const g of this.detect(node)) for (const p of g.prompts) map.set(p.q.id, g);
+    return map;
+  },
+};
+if (typeof window !== 'undefined') window.MatchGroup = MatchGroup;
+if (typeof module !== 'undefined' && module.exports) module.exports = MatchGroup;

--- a/knowledgenode/www/js/core/MatchOptions.js
+++ b/knowledgenode/www/js/core/MatchOptions.js
@@ -23,10 +23,18 @@
  * lettered options starting at A (≥3), so ordinary prose is never mangled.
  */
 const MatchOptions = {
-  // A line that is a single lettered option: "A — text", "B) text", "C. text",
-  // "d: text". Captures the letter and the option body. Letters A–Z so long
-  // matching lists (A…Q) are supported, not just A–F.
-  _LINE: /^\s*\(?([A-Za-z])\)?\s*[—–\-:.)]\s+(\S.*)$/,
+  // A line that is a single lettered option. Two accepted shapes:
+  //
+  //   "A — text", "B) text", "C. text", "d: text"   — an explicit separator
+  //   "A Employees who earn…"                        — letter then just a space
+  //
+  // The second shape is common on real worksheets and used to be missed, which
+  // left those questions as an unreadable text blob instead of tappable
+  // choices. It is riskier (a sentence can begin "A resident must…"), so it is
+  // only accepted when the option text starts with a capital, a digit or a
+  // quote — the same guard the shared splitter uses — and, as with every shape,
+  // only inside a confident in-order A,B,C… run of at least three.
+  _LINE: /^\s*\(?([A-Za-z])\)?(?:\s*[—–\-:.)]\s*|\s+(?=["“(]?[A-Z0-9]))\s*(?=\S)(.*)$/,
 
   /** Break a single-line OCR blob ("… A) x B) y C) z") back onto one option per
    *  line. Self-contained (no dependency on KNText/global load order): needs an

--- a/knowledgenode/www/js/core/MatchOptions.js
+++ b/knowledgenode/www/js/core/MatchOptions.js
@@ -1,0 +1,116 @@
+/**
+ * MatchOptions.js — turn a lettered-option question into structured, tappable
+ * choices. Free, on-device, zero dependencies.
+ *
+ * Revision worksheets are full of matching / multiple-choice items where the
+ * options (Column B) are flattened into the question text, one per line:
+ *
+ *     10. Current withholding tax on dividends
+ *     A — 50%
+ *     B — Medical aid contributions
+ *     C — 20%
+ *     …
+ *     Q — 18%
+ *
+ * Rendered as a plain <textarea> ("Write a thorough answer…") this is unusable.
+ * parse() pulls out the stem (Column A prompt) and the lettered options
+ * (Column B) so the UI can show real tappable choices. Tapping a choice fills
+ * the answer with the full "LETTER — text", which the free LocalGrader marks
+ * instantly (its MCQ / containment rules match a bare letter, the value, or
+ * the full option), so drilling these never costs an AI call.
+ *
+ * Conservative on purpose: only fires when there is a genuine in-order run of
+ * lettered options starting at A (≥3), so ordinary prose is never mangled.
+ */
+const MatchOptions = {
+  // A line that is a single lettered option: "A — text", "B) text", "C. text",
+  // "d: text". Captures the letter and the option body. Letters A–Z so long
+  // matching lists (A…Q) are supported, not just A–F.
+  _LINE: /^\s*\(?([A-Za-z])\)?\s*[—–\-:.)]\s+(\S.*)$/,
+
+  /** Break a single-line OCR blob ("… A) x B) y C) z") back onto one option per
+   *  line. Self-contained (no dependency on KNText/global load order): needs an
+   *  in-order A,B,C… run of ≥3 markers, so ordinary prose is never split. */
+  _toLines(t) {
+    if (/\n/.test(t)) return t.split('\n');
+    const re = /\s\(?([A-Za-z])\)?\s*[—–\-:.)]\s+(?=\S)/g;
+    let m; const found = [];
+    while ((m = re.exec(t))) found.push({ letter: m[1].toUpperCase(), idx: m.index });
+    const chain = []; let want = 'A';
+    for (const f of found) {
+      if (f.letter === want) { chain.push(f); want = String.fromCharCode(want.charCodeAt(0) + 1); }
+    }
+    if (chain.length < 3) return [t];
+    const out = []; let last = 0;
+    for (const c of chain) { out.push(t.slice(last, c.idx)); last = c.idx + 1; }
+    out.push(t.slice(last));
+    return out.filter((s, i) => i === 0 || s.trim());
+  },
+
+  /**
+   * @param {string} questionText
+   * @returns {{stem:string, options:{letter:string,text:string,raw:string}[]}|null}
+   *          null when the text is not a lettered-option question.
+   */
+  parse(questionText) {
+    const t = String(questionText == null ? '' : questionText);
+    if (!t.trim()) return null;
+    // Break a single-line OCR blob into one option per line first.
+    const lines = this._toLines(t);
+
+    const stemLines = [];
+    const opts = [];
+    let want = 'A';          // next letter we expect in the A,B,C… chain
+    let started = false;     // have we entered the option block yet?
+
+    for (const line of lines) {
+      const m = line.match(this._LINE);
+      const letter = m ? m[1].toUpperCase() : null;
+      if (m && letter === want) {
+        opts.push({ letter, text: m[2].trim(), raw: letter + ' — ' + m[2].trim() });
+        want = String.fromCharCode(want.charCodeAt(0) + 1);
+        started = true;
+      } else if (!started) {
+        stemLines.push(line);          // still in the prompt (Column A)
+      } else {
+        // An option's body wrapped onto a second line — append to the last one.
+        if (line.trim() && opts.length) {
+          const last = opts[opts.length - 1];
+          last.text += ' ' + line.trim();
+          last.raw = last.letter + ' — ' + last.text;
+        }
+      }
+    }
+
+    if (opts.length < 3) return null;  // not confidently a lettered-option set
+    return { stem: stemLines.join('\n').trim(), options: opts };
+  },
+
+  /** The answer string to store when a given option letter is chosen. Using the
+   *  full "LETTER — text" makes free grading robust whether the stored model
+   *  answer is the letter, the value, or the full option. */
+  answerFor(parsed, letter) {
+    if (!parsed) return letter;
+    const o = parsed.options.find(x => x.letter === String(letter).toUpperCase());
+    return o ? o.raw : letter;
+  },
+
+  /** Given a saved answer string, which option letter (if any) does it name?
+   *  Lets the UI re-highlight the chosen button when a paper is revisited. */
+  letterOf(parsed, savedAnswer) {
+    if (!parsed || !savedAnswer) return null;
+    const s = String(savedAnswer).trim();
+    // "C", "C — 20%", "(c)", "c)"
+    const m = s.match(/^\(?([A-Za-z])\)?(?:\s*[—–\-:.)]|\s*$)/);
+    if (m) {
+      const L = m[1].toUpperCase();
+      if (parsed.options.some(o => o.letter === L)) return L;
+    }
+    // Fall back: the saved text equals one option's body exactly.
+    const low = s.toLowerCase();
+    const hit = parsed.options.find(o => o.text.toLowerCase() === low || o.raw.toLowerCase() === low);
+    return hit ? hit.letter : null;
+  },
+};
+if (typeof window !== 'undefined') window.MatchOptions = MatchOptions;
+if (typeof module !== 'undefined' && module.exports) module.exports = MatchOptions;

--- a/knowledgenode/www/js/core/NewCardPacer.js
+++ b/knowledgenode/www/js/core/NewCardPacer.js
@@ -1,0 +1,51 @@
+/**
+ * NewCardPacer.js — daily new-card introduction limit (on-device, free).
+ *
+ * Spaced repetition only works if NEW material is introduced at a sustainable
+ * rate. Uploading 200 questions creates 200 "new" cards; drilling all of them
+ * in one sitting is cognitive overload — the exact anti-pattern SRS exists to
+ * prevent. This paces new cards into the daily review flow: a capped batch is
+ * mixed in alongside due reviews, so a big upload becomes a steady drip.
+ *
+ * The budget adapts to the student's session-load lever (light/normal/deep),
+ * and is tracked per calendar day so starting several sessions in one day
+ * cannot smuggle the whole pile in at once. A card counts as "introduced" when
+ * it receives its FIRST rating (repetitions 0 → 1), mirroring how Anki counts.
+ */
+const NewCardPacer = {
+  _BUDGET: { light: 6, normal: 12, deep: 24 },
+  _PREFIX: 'kn_newcards_',
+
+  _today() { return new Date().toISOString().slice(0, 10); },
+  _key()   { return this._PREFIX + this._today(); },
+
+  /** New cards allowed per day for a given load level. */
+  budget(level) { return this._BUDGET[level] || this._BUDGET.normal; },
+
+  /** How many new cards have already been introduced today. */
+  introducedToday() {
+    try { return parseInt(localStorage.getItem(this._key()) || '0', 10) || 0; }
+    catch (e) { return 0; }
+  },
+
+  /** How many new cards may still be introduced today at this load level. */
+  remainingToday(level) {
+    return Math.max(0, this.budget(level) - this.introducedToday());
+  },
+
+  /** Count `n` newly-introduced cards against today's budget. Prunes stale
+   *  day-keys so localStorage doesn't grow without bound. */
+  recordIntroduced(n = 1) {
+    try {
+      const key = this._key();
+      localStorage.setItem(key, String(this.introducedToday() + Math.max(0, n)));
+      // Prune any previous days' counters.
+      for (let i = 0; i < localStorage.length; i++) {
+        const k = localStorage.key(i);
+        if (k && k.startsWith(this._PREFIX) && k !== key) { localStorage.removeItem(k); i--; }
+      }
+    } catch (e) { /* non-critical */ }
+  },
+};
+if (typeof window !== 'undefined') window.NewCardPacer = NewCardPacer;
+if (typeof module !== 'undefined' && module.exports) module.exports = NewCardPacer;

--- a/knowledgenode/www/js/core/NodeStore.js
+++ b/knowledgenode/www/js/core/NodeStore.js
@@ -1,0 +1,266 @@
+/**
+ * NodeStore.js — Persistence & State Management
+ *
+ * Single source of truth for all KnowledgeNodes.
+ * Uses localStorage for persistence. Emits events for UI updates.
+ * In the future this can be swapped for a remote API with minimal changes.
+ */
+
+class NodeStore extends EventTarget {
+  constructor() {
+    super();
+    this._storageKey = 'kn_nodes_v1';
+    /** @type {Map<string, KnowledgeNode>} */
+    this._nodes = new Map();
+    this._load();
+  }
+
+  // ─── Public API ───────────────────────────────────────
+
+  /** @returns {KnowledgeNode[]} All nodes, sorted by creation date desc.
+   *  Cached — only rebuilt when the Map is mutated (save/delete). */
+  getAll() {
+    if (!this._sortedCache) {
+      this._sortedCache = Array.from(this._nodes.values())
+        .sort((a, b) => b.createdAt - a.createdAt);
+    }
+    return this._sortedCache;
+  }
+
+  /** @returns {KnowledgeNode|undefined} */
+  get(id) {
+    return this._nodes.get(id);
+  }
+
+  /** Add or update a node. Emits 'change'.
+   *  Merges volatile learning fields (srsState, sessionLog, weakQuestions,
+   *  timestamps) to prevent concurrent saves from overwriting each other —
+   *  e.g. ReviewView rating a card while ReactiveReshaper saves in background. */
+  save(node) {
+    if (!(node instanceof KnowledgeNode)) node = new KnowledgeNode(node);
+
+    const existing = this._nodes.get(node.id);
+    if (existing && existing !== node) {
+      // SRS state: incoming wins for keys it has; preserve keys it doesn't
+      node.srsState = { ...existing.srsState, ...node.srsState };
+
+      // Session log: union by timestamp — never drop a session
+      const seenTs = new Set();
+      node.sessionLog = [
+        ...(existing.sessionLog || []),
+        ...(node.sessionLog || [])
+      ].filter(e => {
+        if (!e) return false;
+        const k = e.ts || e.date;
+        if (seenTs.has(k)) return false;
+        seenTs.add(k); return true;
+      }).sort((a, b) => (a.ts || 0) - (b.ts || 0)).slice(-20);
+
+      // Weak questions: union
+      const wqSet = new Set([
+        ...(existing.weakQuestions || []),
+        ...(node.weakQuestions || [])
+      ]);
+      node.weakQuestions = Array.from(wqSet);
+
+      // Timestamps: always keep the most recent value
+      node.lastActivity = Math.max(node.lastActivity || 0, existing.lastActivity || 0) || null;
+      node.lastReviewed = Math.max(node.lastReviewed || 0, existing.lastReviewed || 0) || null;
+      node.reviewCount  = Math.max(node.reviewCount  || 0, existing.reviewCount  || 0);
+
+      // Recompute mastery from the now-merged SRS state
+      if (Object.keys(node.srsState).length) node.masteryScore = node.computeMastery();
+
+      // Guard against storage bloat
+      if ((node.userImages  || []).length > 10) node.userImages  = node.userImages.slice(-10);
+      if ((node.sessionLog  || []).length > 20) node.sessionLog  = node.sessionLog.slice(-20);
+    }
+
+    node.updatedAt = Date.now();
+    this._nodes.set(node.id, node);
+    this._sortedCache = null; // invalidate
+
+    // Debounced persist — batches rapid saves (e.g. review ratings every 5s)
+    // into one write instead of serialising all nodes on every tap.
+    clearTimeout(this._persistTimer);
+    this._persistTimer = setTimeout(() => this._flushPersist(), 300);
+
+    this.dispatchEvent(new CustomEvent('change', { detail: { type: 'save', node } }));
+    return node;
+  }
+
+  /** Delete a node by id. Emits 'change'. */
+  delete(id) {
+    const node = this._nodes.get(id);
+    if (!node) return false;
+    this._nodes.delete(id);
+    this._sortedCache = null;
+    clearTimeout(this._persistTimer);
+    this._persistTimer = setTimeout(() => this._flushPersist(), 300);
+    this.dispatchEvent(new CustomEvent('change', { detail: { type: 'delete', id } }));
+    return true;
+  }
+
+  /** @returns {KnowledgeNode[]} Nodes that have at least one question due.
+   *  Inlines the due check rather than calling dueQuestions() to avoid creating
+   *  an intermediate array per node — O(q) check without O(q) allocation. */
+  getDueNodes() {
+    const now = Date.now();
+    return this.getAll().filter(n =>
+      n.questions.some(q => {
+        const s = n.srsState[q.id];
+        return s && s.repetitions > 0 && s.nextReview <= now;
+      })
+    );
+  }
+
+  /** @returns {{ total: number, mastery: number, due: number }}
+   *  Single pass — avoids calling getAll() twice (once here, once in getDueNodes). */
+  getStats() {
+    const all = this.getAll();
+    if (!all.length) return { total: 0, mastery: 0, due: 0 };
+    const now = Date.now();
+    let totalMastery = 0, due = 0;
+    for (const n of all) {
+      totalMastery += n.masteryScore;
+      if (n.questions.some(q => {
+        const s = n.srsState[q.id];
+        return s && s.repetitions > 0 && s.nextReview <= now;
+      })) due++;
+    }
+    return { total: all.length, mastery: Math.round(totalMastery / all.length), due };
+  }
+
+  /** Return all unique subjects */
+  getSubjects() {
+    const subjects = new Set(this.getAll().map(n => n.subject).filter(Boolean));
+    return Array.from(subjects);
+  }
+
+  // ─── Private ──────────────────────────────────────────
+
+  _load() {
+    this._nodes.clear();
+    this._sortedCache = null; // invalidate sort cache on reload
+    try {
+      const raw = localStorage.getItem(this._storageKey);
+      if (!raw) return;
+      const arr = JSON.parse(raw);
+      if (!Array.isArray(arr)) { console.warn('[NodeStore] Invalid data format'); return; }
+      let loaded = 0;
+      arr.forEach(obj => {
+        try {
+          if (!obj || !obj.id) return; // skip corrupt entries
+          const node = KnowledgeNode.fromJSON(obj);
+          this._nodes.set(node.id, node);
+          loaded++;
+        } catch(e2) {
+          console.warn('[NodeStore] Skipping corrupt node:', e2);
+        }
+      });
+      if (loaded > 0) console.log('[NodeStore] Loaded ' + loaded + ' nodes');
+    } catch (e) {
+      console.warn('[NodeStore] Failed to load from localStorage:', e);
+      // Try to recover from backup
+      try {
+        const backup = localStorage.getItem(this._storageKey + '_backup');
+        if (backup) {
+          const arr = JSON.parse(backup);
+          arr.forEach(obj => { if (obj?.id) this._nodes.set(obj.id, KnowledgeNode.fromJSON(obj)); });
+          console.log('[NodeStore] Recovered from backup');
+        }
+      } catch {}
+    }
+  }
+
+  /** Shim for importJSON and any legacy callers — flushes immediately. */
+  _persist() { this._flushPersist(); }
+
+  _flushPersist() {
+    try {
+      const data = this.getAll().map(n => n.toJSON());
+      const json = JSON.stringify(data);
+      localStorage.setItem(this._storageKey, json);
+
+      this._saveCount = (this._saveCount || 0) + 1;
+
+      // Rolling in-browser backup every 10 saves (silent, no download)
+      if (this._saveCount % 10 === 0) {
+        try { localStorage.setItem(this._storageKey + '_backup', json); } catch {}
+      }
+
+      // Versioned snapshot into the in-app Backup Vault (IndexedDB).
+      // Self-gated to at most once / 6h, so this is safe to call on every save.
+      // Replaces the old behaviour of dropping dated files into Downloads.
+      if (typeof BackupVault !== 'undefined') { BackupVault.maybeAuto(); }
+    } catch (e) {
+      if (e.name === 'QuotaExceededError') {
+        console.warn('[NodeStore] localStorage quota exceeded — trying to free space');
+        ['kn_nodes_backup', 'kn_nodes_old'].forEach(k => localStorage.removeItem(k));
+        try { localStorage.setItem(this._storageKey, JSON.stringify(this.getAll().map(n => n.toJSON()))); }
+        catch(e2) {
+          console.error('[NodeStore] Could not persist:', e2);
+          if (typeof Toast !== 'undefined') Toast.error('⚠ Storage full — export your data now from Settings.');
+        }
+      } else {
+        console.warn('[NodeStore] Failed to persist to localStorage:', e);
+      }
+    }
+  }
+
+  /** Export all data as JSON string — use for backup */
+  exportJSON() {
+    return JSON.stringify(this.getAll().map(n => n.toJSON()), null, 2);
+  }
+
+  /** Parse a backup string in either format:
+   *    - legacy: a bare array of node objects
+   *    - current: { _knBackup, nodes:[...], ai:{...} }
+   *  Returns { nodes:[...], ai:obj|null }. */
+  _parseBackup(jsonStr) {
+    const data = JSON.parse(jsonStr);
+    if (Array.isArray(data)) return { nodes: data, ai: null };
+    if (data && Array.isArray(data.nodes)) return { nodes: data.nodes, ai: data.ai || null };
+    throw new Error('Unrecognised backup format');
+  }
+
+  /** Import data from JSON string — merges with existing nodes (re-import overwrites by id).
+   *  Also restores AI configuration if the backup contains it. */
+  importJSON(jsonStr) {
+    try {
+      const { nodes, ai } = this._parseBackup(jsonStr);
+      nodes.forEach(obj => {
+        const node = KnowledgeNode.fromJSON(obj);
+        this._nodes.set(node.id, node);
+      });
+      this._sortedCache = null;
+      this._flushPersist();
+      if (ai && typeof AIService !== 'undefined') { try { AIService.importConfig(ai); } catch {} }
+      this.dispatchEvent(new CustomEvent('change', { detail: { type: 'import' } }));
+      return nodes.length;
+    } catch(e) {
+      throw new Error('Invalid backup file: ' + e.message);
+    }
+  }
+
+  /** Replace ALL current data with the contents of a snapshot (true restore).
+   *  Unlike importJSON (which merges), this clears existing nodes first so the
+   *  result exactly matches the chosen version. Also restores AI config if present. */
+  replaceAllFromJSON(jsonStr) {
+    const { nodes, ai } = this._parseBackup(jsonStr);   // validate before clearing
+    this._nodes.clear();
+    let loaded = 0;
+    nodes.forEach(obj => {
+      try { if (obj?.id) { this._nodes.set(obj.id, KnowledgeNode.fromJSON(obj)); loaded++; } }
+      catch(e) { console.warn('[NodeStore] Skipping corrupt node on restore:', e); }
+    });
+    this._sortedCache = null;
+    this._flushPersist();
+    if (ai && typeof AIService !== 'undefined') { try { AIService.importConfig(ai); } catch {} }
+    this.dispatchEvent(new CustomEvent('change', { detail: { type: 'restore' } }));
+    return loaded;
+  }
+}
+
+// Singleton
+const nodeStore = new NodeStore();

--- a/knowledgenode/www/js/core/QuestionKind.js
+++ b/knowledgenode/www/js/core/QuestionKind.js
@@ -1,0 +1,69 @@
+/**
+ * QuestionKind.js — tell a quick recall question apart from a full worked
+ * calculation. Free, on-device, zero dependencies.
+ *
+ * Imported worksheets arrive with everything typed 'recall', so a ten-minute
+ * multi-part computation ("Chris, whose age next birthday will be 65, donated a
+ * usufructuary interest… Calculate the donations tax payable") was scheduled as
+ * a flashcard. That does not work: nobody works a usufruct valuation on their
+ * phone between two other cards, so it gets skipped and rated Again, which
+ * makes the interval meaningless and eventually trips the leech detector on a
+ * question the student never actually attempted.
+ *
+ * Spaced repetition is for fast retrieval. Full calculations belong in the exam,
+ * sat properly and marked at the end. This decides which is which so each goes
+ * where it works.
+ *
+ * Deliberately biased toward 'recall': a question is only treated as a
+ * calculation on CLEAR evidence, because wrongly hiding a legitimate recall card
+ * from review costs the student real practice.
+ */
+const QuestionKind = {
+  /** An explicit instruction to compute something. */
+  _DO: /\b(calculate|compute|determine the (?:amount|tax|value|total)|work out|how much (?:tax|is|would|must))\b/i,
+  /** Scenario scaffolding — the long story a computation hangs off. */
+  _STORY: /\b(aged \d|age next birthday|during the (?:current |)year of assessment|financial year|the following (?:information|transactions)|assume that)\b/i,
+  /** An amount: R 3 250 000 / R36 000 / 1,250.50 */
+  _MONEY: /(?:^|[^\w])(?:r\s?)?\d{1,3}(?:[ ,]\d{3})+(?:\.\d+)?|\br\s?\d+(?:\.\d{2})?\b/i,
+
+  /**
+   * @param {{question?:string, answer?:string, type?:string}} q
+   * @returns {'calculation'|'recall'}
+   */
+  of(q) {
+    if (!q) return 'recall';
+    const text = String(q.question || '');
+    const ans  = String(q.answer || '');
+    if (!text.trim()) return 'recall';
+
+    // A lettered multiple-choice question is always quick, whatever it asks
+    // about — the student picks an option, they do not compute anything.
+    if (typeof MatchOptions !== 'undefined' && MatchOptions.parse && MatchOptions.parse(text)) return 'recall';
+
+    let score = 0;
+    if (this._DO.test(text))                       score += 2;   // "Calculate the…"
+    if (this._STORY.test(text))                    score += 1;   // scenario setup
+    if ((text.match(this._MONEY) || []).length)    score += 1;   // amounts in the question
+    if (text.length > 260)                         score += 1;   // long by any measure
+    if (text.length > 500)                         score += 1;
+    // A model answer laid out as workings (several lines, or lines with "=") is
+    // the strongest signal of all: the answer is a method, not a fact.
+    const lines = ans.split('\n').filter(l => l.trim()).length;
+    if (lines >= 3)                                score += 2;
+    if (/=/.test(ans) && this._MONEY.test(ans))    score += 1;
+
+    return score >= 3 ? 'calculation' : 'recall';
+  },
+
+  /** Should this question appear in spaced repetition? */
+  isReviewable(q) { return this.of(q) !== 'calculation'; },
+
+  /** Split a question list into the two streams. */
+  split(questions) {
+    const recall = [], calculation = [];
+    (questions || []).forEach(q => (this.of(q) === 'calculation' ? calculation : recall).push(q));
+    return { recall, calculation };
+  },
+};
+if (typeof window !== 'undefined') window.QuestionKind = QuestionKind;
+if (typeof module !== 'undefined' && module.exports) module.exports = QuestionKind;

--- a/knowledgenode/www/js/core/Sanitizer.js
+++ b/knowledgenode/www/js/core/Sanitizer.js
@@ -1,0 +1,86 @@
+/**
+ * Sanitizer.js — allowlist HTML sanitizer (zero dependencies)
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * The AI is asked to return content blocks that contain raw HTML (e.g. the
+ * "prose" and "callout" block types in AIService.generateBlocks). That HTML is
+ * built from a *source the user did not necessarily write* — a photographed page,
+ * a PDF, or text someone else shared — so a prompt-injection in the source could
+ * steer the model into emitting <script>, <img onerror=…>, javascript: URLs, etc.
+ * Inserting that straight into innerHTML is a stored-XSS sink that, inside the
+ * Android WebView, can reach the native bridges (file save / print).
+ *
+ * RULE: never assign AI/source-derived HTML to innerHTML directly. Run it through
+ * Sanitizer.clean(html) first, OR use Sanitizer.setHTML(el, html).
+ *
+ * This uses the browser's own parser (an inert <template>, never executed) and
+ * walks the tree removing any tag/attribute not on the allowlist and any
+ * dangerous URL scheme. For a higher-assurance production build, prefer
+ * DOMPurify (https://github.com/cure53/DOMPurify) and bundle it locally — this
+ * module is a safe, self-contained baseline for when that isn't available.
+ */
+const Sanitizer = (function () {
+  // Tags allowed in rendered note/block HTML. No <script>, <style>, <iframe>,
+  // <object>, <embed>, <form>, <link>, <meta>, event-bearing media, etc.
+  const ALLOWED_TAGS = new Set([
+    'p','br','hr','span','div','b','strong','i','em','u','s','small','sub','sup',
+    'mark','code','pre','kbd','samp','blockquote','q','cite','abbr',
+    'ul','ol','li','dl','dt','dd',
+    'table','thead','tbody','tfoot','tr','th','td','caption','colgroup','col',
+    'h1','h2','h3','h4','h5','h6','figure','figcaption',
+  ]);
+
+  // Attributes allowed on any element. Deliberately excludes every on* handler,
+  // style (can load url()/expression), src, href, srcset, formaction, etc.
+  const ALLOWED_ATTRS = new Set([
+    'class','title','colspan','rowspan','scope','dir','lang','align','aria-label','role',
+  ]);
+
+  function scrub(node) {
+    // Walk a static snapshot of children so removals don't disturb iteration.
+    const children = Array.prototype.slice.call(node.childNodes);
+    for (const child of children) {
+      if (child.nodeType === 1) { // element
+        const tag = child.tagName.toLowerCase();
+        if (!ALLOWED_TAGS.has(tag)) {
+          // Drop the element but keep its (sanitized) text so content survives.
+          const text = document.createTextNode(child.textContent || '');
+          child.parentNode.replaceChild(text, child);
+          continue;
+        }
+        // Strip every attribute that isn't explicitly allowed.
+        for (const attr of Array.prototype.slice.call(child.attributes)) {
+          const name = attr.name.toLowerCase();
+          if (!ALLOWED_ATTRS.has(name) || name.startsWith('on')) {
+            child.removeAttribute(attr.name);
+          }
+        }
+        scrub(child);
+      } else if (child.nodeType === 8) { // comment — could hide conditional markup
+        child.parentNode.removeChild(child);
+      }
+      // text nodes (type 3) are left as-is; they cannot execute
+    }
+  }
+
+  return {
+    /** Return a sanitized HTML string safe to assign to innerHTML. */
+    clean(html) {
+      if (html == null) return '';
+      const tpl = document.createElement('template'); // inert: contents never run
+      tpl.innerHTML = String(html);
+      scrub(tpl.content);
+      return tpl.innerHTML;
+    },
+
+    /** Convenience: sanitize and assign in one call. */
+    setHTML(el, html) {
+      if (el) el.innerHTML = this.clean(html);
+      return el;
+    },
+  };
+})();
+
+if (typeof window !== 'undefined') window.Sanitizer = Sanitizer;
+if (typeof module !== 'undefined' && module.exports) module.exports = Sanitizer;

--- a/knowledgenode/www/js/core/ScrollLock.js
+++ b/knowledgenode/www/js/core/ScrollLock.js
@@ -1,0 +1,95 @@
+/**
+ * ScrollLock.js — automatic background scroll lock for overlays
+ *
+ * Goal: when any popup/overlay is on screen (coach chat, settings, the
+ * More sheet, the guide, the scan view, etc.) the page BEHIND it must not
+ * scroll. Background scroll-through (“scroll bleed”) is a classic tell that
+ * an app isn’t polished.
+ *
+ * How it works — no per-popup wiring needed:
+ *   A MutationObserver watches the DOM. Whenever something changes, we scan
+ *   the <body>’s direct children for a fixed, full-bleed, high-z-index
+ *   element (i.e. an overlay). If one is visible, we add `scroll-locked` to
+ *   <html>/<body>; when it closes, we remove it. New overlays added in the
+ *   future are covered automatically.
+ *
+ * We lock with `overflow:hidden` (not position:fixed), matching the rest of
+ * the app — position:fixed was found to cause page-jump on mobile here.
+ *
+ * Persistent fixed UI that is NOT an overlay (sidebar, bottom nav, the API-key
+ * banner, toasts, the selection toolbar, and LectureMode which locks itself)
+ * is excluded.
+ */
+
+const ScrollLock = {
+  EXCLUDE_IDS:     ['api-key-banner', 'lm-present'],
+  EXCLUDE_CLASSES: ['sidebar', 'mobile-nav', 'toast-container', 'mobile-select-bar'],
+  _locked: false,
+  _scheduled: false,
+  _obs: null,
+
+  _isOverlay(el) {
+    if (!el || el.nodeType !== 1) return false;
+    if (this.EXCLUDE_IDS.includes(el.id)) return false;
+    for (const c of this.EXCLUDE_CLASSES) if (el.classList.contains(c)) return false;
+    let cs;
+    try { cs = getComputedStyle(el); } catch { return false; }
+    if (cs.position !== 'fixed') return false;
+    if (cs.display === 'none' || cs.visibility === 'hidden') return false;
+    if ((parseInt(cs.zIndex, 10) || 0) < 200) return false;     // overlays sit high; nav/banners are excluded anyway
+    const r  = el.getBoundingClientRect();
+    const vw = window.innerWidth, vh = window.innerHeight;
+    // Full-bleed sheets and dialogs: most of the width, a meaningful slice of height.
+    return r.width >= vw * 0.8 && r.height >= vh * 0.2;
+  },
+
+  _anyOpen() {
+    const kids = document.body ? document.body.children : [];
+    for (let i = 0; i < kids.length; i++) if (this._isOverlay(kids[i])) return true;
+    return false;
+  },
+
+  apply() {
+    const lock = this._anyOpen();
+    if (lock === this._locked) return;
+    this._locked = lock;
+    document.documentElement.classList.toggle('scroll-locked', lock);
+    document.body.classList.toggle('scroll-locked', lock);
+  },
+
+  schedule() {
+    if (this._scheduled) return;
+    this._scheduled = true;
+    requestAnimationFrame(() => { this._scheduled = false; this.apply(); });
+  },
+
+  init() {
+    if (this._obs || !document.body) return;
+    try {
+      this._obs = new MutationObserver((muts) => {
+        for (let i = 0; i < muts.length; i++) {
+          const m = muts[i];
+          // Ignore our own html/body class toggles — prevents a feedback loop.
+          if (m.type === 'attributes' && m.attributeName === 'class' &&
+              (m.target === document.body || m.target === document.documentElement)) continue;
+          this.schedule();
+          return;
+        }
+      });
+      this._obs.observe(document.body, {
+        childList: true, subtree: true, attributes: true,
+        attributeFilter: ['class', 'style', 'hidden'],
+      });
+      this.apply();
+    } catch (e) { console.warn('[ScrollLock] init failed:', e); }
+    // Coverage math depends on viewport size.
+    window.addEventListener('resize', () => this.schedule());
+    window.addEventListener('orientationchange', () => this.schedule());
+  },
+};
+
+if (typeof window !== 'undefined') {
+  window.ScrollLock = ScrollLock;
+  if (document.body) ScrollLock.init();
+  else document.addEventListener('DOMContentLoaded', () => ScrollLock.init());
+}

--- a/knowledgenode/www/js/core/SharePack.js
+++ b/knowledgenode/www/js/core/SharePack.js
@@ -1,0 +1,53 @@
+/**
+ * SharePack.js — share a subject's topics with a friend as one small file.
+ *
+ * The pack contains study CONTENT only (notes, questions, examples, images):
+ * your review history, mastery scores, and AI keys are stripped, so the
+ * recipient starts fresh and nothing personal travels. The file imports
+ * through the normal Settings → Import flow (nodes merge by id, and a
+ * pre-import safety snapshot is taken automatically).
+ */
+const SharePack = {
+  build(subject) {
+    const all = nodeStore.getAll().filter(n => n.processingStatus !== 'processing');
+    const nodes = (subject && subject !== 'all') ? all.filter(n => n.subject === subject) : all;
+    if (!nodes.length) return null;
+    const clean = nodes.map(n => {
+      const j = n.toJSON();
+      delete j.srsState;        // recipient's practice starts fresh
+      delete j.masteryScore;
+      delete j.lastReviewed;
+      return j;
+    });
+    return {
+      _knPack: 1,
+      subject: (subject && subject !== 'all') ? subject : '',
+      exportedAt: Date.now(),
+      nodes: clean,
+    };
+  },
+
+  share(subject) {
+    const pack = this.build(subject);
+    if (!pack) { if (window.Toast) Toast.error('No topics to share yet.'); return false; }
+    const label = pack.subject || 'All_Topics';
+    const safe = label.replace(/[^\w\-]+/g, '_').replace(/^_+|_+$/g, '').slice(0, 40) || 'Topics';
+    const filename = 'KnowledgeNode_pack_' + safe + '.json';
+    const json = JSON.stringify(pack);
+    if (window.KNFiles) {
+      KNFiles.save(filename, 'application/json', json);
+    } else {
+      const blob = new Blob([json], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url; a.download = filename; a.style.display = 'none';
+      document.body.appendChild(a); a.click();
+      setTimeout(() => { URL.revokeObjectURL(url); a.remove(); }, 1000);
+    }
+    if (window.Toast) Toast.success(
+      pack.nodes.length + ' topic' + (pack.nodes.length > 1 ? 's' : '')
+      + ' packed — send the file to a friend. They import it in Settings → Import.');
+    return true;
+  },
+};
+if (typeof window !== 'undefined') window.SharePack = SharePack;

--- a/knowledgenode/www/js/core/SpacedRepetition.js
+++ b/knowledgenode/www/js/core/SpacedRepetition.js
@@ -1,0 +1,192 @@
+/**
+ * SpacedRepetition.js — FSRS scheduler (Free Spaced Repetition Scheduler, v4.5)
+ *
+ * Upgraded from SM-2. FSRS models each card's actual forgetting curve with two
+ * memory variables — stability S (days until recall probability drops to 90%)
+ * and difficulty D (1–10) — and schedules the next review for when recall is
+ * predicted to hit the 90% target. Same retention as SM-2 with roughly 20-30%
+ * fewer reviews. Default parameters from the open FSRS-4.5 release.
+ *
+ * Rating scale (unchanged): 1=Again, 2=Hard, 3=Good, 4=Easy
+ *
+ * Compatibility: cards keep the legacy fields (`ease`, `interval`,
+ * `repetitions`, `nextReview`) alongside the FSRS state (`stability`,
+ * `difficulty`, `lapses`, `lastReview`) — Dashboard, Review and the mastery
+ * calculator read the legacy fields. Existing SM-2 cards migrate on their
+ * next rating: stability seeds from the current interval, difficulty from
+ * ease. `repetitions` is no longer reset on a lapse (FSRS tracks `lapses`
+ * separately) — a forgotten card is not a "new" card.
+ *
+ * Reference: https://github.com/open-spaced-repetition/fsrs4anki/wiki/The-Algorithm
+ */
+
+const SpacedRepetition = {
+  // FSRS-4.5 default weights
+  _W: [0.4872, 1.4003, 3.7145, 13.8206, 5.1618, 1.2298, 0.8975, 0.031,
+       1.6474, 0.1367, 1.0461, 2.1072, 0.0793, 0.3246, 1.587, 0.2272, 2.8755],
+  _DECAY: -0.5,
+  _FACTOR: 19 / 81,
+  REQUEST_RETENTION: 0.9,   // schedule reviews at predicted 90% recall
+  MAX_INTERVAL: 365,
+
+  /** Predicted recall probability after `elapsedDays` for a card of stability S. */
+  retrievability(elapsedDays, stability) {
+    if (!(stability > 0)) return 0;
+    return Math.pow(1 + this._FACTOR * Math.max(0, elapsedDays) / stability, this._DECAY);
+  },
+
+  _clampD(d) { return Math.min(10, Math.max(1, d)); },
+  _initS(g)  { return Math.max(0.1, this._W[g - 1]); },
+  _initD(g)  { return this._clampD(this._W[4] - (g - 3) * this._W[5]); },
+
+  _nextD(d, g) {
+    const w = this._W;
+    const next = d - w[6] * (g - 3);
+    return this._clampD(w[7] * this._initD(4) + (1 - w[7]) * next);   // mean reversion
+  },
+
+  _nextSSuccess(d, s, r, g) {
+    const w = this._W;
+    const hard = g === 2 ? w[15] : 1;
+    const easy = g === 4 ? w[16] : 1;
+    return s * (1 + Math.exp(w[8]) * (11 - d) * Math.pow(s, -w[9])
+                  * (Math.exp((1 - r) * w[10]) - 1) * hard * easy);
+  },
+
+  _nextSForget(d, s, r) {
+    const w = this._W;
+    const ns = w[11] * Math.pow(d, -w[12]) * (Math.pow(s + 1, w[13]) - 1) * Math.exp((1 - r) * w[14]);
+    return Math.min(ns, s);   // forgetting never increases stability
+  },
+
+  _intervalFor(stability) {
+    const days = (stability / this._FACTOR) * (Math.pow(this.REQUEST_RETENTION, 1 / this._DECAY) - 1);
+    return Math.min(this.MAX_INTERVAL, Math.max(1, Math.round(days)));
+  },
+
+  /**
+   * Update a card's SRS state based on a rating.
+   * @param {object} card
+   * @param {1|2|3|4} rating
+   * @returns {object} Updated card (new object)
+   */
+  update(card, rating) {
+    const g = [1, 2, 3, 4].includes(rating) ? rating : 3;
+    const now = Date.now();
+    let { stability, difficulty } = card;
+    let repetitions = Math.max(0, card.repetitions || 0);
+    let lapses = Math.max(0, card.lapses || 0);
+
+    if (!(stability > 0)) {
+      if (repetitions > 0 && card.interval > 0) {
+        // Migrating a card that lived under SM-2: interval ≈ stability,
+        // ease 2.5→D≈2 (easy) … ease 1.3→D=10 (leech).
+        stability  = Math.max(0.5, card.interval);
+        difficulty = this._clampD(11 - ((card.ease || 2.5) - 1.3) * (9 / 1.2));
+        const elapsed = card.nextReview ? Math.max(0, (now - (card.nextReview - card.interval * 86400000)) / 86400000) : card.interval;
+        const r = this.retrievability(elapsed, stability);
+        difficulty = this._nextD(difficulty, g);
+        stability  = g === 1 ? this._nextSForget(difficulty, stability, r)
+                             : this._nextSSuccess(difficulty, stability, r, g);
+      } else {
+        // Brand-new card: first rating seeds the memory state
+        stability  = this._initS(g);
+        difficulty = this._initD(g);
+      }
+    } else {
+      const elapsed = card.lastReview ? (now - card.lastReview) / 86400000 : (card.interval || 0);
+      const r = this.retrievability(elapsed, stability);
+      difficulty = this._nextD(difficulty, g);
+      stability  = g === 1 ? this._nextSForget(difficulty, stability, r)
+                           : this._nextSSuccess(difficulty, stability, r, g);
+    }
+
+    if (g === 1) lapses += 1;
+    // Durability guard: mastery is built on `repetitions` (≈4 spaced successes
+    // → mastered), so re-rating a card within the same sitting must NOT count
+    // as another rep — otherwise tapping through a question 4× in one session
+    // farms 100% mastery, breaking the promise that mastery "builds over days,
+    // not in one sitting". Scheduling (stability/difficulty) still updates on
+    // every rating; only the durability counter is gated. The first-ever
+    // rating always counts.
+    const sinceLast = card.lastReview ? (now - card.lastReview) : Infinity;
+    if (sinceLast >= 12 * 3600000) repetitions += 1;
+
+    const interval   = g === 1 ? 1 : this._intervalFor(stability);   // relearn tomorrow
+    const nextReview = now + interval * 86400000;
+    // Legacy compat: mastery reads `ease` as an inverse-difficulty signal
+    const ease = 1.3 + ((10 - difficulty) / 9) * 1.2;
+
+    return { stability, difficulty, ease, interval, repetitions, lapses, nextReview, lastReview: now };
+  },
+
+  /**
+   * Get all due question-node pairs for a review session.
+   * @param {KnowledgeNode[]} nodes
+   * @returns {{ node: KnowledgeNode, question: object, state: object|null }[]}
+   */
+  buildSession(nodes) {
+    const now = Date.now();
+    const items = [];
+
+    nodes.forEach(node => {
+      node.questions.forEach(q => {
+        const state = node.srsState[q.id] || null;
+        const isDue = !state || state.nextReview <= now;
+        if (isDue) {
+          items.push({ node, question: q, state });
+        }
+      });
+    });
+
+    // Shuffle
+    return SpacedRepetition._shuffle(items);
+  },
+
+  /**
+   * Prioritize new cards and overdue first, then by how overdue they are.
+   * @param {KnowledgeNode[]} nodes
+   */
+  buildPrioritizedSession(nodes) {
+    const now = Date.now();
+    const items = SpacedRepetition.buildSession(nodes);
+
+    return items.sort((a, b) => {
+      const aOverdue = !a.state ? -Infinity : a.state.nextReview - now;
+      const bOverdue = !b.state ? -Infinity : b.state.nextReview - now;
+      return aOverdue - bOverdue;   // most overdue first
+    });
+  },
+
+  /** Fisher-Yates shuffle */
+  _shuffle(arr) {
+    const a = [...arr];
+    for (let i = a.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [a[i], a[j]] = [a[j], a[i]];
+    }
+    return a;
+  },
+
+  /**
+   * Days until next review for a card.
+   */
+  daysUntil(state) {
+    if (!state) return 0;
+    const ms = state.nextReview - Date.now();
+    return Math.max(0, Math.round(ms / (24 * 60 * 60 * 1000)));
+  },
+
+  /**
+   * Human-readable interval label.
+   */
+  intervalLabel(state) {
+    if (!state || state.repetitions === 0) return 'New';
+    const days = SpacedRepetition.daysUntil(state);
+    if (days === 0) return 'Due today';
+    if (days === 1) return 'Tomorrow';
+    if (days < 7) return `${days} days`;
+    if (days < 30) return `${Math.round(days / 7)}w`;
+    return `${Math.round(days / 30)}mo`;
+  },
+};

--- a/knowledgenode/www/js/core/StudyPlan.js
+++ b/knowledgenode/www/js/core/StudyPlan.js
@@ -1,0 +1,375 @@
+/**
+ * StudyPlan.js — Core data model for study plans
+ *
+ * A StudyPlan contains:
+ *  - metadata (exam date, daily budget, difficulty)
+ *  - an array of StudyDay objects (one per calendar day)
+ *  - each StudyDay has StudyTask objects (node + activity type)
+ *
+ * The plan engine allocates tasks by:
+ *  1. Ranking nodes by urgency = (1 - mastery/100) * daysUntilExam weighting
+ *  2. Spreading them across available days within daily time budget
+ *  3. Respecting difficulty curve (hardest material earlier)
+ */
+
+class StudyPlan {
+  constructor(data = {}) {
+    this.id          = data.id          || StudyPlan._id();
+    this.title       = data.title       || 'Study Plan';
+    this.examDate    = data.examDate    || null;        // ISO date string
+    this.dailyMins   = data.dailyMins   || 60;          // minutes per day
+    this.difficulty  = data.difficulty  || 'balanced';  // 'easy-first'|'balanced'|'hard-first'
+    this.subjects    = data.subjects    || [];           // subject strings to include ([] = all)
+    this.createdAt   = data.createdAt   || Date.now();
+    this.updatedAt   = data.updatedAt   || Date.now();
+    this.days        = (data.days || []).map(d => new StudyDay(d));
+    this.aiGenerated = data.aiGenerated || false;
+    this.aiRationale = data.aiRationale || '';
+    this.isActive    = data.isActive    !== undefined ? data.isActive : true;
+  }
+
+  /** Total tasks across all days */
+  get totalTasks()     { return this.days.reduce((s,d) => s + d.tasks.length, 0); }
+  get completedTasks() { return this.days.reduce((s,d) => s + d.tasks.filter(t=>t.done).length, 0); }
+  get progressPct()    { return this.totalTasks ? Math.round((this.completedTasks/this.totalTasks)*100) : 0; }
+
+  /** Days remaining until exam */
+  get daysRemaining() {
+    if (!this.examDate) return null;
+    const diff = new Date(this.examDate) - new Date();
+    return Math.max(0, Math.ceil(diff / 86400000));
+  }
+
+  /** Today's StudyDay (or null) */
+  todayPlan() {
+    const today = StudyPlan._dateStr(new Date());
+    return this.days.find(d => d.date === today) || null;
+  }
+
+  toJSON() { return { ...this, days: this.days.map(d => d.toJSON()) }; }
+  static fromJSON(o) { return new StudyPlan(o); }
+  static _id()       { return 'sp_' + Date.now().toString(36) + '_' + Math.random().toString(36).slice(2,6); }
+  static _dateStr(d) {
+    // Use LOCAL date to avoid UTC off-by-one in timezones east of UTC
+    const yr  = d.getFullYear();
+    const mo  = String(d.getMonth() + 1).padStart(2, '0');
+    const day = String(d.getDate()).padStart(2, '0');
+    return `${yr}-${mo}-${day}`;
+  }
+}
+
+class StudyDay {
+  constructor(data = {}) {
+    this.date   = data.date  || '';
+    this.tasks  = (data.tasks || []).map(t => new StudyTask(t));
+    this.breaks = data.breaks || [];   // [{ afterTaskIndex, durationMins }]
+    this.note   = data.note  || '';
+  }
+  get totalMins()  { return this.tasks.reduce((s,t) => s + t.estimatedMins, 0); }
+  get doneMins()   { return this.tasks.filter(t=>t.done).reduce((s,t)=>s+t.estimatedMins,0); }
+  get isComplete() { return this.tasks.length > 0 && this.tasks.every(t=>t.done); }
+  toJSON() { return { ...this, tasks: this.tasks.map(t=>({...t})) }; }
+}
+
+class StudyBreak {
+  constructor(data = {}) {
+    this.id           = data.id           || StudyPlan._id();
+    this.type         = 'break';
+    this.durationMins = data.durationMins || 10;
+    this.label        = data.label        || 'Break';
+  }
+}
+
+class StudyTask {
+  constructor(data = {}) {
+    this.id             = data.id             || StudyPlan._id();
+    this.nodeId         = data.nodeId         || '';
+    this.nodeTitle      = data.nodeTitle      || '';
+    this.subject        = data.subject        || '';
+    this.activityType   = data.activityType   || 'review';
+    // 'review'|'recall'|'application'|'summary'|'lecture'|'competency'
+    this.estimatedMins  = data.estimatedMins  || 15;
+    this.done           = data.done           || false;
+    this.doneAt         = data.doneAt         || null;
+    this.priority       = data.priority       || 1;  // 1=low, 2=medium, 3=high
+  }
+}
+
+/** PlanStore — persists one active plan per localStorage slot */
+const PlanStore = {
+  _key: 'kn_study_plans_v1',
+
+  getAll() {
+    try {
+      const raw = localStorage.getItem(this._key);
+      return raw ? JSON.parse(raw).map(StudyPlan.fromJSON) : [];
+    } catch { return []; }
+  },
+
+  getActive() { return this.getAll().find(p => p.isActive) || null; },
+
+  save(plan) {
+    const all = this.getAll().filter(p => p.id !== plan.id);
+    all.unshift(plan);
+    localStorage.setItem(this._key, JSON.stringify(all.slice(0,5).map(p=>p.toJSON())));
+    return plan;
+  },
+
+  delete(id) {
+    const all = this.getAll().filter(p => p.id !== id);
+    localStorage.setItem(this._key, JSON.stringify(all.map(p=>p.toJSON())));
+  },
+
+  setActive(id) {
+    const all = this.getAll().map(p => { p.isActive = p.id === id; return p; });
+    localStorage.setItem(this._key, JSON.stringify(all.map(p=>p.toJSON())));
+  },
+};
+
+/** PlanEngine — builds task allocations from nodes */
+const PlanEngine = {
+  /**
+   * Build a StudyPlan from user settings + node list.
+   * @param {{ title, examDate, dailyMins, difficulty, subjects }} settings
+   * @param {KnowledgeNode[]} nodes
+   * @param {string} aiRationale
+   */
+  build(settings, nodes, aiRationale = '') {
+    const plan = new StudyPlan({
+      ...settings,
+      aiRationale,
+      aiGenerated: !!aiRationale,
+    });
+
+    if (!nodes.length || !settings.examDate) return plan;
+
+    const today = new Date();
+    today.setHours(0, 0, 0, 0); // midnight LOCAL time
+    const examDay  = new Date(settings.examDate);
+    examDay.setHours(23,59,59,0);
+    const totalDays = Math.max(1, Math.ceil((examDay - today) / 86400000));
+
+    // Score nodes by urgency (lower mastery + closer to exam = higher priority)
+    const daysLeft   = totalDays;
+    const scoredNodes = nodes.map(n => {
+      const masteryGap = 1 - (n.masteryScore / 100);
+      const urgency    = masteryGap * (1 + (1 / Math.max(1, daysLeft)));
+      return { node: n, urgency };
+    });
+
+    // Sort by difficulty setting
+    if (settings.difficulty === 'hard-first') {
+      scoredNodes.sort((a,b) => b.urgency - a.urgency);
+    } else if (settings.difficulty === 'easy-first') {
+      scoredNodes.sort((a,b) => a.urgency - b.urgency);
+    } else {
+      // balanced: interleave hard and easy
+      scoredNodes.sort((a,b) => b.urgency - a.urgency);
+      const half   = Math.ceil(scoredNodes.length / 2);
+      const hard   = scoredNodes.slice(0, half);
+      const easy   = scoredNodes.slice(half).reverse();
+      scoredNodes.splice(0, scoredNodes.length, ...hard.flatMap((h,i) => easy[i] ? [h, easy[i]] : [h]));
+    }
+
+    // Activity types per pass (each node gets multiple passes across days)
+    const activityCycle = ['review', 'recall', 'application', 'summary'];
+    const minsPerActivity = { review: 20, recall: 15, application: 20, summary: 10, lecture: 25, competency: 30 };
+
+    // Build task list
+    const allTasks = [];
+    scoredNodes.forEach(({ node, urgency }) => {
+      const priority = urgency > 0.7 ? 3 : urgency > 0.4 ? 2 : 1;
+      const passes   = priority === 3 ? 3 : priority === 2 ? 2 : 1;
+      for (let pass = 0; pass < passes; pass++) {
+        const actType = activityCycle[pass % activityCycle.length];
+        allTasks.push(new StudyTask({
+          nodeId:        node.id,
+          nodeTitle:     node.title,
+          subject:       node.subject,
+          activityType:  actType,
+          estimatedMins: minsPerActivity[actType],
+          priority,
+        }));
+      }
+    });
+
+    // Add one competency test per subject near end (last 20% of days)
+    const subjects = [...new Set(nodes.map(n=>n.subject).filter(Boolean))];
+    subjects.forEach(subj => {
+      allTasks.push(new StudyTask({
+        nodeId: 'competency_' + subj,
+        nodeTitle: `${subj} — Competency Test`,
+        subject: subj,
+        activityType: 'competency',
+        estimatedMins: 30,
+        priority: 3,
+      }));
+    });
+
+    // Distribute tasks across days respecting dailyMins budget
+    let dayIdx  = 0;
+    let taskIdx = 0;
+    const compTasks = allTasks.filter(t => t.activityType === 'competency');
+    const regTasks  = allTasks.filter(t => t.activityType !== 'competency');
+
+    // Place competency tests in last 20% of days
+    const compStartDay = Math.max(0, Math.floor(totalDays * 0.8));
+
+    // Fill regular days
+    while (taskIdx < regTasks.length && dayIdx < compStartDay) {
+      const date    = new Date(today);
+      date.setDate(date.getDate() + dayIdx);
+      const dayPlan = new StudyDay({ date: StudyPlan._dateStr(date) });
+      let minsUsed  = 0;
+
+      while (taskIdx < regTasks.length && minsUsed + regTasks[taskIdx].estimatedMins <= settings.dailyMins) {
+        dayPlan.tasks.push(regTasks[taskIdx]);
+        minsUsed += regTasks[taskIdx].estimatedMins;
+        taskIdx++;
+      }
+      if (dayPlan.tasks.length) {
+        // Add a break after every sessionMins worth of tasks
+        const sessionMins = settings.sessionMins || 45;
+        // Match StudySession break schedule including short sessions
+        const breakMins = sessionMins < 5  ? 0
+                        : sessionMins <= 10 ? 2
+                        : sessionMins <= 20 ? 3
+                        : sessionMins <= 25 ? 5
+                        : sessionMins <= 45 ? 10
+                        : sessionMins <= 60 ? 15 : 20;
+        let accumulated = 0;
+        const breaks = [];
+        dayPlan.tasks.forEach((task, idx) => {
+          accumulated += task.estimatedMins;
+          if (accumulated >= sessionMins && idx < dayPlan.tasks.length - 1) {
+            breaks.push({ afterTaskIndex: idx, durationMins: breakMins });
+            accumulated = 0;
+          }
+        });
+        dayPlan.breaks = breaks;
+        plan.days.push(dayPlan);
+      }
+      dayIdx++;
+    }
+
+    // Fill competency days
+    let compIdx = 0;
+    for (let d = compStartDay; d < totalDays && compIdx < compTasks.length; d++) {
+      const date    = new Date(today);
+      date.setDate(date.getDate() + d);
+      const dayPlan = new StudyDay({ date: StudyPlan._dateStr(date) });
+      let minsUsed  = 0;
+      while (compIdx < compTasks.length && minsUsed + compTasks[compIdx].estimatedMins <= settings.dailyMins) {
+        dayPlan.tasks.push(compTasks[compIdx]);
+        minsUsed += compTasks[compIdx].estimatedMins;
+        compIdx++;
+      }
+      // Also add remaining regular tasks if any
+      while (taskIdx < regTasks.length && minsUsed + regTasks[taskIdx].estimatedMins <= settings.dailyMins) {
+        dayPlan.tasks.push(regTasks[taskIdx]);
+        minsUsed += regTasks[taskIdx].estimatedMins;
+        taskIdx++;
+      }
+      if (dayPlan.tasks.length) plan.days.push(dayPlan);
+    }
+
+    return plan;
+  },
+
+  /**
+   * Rebalance an existing plan based on updated mastery.
+   * Returns proposed changes without saving.
+   */
+  rebalance(plan, nodes) {
+    const nodeMap = Object.fromEntries(nodes.map(n => [n.id, n]));
+    const changes = [];
+
+    plan.days.forEach(day => {
+      if (day.date < StudyPlan._dateStr(new Date())) return; // skip past days
+      day.tasks.forEach(task => {
+        const node = nodeMap[task.nodeId];
+        if (!node) return;
+
+        // Mastered → upgrade to application
+        if (node.masteryScore >= 80 && task.activityType === 'review') {
+          changes.push({
+            dayDate: day.date,
+            taskId:  task.id,
+            from:    'review',
+            to:      'application',
+            reason:  `"${node.title}" mastery now ${node.masteryScore}% — upgrading to application tasks`,
+          });
+        }
+
+        // Struggling (weak questions exist + mastery < 50) → downgrade to guided
+        const hasWeakQuestions = node.weakQuestions?.length > 0;
+        if (hasWeakQuestions && (node.masteryScore ?? 100) < 50 && task.activityType === 'application') {
+          changes.push({
+            dayDate: day.date,
+            taskId:  task.id,
+            from:    'application',
+            to:      'review',
+            reason:  `"${node.title}" mastery ${node.masteryScore ?? 0}% with active struggle areas — stepping back to review`,
+          });
+        }
+
+        // Not studied recently (no activity in 7+ days) → flag as urgent
+        const lastAt = node.lastActivity;
+        const daysSince = lastAt ? Math.floor((Date.now() - lastAt) / 86400000) : 999;
+        if (daysSince >= 7 && task.activityType !== 'urgent-review') {
+          changes.push({
+            dayDate: day.date,
+            taskId:  task.id,
+            from:    task.activityType,
+            to:      'review',
+            reason:  `"${node.title}" not studied in ${daysSince} days — scheduling review`,
+          });
+        }
+      });
+    });
+
+    // Deduplicate by taskId — only one change per task
+    const seen = new Set();
+    return changes.filter(c => {
+      if (seen.has(c.taskId)) return false;
+      seen.add(c.taskId);
+      return true;
+    });
+  },
+
+  /**
+   * Check whether the student's deferred backlog still fits before the exam.
+   * Returns { fits, deferred, daysLeft, message } — the caller decides how to
+   * surface it. This is the safety valve so light days can't silently sink prep.
+   */
+  checkDeferredFit(plan) {
+    let deferred = 0;
+    try { if (typeof LearnerState !== 'undefined') deferred = LearnerState.deferredCount(); } catch (_) {}
+    if (!deferred) return { fits: true, deferred: 0 };
+
+    const daysLeft = plan && plan.daysUntilExam != null
+      ? plan.daysUntilExam
+      : (plan && plan.examDate ? Math.ceil((new Date(plan.examDate) - Date.now()) / 86400000) : null);
+
+    // Rough capacity: assume ~3 deferred tasks can be absorbed per remaining day.
+    const fits = daysLeft == null || deferred <= daysLeft * 3;
+    return {
+      fits,
+      deferred,
+      daysLeft,
+      message: fits
+        ? `${deferred} deferred task(s) — still room to catch up before your exam.`
+        : `You have ${deferred} deferred task(s) and only ${daysLeft} day(s) left. The next few sessions need to go deep, or some topics won't be covered.`,
+    };
+  },
+
+  applyRebalance(plan, changes) {
+    changes.forEach(ch => {
+      const day  = plan.days.find(d => d.date === ch.dayDate);
+      const task = day?.tasks.find(t => t.id === ch.taskId);
+      if (task) task.activityType = ch.to;
+    });
+    plan.updatedAt = Date.now();
+    return plan;
+  },
+};

--- a/knowledgenode/www/js/ui/AIDirector.js
+++ b/knowledgenode/www/js/ui/AIDirector.js
@@ -1,0 +1,214 @@
+/**
+ * AIDirector.js — "Let AI take the wheel."
+ *
+ * One button. The AI evaluates the learner across every node (mastery,
+ * due counts, review history, self-ratings) and DICTATES a coordinated
+ * set of changes:
+ *   • per-node note method (standard / cornell / outline / feynman)
+ *   • per-node learner profile (primary / high / college / pro)
+ *   • which nodes are urgent
+ *   • one overall study method to push right now
+ *   • study-plan guidance + a concrete first action
+ *
+ * It shows its assessment, then applies the changes live (narrated by the
+ * reshaping bar) and drops the learner straight into the method it chose.
+ */
+const AIDirector = {
+  _STUDY_METHOD_VIEW: {
+    'review':      { view: 'review',  label: 'Spaced Repetition Review' },
+    'guided':      { view: 'guided',  label: 'Guided Step-by-Step Study' },
+    'blank-recall':{ view: 'guided',  label: 'Active Recall' },
+    'exam':        { view: 'review',  label: 'Exam-Pressure Practice' },
+  },
+
+  /** Entry point — wired to the "AI: assess & adapt" button. */
+  async run() {
+    const nodes = nodeStore.getAll();
+    if (!nodes.length) { Toast.info('Add at least one node first — the AI adapts your library.'); return; }
+    if (!AIService.hasApiKey()) {
+      Modal.open(this._noKeyHtml());
+      document.getElementById('aidir-configure')?.addEventListener('click', () => { Modal.close(); AISettingsModal.open(); });
+      return;
+    }
+
+    // Loading modal
+    Modal.open(`<div class="aidir">
+      <div class="aidir-head"><span class="aidir-orb">⬡</span><h2>AI is evaluating your library…</h2></div>
+      <p class="aidir-sub">Reading mastery, review history and where you've struggled across ${nodes.length} node${nodes.length>1?'s':''}, then deciding how to reshape your study.</p>
+      <div class="aidir-loading"><div class="aif-dot"></div><div class="aif-dot"></div><div class="aif-dot"></div></div>
+    </div>`);
+
+    try {
+      const plan = (typeof PlanStore !== 'undefined' ? PlanStore.getActive() : null)
+                 || (typeof StudyPlanView !== 'undefined' ? StudyPlanView._plan : null);
+      const daysToExam = plan?.examDate
+        ? Math.ceil((new Date(plan.examDate) - Date.now()) / 86400000) : null;
+
+      // Build full plan context — same information the Coach gets — so Director
+      // can give specific plan guidance, not just days-remaining generics.
+      let planContext = null;
+      if (plan) {
+        const todayStr = new Date().toISOString().slice(0, 10);
+        const todayTasks = (plan.days || [])
+          .find(d => d.date === todayStr)?.tasks || [];
+        const doneSessions  = (plan.days || []).reduce((n, d) => n + (d.tasks || []).filter(t => t.done).length, 0);
+        const totalSessions = (plan.days || []).reduce((n, d) => n + (d.tasks || []).length, 0);
+        planContext = {
+          title:          plan.title || 'Study Plan',
+          daysToExam,
+          dailyMinutes:   plan.dailyMinutes || null,
+          todayTasks:     todayTasks.map(t => t.nodeTitle + ' (' + (t.activityType || 'study') + ', ' + (t.estimatedMins || '?') + ' min)'),
+          progressFraction: totalSessions ? (doneSessions + '/' + totalSessions) : null,
+          progressPct:    totalSessions ? Math.round(doneSessions / totalSessions * 100) : null,
+        };
+      }
+
+      // Pass global learner state so the AI has real cross-session evidence
+      const globalState = LearnerMemory.getGlobalState();
+      const directive = await AIService.directLearning(nodes, { daysToExam, globalState, planContext });
+      this._directive = directive;
+      this._renderReview(directive, nodes);
+    } catch (e) {
+      Modal.open(`<div class="aidir"><div class="aidir-head"><span class="aidir-orb" style="animation:none">⬡</span><h2>Couldn't evaluate</h2></div><p class="aidir-sub">${this._esc(e.message || 'Try again in a moment.')}</p><button class="btn-secondary" onclick="Modal.close()">Close</button></div>`);
+    }
+  },
+
+  /** Show the AI's assessment + the changes it wants to make, with one Apply button. */
+  _renderReview(d, nodes) {
+    const directives = (d.nodeDirectives || []).map(nd => {
+      const node = nodes.find(n => n.title === nd.title) || nodes.find(n => n.title.toLowerCase() === (nd.title||'').toLowerCase());
+      const changed = node && (node.noteMethod !== nd.noteMethod || node.learnerProfile !== nd.profile);
+      return { nd, node, changed };
+    }).filter(x => x.node);
+
+    const methodLabel = this._STUDY_METHOD_VIEW[d.overallStudyMethod]?.label || d.overallStudyMethod;
+
+    // Only show nodes where something actually changes or are flagged urgent.
+    // Showing all 50 nodes when 40 are unchanged creates noise that buries the real decisions.
+    const visibleDirectives = directives.filter(({ nd, changed }) => changed || nd.urgent);
+    const hiddenCount = directives.length - visibleDirectives.length;
+
+    const rows = visibleDirectives.map(({ nd, node, changed }) => `
+      <div class="aidir-row${nd.urgent ? ' urgent' : ''}">
+        <div class="aidir-row-main">
+          <div class="aidir-node-title">${nd.urgent ? '<span class="aidir-urgent-dot"></span>' : ''}${this._esc(nd.title)}</div>
+          <div class="aidir-change">
+            ${changed
+              ? `<span class="aidir-pill">${this._esc(node.noteMethod || 'standard')}</span>
+                 <span class="aidir-arrow">→</span>
+                 <span class="aidir-pill new">${this._esc(nd.noteMethod)}</span>
+                 <span class="aidir-pill new">${this._esc(nd.profile)}</span>`
+              : `<span class="aidir-pill urgent-only">urgent — no method change needed</span>`
+            }
+          </div>
+          <div class="aidir-why">${this._esc(nd.why || '')}</div>
+        </div>
+      </div>`).join('')
+    + (hiddenCount > 0
+        ? `<p class="aidir-sub" style="margin-top:10px;font-size:11px;">+ ${hiddenCount} other topic${hiddenCount===1?'':'s'} — no changes needed, already well set up.</p>`
+        : '');
+
+    const hasDetail = !!(d.assessment || d.studyMethodWhy || d.planGuidance || rows);
+    const changeSummary = visibleDirectives.length
+      ? `Updating ${visibleDirectives.length} topic${visibleDirectives.length===1?'':'s'}`
+        + (directives.length > visibleDirectives.length ? ` · ${directives.length} reviewed` : '')
+      : 'No topic changes needed — your setup already fits';
+
+    Modal.open(`<div class="aidir">
+      <div class="aidir-head"><span class="aidir-orb" style="animation:none">⬡</span><h2>Your plan is ready</h2></div>
+
+      <div class="aidir-method-card">
+        <div class="aidir-method-label">Study method I'm putting you in now</div>
+        <div class="aidir-method-name">${this._esc(methodLabel)}</div>
+        <div class="aidir-method-meta">${this._esc(changeSummary)}</div>
+      </div>
+
+      ${d.firstAction ? `<div class="aidir-firstaction">▶ First: ${this._esc(d.firstAction)}</div>` : ''}
+
+      ${hasDetail ? `<details class="aidir-details">
+        <summary>Why this plan &amp; what changes</summary>
+        <div class="aidir-details-body">
+          ${d.assessment ? `<p class="aidir-assessment">${this._esc(d.assessment)}</p>` : ''}
+          ${d.studyMethodWhy ? `<div class="aidir-section-label">Why ${this._esc(methodLabel)}</div><p class="aidir-sub">${this._esc(d.studyMethodWhy)}</p>` : ''}
+          ${rows ? `<div class="aidir-section-label">Changes to your topics (${visibleDirectives.length} of ${directives.length})</div><div class="aidir-rows">${rows}</div>` : ''}
+          ${d.planGuidance ? `<div class="aidir-section-label">Study plan direction</div><p class="aidir-sub">${this._esc(d.planGuidance)}</p>` : ''}
+        </div>
+      </details>` : ''}
+
+      <div class="aidir-btns">
+        <button class="btn-secondary" id="aidir-cancel">Not now</button>
+        <button class="btn-primary" id="aidir-apply">⬡ Apply &amp; start</button>
+      </div>
+    </div>`);
+
+    document.getElementById('aidir-cancel')?.addEventListener('click', () => Modal.close());
+    document.getElementById('aidir-apply')?.addEventListener('click', () => this._apply(d, directives));
+  },
+
+  /** Apply every change the AI dictated, narrated live, then enter the chosen method. */
+  async _apply(d, directives) {
+    Modal.close();
+    const bar = (typeof ReactiveReshaper !== 'undefined') ? ReactiveReshaper : null;
+
+    for (const { nd, node } of directives) {
+      bar?.show(`Reshaping "${this._short(nd.title)}" → ${nd.noteMethod} · ${nd.profile}`);
+      node.noteMethod     = nd.noteMethod || node.noteMethod;
+      node.learnerProfile = nd.profile    || node.learnerProfile;
+      node._aiUrgent      = !!nd.urgent;
+      node._aiNoteWhy     = nd.why || '';
+      nodeStore.save(node);
+      await this._tick(380);
+    }
+
+    // Persist the directive to the shared LearnerState so the Coach
+    // (and any future system) can always see what was decided and why.
+    try {
+      LearnerState.saveDirectorRun({
+        assessment:         d.assessment         || '',
+        overallStudyMethod: d.overallStudyMethod || '',
+        studyMethodWhy:     d.studyMethodWhy     || '',
+        startNodeTitle:     d.startNodeTitle     || null,
+        urgentNodes:        directives.filter(x => x.nd.urgent).map(x => x.nd.title),
+        planGuidance:       d.planGuidance       || '',
+        firstAction:        d.firstAction        || '',  // Coach can reference this
+        reshapedCount:      directives.length,
+      });
+    } catch(e) { /* storage optional */ }
+
+    // Persist the directive's plan guidance where the plan view can show it.
+    if (d.planGuidance && typeof StudyPlanView !== 'undefined') {
+      try { StudyPlanView._aiGuidance = d.planGuidance; } catch (e) {}
+    }
+
+    bar?.show('Setting your study method…');
+    await this._tick(500);
+    bar?.hide(400);
+
+    Toast.success('Done — the AI reshaped ' + directives.length + ' node' + (directives.length!==1?'s':'') + ' and chose your study method.');
+
+    const target = this._STUDY_METHOD_VIEW[d.overallStudyMethod] || this._STUDY_METHOD_VIEW.review;
+
+    // Make the recommendation and behaviour agree: if the AI named a start node
+    // and we're entering guided study, force the flow to begin there (not resume).
+    if (target.view === 'guided' && d.startNodeTitle && typeof GuidedView !== 'undefined') {
+      const all = nodeStore.getAll();
+      const start = all.find(n => n.title === d.startNodeTitle)
+                 || all.find(n => (n.title||'').toLowerCase().trim() === (d.startNodeTitle||'').toLowerCase().trim());
+      if (start) GuidedView.startAtNode(start.id);
+    }
+
+    App.navigateTo(target.view);
+  },
+
+  _noKeyHtml() {
+    return `<div class="aidir">
+      <div class="aidir-head"><span class="aidir-orb" style="animation:none">⬡</span><h2>Let the AI take the wheel</h2></div>
+      <p class="aidir-sub">This evaluates how you're doing across every node, then dictates the best note method, learner level, and study method for each — and reshapes them for you. It needs an AI key configured.</p>
+      <div class="aidir-btns"><button class="btn-secondary" onclick="Modal.close()">Later</button><button class="btn-primary" id="aidir-configure">Configure AI</button></div>
+    </div>`;
+  },
+
+  _tick(ms) { return new Promise(r => setTimeout(r, ms)); },
+  _short(s) { s = String(s || ''); return s.length > 32 ? s.slice(0, 30) + '…' : s; },
+  _esc(s) { return String(s ?? '').replace(/[&<>"]/g, c => ({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;' }[c])); },
+};

--- a/knowledgenode/www/js/ui/AINodeTools.js
+++ b/knowledgenode/www/js/ui/AINodeTools.js
@@ -1,0 +1,205 @@
+/**
+ * AINodeTools.js
+ * In-node AI actions: generate from image, restructure notes, generate exam question
+ * Called from NodeDetailView's AI floater and section buttons
+ */
+const AINodeTools = {
+
+  /* ─── Generate content from a new image ───────────── */
+  async generateFromImage(node, targetSection) {
+    const input = document.createElement('input');
+    input.type = 'file'; input.accept = 'image/*'; input.multiple = false;
+    input.addEventListener('change', async () => {
+      const file = input.files[0];
+      if (!file) return;
+      input.value = '';
+
+      const overlay = this._showSpinner('AI is reading the image…');
+      try {
+        const b64 = await this._toBase64(file);
+        const result = await AIService.generateFromImage(b64, node, targetSection || 'auto');
+        overlay.remove();
+        this._showGeneratedPreview(result, node, file);
+      } catch(e) {
+        overlay.remove();
+        Toast.error('AI image read failed: ' + e.message);
+      }
+    });
+    input.click();
+  },
+
+  /* ─── Restructure existing raw notes ───────────────── */
+  async restructureNotes(node) {
+    if (!node.rawOCR && !node.userNotes && !node.definitions.length) {
+      Toast.info('No raw content to restructure. Add some notes first.');
+      return;
+    }
+    const overlay = this._showSpinner('AI is restructuring your notes…');
+    try {
+      const result = await AIService.restructureNotes(node);
+      overlay.remove();
+      this._showGeneratedPreview(result, node, null);
+    } catch(e) {
+      overlay.remove();
+      Toast.error('Restructure failed: ' + e.message);
+    }
+  },
+
+  /* ─── Generate exam-style question ─────────────────── */
+  async generateExamQuestion(node) {
+    const overlay = this._showSpinner('Generating exam question…');
+    try {
+      const q = await AIService.generateExamQuestion(node);
+      overlay.remove();
+      this._showExamQuestion(q, node);
+    } catch(e) {
+      overlay.remove();
+      Toast.error('Exam question generation failed: ' + e.message);
+    }
+  },
+
+  /* ─── Show preview of AI-generated content ─────────── */
+  _showGeneratedPreview(result, node, imageFile) {
+    const sections = [];
+    if (result.definitions?.length)    sections.push({ key:'definitions',    label:'Definitions ('      + result.definitions.length    + ')', count:result.definitions.length });
+    if (result.tables?.length)         sections.push({ key:'tables',         label:'Tables ('           + result.tables.length         + ')', count:result.tables.length });
+    if (result.formulas?.length)       sections.push({ key:'formulas',       label:'Formulas ('         + result.formulas.length        + ')', count:result.formulas.length });
+    if (result.procedures?.length)     sections.push({ key:'procedures',     label:'Procedures ('       + result.procedures.length      + ')', count:result.procedures.length });
+    if (result.commonMistakes?.length) sections.push({ key:'commonMistakes', label:'Common Mistakes ('  + result.commonMistakes.length  + ')', count:result.commonMistakes.length });
+    if (result.summary)                sections.push({ key:'summary',        label:'Summary', count:1 });
+
+    if (!sections.length) {
+      Toast.info('AI did not detect structured content in this image. Try a clearer photo.');
+      return;
+    }
+
+    const checklist = sections.map(s =>
+      '<label style="display:flex;align-items:center;gap:10px;padding:10px 14px;background:var(--bg-raised);border:1px solid var(--border);border-radius:var(--radius-md);cursor:pointer;font-family:var(--font-ui);font-size:13px;font-weight:500;color:var(--text-primary);">'
+      + '<input type="checkbox" checked class="ai-gen-check" value="' + s.key + '" style="accent-color:var(--accent);width:16px;height:16px;flex-shrink:0;"/>'
+      + s.label
+      + '</label>'
+    ).join('');
+
+    // Mini preview of detected content
+    const preview = sections.slice(0,3).map(s => {
+      if (s.key==='definitions' && result.definitions[0]) return '<div style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);padding:6px 0;border-bottom:1px solid var(--border-soft);">📌 ' + result.definitions[0].term + '</div>';
+      if (s.key==='tables'      && result.tables[0])      return '<div style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);padding:6px 0;border-bottom:1px solid var(--border-soft);">📊 ' + (result.tables[0].title||'Table') + ' (' + result.tables[0].columns?.join(', ') + ')</div>';
+      if (s.key==='procedures'  && result.procedures[0])  return '<div style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);padding:6px 0;border-bottom:1px solid var(--border-soft);">📋 ' + (result.procedures[0].title||'Procedure') + ' — ' + (result.procedures[0].steps?.length||0) + ' steps</div>';
+      if (s.key==='formulas'    && result.formulas[0])    return '<div style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);padding:6px 0;border-bottom:1px solid var(--border-soft);">⚗ ' + result.formulas[0].expression + '</div>';
+      return '';
+    }).join('');
+
+    Modal.open(
+      '<h2 style="font-family:var(--font-ui);font-size:18px;font-weight:800;margin-bottom:6px;">AI Found ' + sections.length + ' Section' + (sections.length>1?'s':'') + '</h2>'
+      + '<p style="font-family:var(--font-mono);font-size:12px;color:var(--text-muted);margin-bottom:16px;">Select which sections to add to this node. Existing content is preserved.</p>'
+      + (preview ? '<div style="background:var(--bg-raised);border:1px solid var(--border);border-radius:var(--radius-md);padding:10px 14px;margin-bottom:16px;">' + preview + '</div>' : '')
+      + '<div style="display:flex;flex-direction:column;gap:8px;margin-bottom:20px;">' + checklist + '</div>'
+      + '<div style="display:flex;gap:8px;">'
+      + '<button class="btn-primary" id="ai-gen-apply-btn" style="flex:1;justify-content:center;">Add to Node</button>'
+      + '<button class="btn-secondary" onclick="Modal.close()">Cancel</button>'
+      + '</div>'
+    );
+
+    setTimeout(() => {
+      document.getElementById('ai-gen-apply-btn')?.addEventListener('click', () => {
+        const selected = Array.from(document.querySelectorAll('.ai-gen-check:checked')).map(c => c.value);
+        if (!selected.length) { Toast.info('Select at least one section.'); return; }
+
+        selected.forEach(key => {
+          if (key === 'definitions' && result.definitions) {
+            result.definitions.forEach(d => {
+              node.definitions.push({ term:d.term||'', examples:d.examples||'', description:d.description||'' });
+            });
+          }
+          if (key === 'tables' && result.tables) {
+            node.tables = node.tables || [];
+            result.tables.forEach(t => node.tables.push({...t, id:'tbl_'+Math.random().toString(36).slice(2,8)}));
+          }
+          if (key === 'formulas' && result.formulas) {
+            result.formulas.forEach(f => node.formulas.push(f));
+          }
+          if (key === 'procedures' && result.procedures) {
+            node.procedures = node.procedures || [];
+            result.procedures.forEach(p => node.procedures.push({...p, id:'proc_'+Math.random().toString(36).slice(2,8)}));
+          }
+          if (key === 'commonMistakes' && result.commonMistakes) {
+            node.commonMistakes = [...node.commonMistakes, ...result.commonMistakes];
+          }
+          if (key === 'summary' && result.summary) {
+            node.summary = node.summary ? node.summary + '\n\n' + result.summary : result.summary;
+          }
+        });
+
+        nodeStore.save(node);
+        Modal.close();
+        Toast.success('Added ' + selected.length + ' section' + (selected.length>1?'s':'') + ' to node!');
+        NodeDetailView._renderSection();
+      });
+    }, 0);
+  },
+
+  /* ─── Show exam question ────────────────────────────── */
+  _showExamQuestion(q, node) {
+    Modal.open(
+      '<h2 style="font-family:var(--font-ui);font-size:18px;font-weight:800;margin-bottom:16px;">🏆 Exam Question — ' + (node.title||'') + '</h2>'
+      + '<div style="background:var(--bg-raised);border:1px solid var(--border);border-radius:var(--radius-md);padding:18px 20px;margin-bottom:16px;">'
+      + '<div style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.08em;margin-bottom:10px;">' + (q.marks||'') + ' marks</div>'
+      + '<div style="font-family:var(--font-body);font-size:14px;color:var(--text-primary);line-height:1.7;margin-bottom:12px;">' + this._esc(q.scenario||'') + '</div>'
+      + '<div style="font-family:var(--font-ui);font-size:13px;font-weight:700;color:var(--accent);">' + this._esc(q.requirement||'') + '</div>'
+      + '</div>'
+      + '<div class="config-row" style="margin-bottom:12px;">'
+      + '<label class="config-label">Your Answer</label>'
+      + '<textarea id="exam-q-answer" class="config-input" rows="5" style="resize:vertical;touch-action:pan-y;font-size:14px;line-height:1.65;" placeholder="Write your answer and working here…"></textarea>'
+      + '</div>'
+      + '<div style="display:flex;gap:8px;margin-bottom:0;">'
+      + '<button class="btn-primary" id="exam-q-submit-btn" style="flex:1;justify-content:center;">Submit for AI Grading</button>'
+      + '<button class="btn-secondary" id="exam-q-reveal-btn">Show Model Answer</button>'
+      + '</div>'
+      + '<div id="exam-q-model" style="display:none;margin-top:16px;background:var(--green-dim);border:1px solid rgba(52,199,123,0.2);border-radius:var(--radius-md);padding:16px;">'
+      + '<div style="font-family:var(--font-ui);font-size:12px;font-weight:700;color:var(--green);text-transform:uppercase;letter-spacing:0.08em;margin-bottom:8px;">Model Answer</div>'
+      + '<div style="font-family:var(--font-body);font-size:13px;color:var(--text-primary);line-height:1.7;white-space:pre-wrap;">' + this._esc(q.modelAnswer||'') + '</div>'
+      + (q.markingGuidance?.length ? '<div style="margin-top:12px;"><div style="font-family:var(--font-ui);font-size:11px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.08em;margin-bottom:6px;">Marking Guidance</div>' + q.markingGuidance.map(g=>'<div style="font-family:var(--font-mono);font-size:12px;color:var(--text-secondary);padding:3px 0;">· '+this._esc(g)+'</div>').join('') + '</div>' : '')
+      + '</div>'
+      + '<div id="exam-q-feedback" style="display:none;margin-top:16px;"></div>'
+    );
+
+    setTimeout(() => {
+      document.getElementById('exam-q-reveal-btn')?.addEventListener('click', () => {
+        document.getElementById('exam-q-model').style.display='block';
+      });
+      document.getElementById('exam-q-submit-btn')?.addEventListener('click', async () => {
+        const answer = document.getElementById('exam-q-answer')?.value.trim();
+        if (!answer) { Toast.info('Write your answer first.'); return; }
+        const btn = document.getElementById('exam-q-submit-btn');
+        if (btn) { btn.disabled=true; btn.textContent='Grading…'; }
+        try {
+          const result = AIService.hasApiKey()
+            ? await AIService.checkAnswer(q.requirement||q.scenario, q.modelAnswer, answer, node.subject)
+            : { score:Math.floor(Math.random()*40+50), feedback:'Configure AI in Settings for real grading.', correct:false };
+          const color  = result.score>=70?'var(--green)':result.score>=50?'var(--accent)':'var(--red)';
+          const fb = document.getElementById('exam-q-feedback');
+          if (fb) {
+            fb.style.display='block';
+            fb.innerHTML = '<div style="background:var(--bg-raised);border:1px solid var(--border);border-left:3px solid '+color+';border-radius:var(--radius-md);padding:14px 18px;"><div style="font-family:var(--font-mono);font-size:18px;font-weight:700;color:'+color+';margin-bottom:6px;">'+result.score+'/100</div><p style="font-family:var(--font-body);font-size:13px;color:var(--text-primary);line-height:1.65;">'+this._esc(result.feedback||'')+'</p></div>';
+          }
+        } catch(e) { Toast.error('Grading failed: '+e.message); }
+        if (btn) { btn.disabled=false; btn.textContent='Submit for AI Grading'; }
+      });
+    }, 0);
+  },
+
+  /* ─── Helpers ───────────────────────────────────────── */
+  _showSpinner(label) {
+    const el = document.createElement('div');
+    el.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,0.75);z-index:99000;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:16px;';
+    el.innerHTML = '<div class="hex-ring"></div><p style="font-family:var(--font-mono);font-size:14px;color:var(--accent);">' + label + '</p>';
+    document.body.appendChild(el);
+    return el;
+  },
+
+  _toBase64(file) {
+    return new Promise((res,rej) => { const r=new FileReader(); r.onload=()=>res(r.result.split(',')[1]); r.onerror=rej; r.readAsDataURL(file); });
+  },
+
+  _esc: s => String(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'),
+};

--- a/knowledgenode/www/js/ui/AISettingsModal.js
+++ b/knowledgenode/www/js/ui/AISettingsModal.js
@@ -1,0 +1,351 @@
+/**
+ * AISettingsModal.js — Final with OpenRouter
+ * Paste one key → everything works. Advanced tab for per-function model config.
+ */
+const AISettingsModal = {
+  _tab: 'main',  // 'main' | 'functions'
+
+  open() {
+    // Managed-AI build: there is no bring-your-own-key. Show a subscription
+    // panel instead of provider/key config so the paywall can't be bypassed.
+    if (typeof AppConfig !== 'undefined' && AppConfig.MANAGED_ONLY) {
+      this._renderSubscription();
+      return;
+    }
+    this._tab = 'main';
+    this._render();
+  },
+
+  _renderSubscription() {
+    const entitled = (typeof Paywall !== 'undefined') && Paywall.isEntitled();
+    const status = entitled
+      ? '<div style="background:rgba(80,200,120,0.12);border:1px solid rgba(80,200,120,0.4);border-radius:var(--radius-sm);padding:12px 14px;font-family:var(--font-mono);font-size:12px;line-height:1.5;">✓ <strong>Subscription active</strong> — all AI features are unlocked.</div>'
+      : '<div style="background:var(--accent-soft);border:1px solid var(--accent-dim);border-radius:var(--radius-sm);padding:12px 14px;font-family:var(--font-mono);font-size:12px;line-height:1.5;">AI study tools are part of the subscription. Subscribe to unlock note processing, questions, lectures, the tutor, and more.</div>';
+    Modal.open(
+      '<h2 style="font-family:var(--font-ui);font-size:20px;font-weight:800;margin-bottom:4px;">AI Subscription</h2>'
+      + '<p style="font-family:var(--font-mono);font-size:12px;color:var(--text-muted);margin-bottom:16px;">Billing is handled securely by Google Play.</p>'
+      + status
+      + '<div style="display:flex;flex-direction:column;gap:8px;margin-top:18px;">'
+      + (entitled
+          ? '<button class="btn-secondary" id="ai-sub-restore" style="justify-content:center;">Restore / refresh</button>'
+          : '<button class="btn-primary" id="ai-sub-subscribe" style="justify-content:center;padding:13px;font-size:15px;">Subscribe</button>'
+            + '<button class="btn-secondary" id="ai-sub-restore" style="justify-content:center;">Restore purchase</button>')
+      + '<button style="background:none;border:none;color:var(--text-muted);font-family:var(--font-mono);font-size:11px;cursor:pointer;margin-top:4px;" onclick="Modal.close()">Close</button>'
+      + '</div>'
+    );
+    requestAnimationFrame(() => {
+      document.getElementById('ai-sub-subscribe')?.addEventListener('click', () => { Modal.close(); Paywall.show('Subscribe to unlock the AI study tools.'); });
+      document.getElementById('ai-sub-restore')?.addEventListener('click', async () => { if (typeof Paywall !== 'undefined') { await Paywall.restore(); Modal.close(); } });
+    });
+  },
+
+  _render() {
+    const active = AIService.getActiveProviderKey();
+    const cfg    = AIService.getActiveConfig();
+
+    Modal.open(this._buildHTML(active, cfg));
+    // Use requestAnimationFrame to ensure DOM is painted before binding
+    requestAnimationFrame(() => {
+      this._bindEvents();
+    });
+  },
+
+  _buildHTML(active, cfg) {
+    const isOR = active === 'openrouter';
+
+    // When the site owner has deployed a server proxy with a key, AI already
+    // works for everyone with no setup. Make that explicit; a personal key is optional.
+    const proxyNote = AIService.isUsingProxy()
+      ? '<div style="background:rgba(80,200,120,0.12);border:1px solid rgba(80,200,120,0.4);border-radius:var(--radius-sm);padding:12px 14px;margin-bottom:16px;font-family:var(--font-mono);font-size:12px;line-height:1.5;">'
+        + '✓ <strong>AI is provided by this site</strong> — you can start studying right away, no key needed. '
+        + 'Setting your own key below is optional and will override the shared one for you only.'
+        + '</div>'
+      : '';
+
+    const providerIcons = { openrouter:'🔀', claude:'🧠', openai:'💬', gemini:'✨', custom:'🔧' };
+    const providers     = AIService.getProviderList();
+
+    const providerBtns = providers.map(p =>
+      '<button class="provider-btn ' + (p.id===active?'selected':'') + '" data-provider="' + p.id + '">'
+      + '<span class="provider-icon">' + (providerIcons[p.id]||'🤖') + '</span>'
+      + '<span class="provider-name">' + p.name + (p.id==='openrouter'?' ⭐':'') + '</span>'
+      + '</button>'
+    ).join('');
+
+    // Tab bar (only show for OpenRouter)
+    const tabBar = isOR
+      ? '<div class="ai-tab-bar">'
+        + '<button class="ai-tab ' + (this._tab==='main'?'active':'') + '" id="ai-tab-main">⚙ Setup</button>'
+        + '<button class="ai-tab ' + (this._tab==='functions'?'active':'') + '" id="ai-tab-functions">🔀 Model Profiles</button>'
+        + '</div>'
+      : '';
+
+    return '<h2 style="font-family:var(--font-ui);font-size:20px;font-weight:800;margin-bottom:4px;">AI Configuration</h2>'
+      + '<p style="font-family:var(--font-mono);font-size:12px;color:var(--text-muted);margin-bottom:20px;">Keys stored only in your browser. Never sent anywhere except the AI provider.</p>'
+      + proxyNote
+      + '<label class="config-label" style="margin-bottom:10px;">Provider</label>'
+      + '<div class="provider-grid">' + providerBtns + '</div>'
+      + tabBar
+      + '<div id="ai-modal-body" style="margin-top:16px;"></div>'
+      + '<div style="display:flex;gap:10px;margin-top:20px;">'
+      + '<button class="btn-primary" id="ai-save-btn">Save</button>'
+      + '<button class="btn-secondary" onclick="Modal.close()">Cancel</button>'
+      + '</div>';
+  },
+
+  _renderBody(providerId) {
+    const isOR = providerId === 'openrouter';
+    if (isOR && this._tab === 'functions') {
+      this._renderFunctionTab();
+    } else {
+      this._renderMainTab(providerId);
+    }
+  },
+
+  _renderMainTab(providerId) {
+    const p   = AIService._providers[providerId];
+    const cfg = AIService._config[providerId] || {};
+    const isOR= providerId === 'openrouter';
+
+    let html = '';
+
+    // OpenRouter: show "paste key → works" hero section
+    if (isOR) {
+      html += '<div style="background:var(--accent-soft);border:1px solid var(--accent-dim);border-radius:var(--radius-md);padding:16px 20px;margin-bottom:20px;">'
+        + '<div style="font-family:var(--font-ui);font-size:13px;font-weight:700;color:var(--accent);margin-bottom:8px;">🚀 Recommended — One key, 300+ models</div>'
+        + '<ol style="font-family:var(--font-body);font-size:13px;color:var(--text-secondary);line-height:1.8;padding-left:20px;margin:0;">'
+        + '<li>Go to <a href="https://openrouter.ai/keys" target="_blank" style="color:var(--accent);">openrouter.ai/keys</a> → Create key</li>'
+        + '<li>Paste it below → click Save</li>'
+        + '<li>Everything works immediately with smart defaults</li>'
+        + '</ol>'
+        + '</div>';
+    }
+
+    // API key field — the saved key is NEVER written into the DOM (a screenshot
+    // or inspector would otherwise leak it, and it is recoverable from a password
+    // field). When a key exists the field starts blank with a "saved" hint;
+    // leaving it blank on Save keeps the stored key, typing a new one replaces it.
+    const hasSavedKey = !!(cfg.key);
+    html += '<div class="config-row" style="margin-bottom:16px;">'
+      + '<label class="config-label">API Key <a href="' + (p.docsUrl||'#') + '" target="_blank" rel="noopener" style="float:right;color:var(--accent);font-family:var(--font-mono);font-size:11px;">Get key →</a></label>'
+      + '<input type="password" id="ai-key-input" class="config-input" autocomplete="off" autocapitalize="off" autocorrect="off" spellcheck="false"'
+      + ' placeholder="' + (hasSavedKey ? '•••••••••• saved — leave blank to keep' : (p.keyPlaceholder||'api-key')) + '"'
+      + ' value="" style="font-size:14px;padding:12px 14px;"/>'
+      + (hasSavedKey ? '<p style="font-family:var(--font-mono);font-size:10.5px;color:var(--green);margin-top:6px;">✓ A key is saved on this device. Type a new one only to replace it.</p>' : '')
+      + '</div>';
+
+    // OpenRouter: preset picker + default model display
+    if (isOR) {
+      const presets = p.presets || {};
+      html += '<div class="config-row" style="margin-bottom:16px;">'
+        + '<label class="config-label">Preset</label>'
+        + '<div class="or-preset-grid">'
+        + Object.entries(presets).map(([key, preset]) =>
+            '<button class="or-preset-btn" data-preset="' + key + '">'
+            + '<div class="or-preset-label">' + preset.label + '</div>'
+            + '<div class="or-preset-desc">' + preset.desc + '</div>'
+            + '</button>'
+          ).join('')
+        + '</div>'
+        + '<p style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);margin-top:8px;">Presets auto-assign models per function. Customise in "Model Profiles" tab.</p>'
+        + '</div>';
+
+      // Show which models are currently active
+      const fnLabels = AIService._functionLabels;
+      const activeModels = Object.entries(fnLabels).map(([fn, info]) => {
+        const model = (cfg.functionModels?.[fn]) || (p.defaults?.[fn]) || '—';
+        return '<div style="display:flex;justify-content:space-between;padding:5px 0;border-bottom:1px solid var(--border-soft);">'
+          + '<span style="font-family:var(--font-ui);font-size:12px;color:var(--text-secondary);">' + info.label + '</span>'
+          + '<span style="font-family:var(--font-mono);font-size:11px;color:var(--accent);">' + model.split('/').pop() + '</span>'
+          + '</div>';
+      }).join('');
+
+      html += '<div style="background:var(--bg-raised);border:1px solid var(--border);border-radius:var(--radius-md);padding:14px 16px;">'
+        + '<div style="font-family:var(--font-ui);font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:0.08em;color:var(--text-muted);margin-bottom:10px;">Active Models</div>'
+        + activeModels
+        + '</div>';
+
+    } else {
+      // Direct providers: model selector
+      if (p.models?.length) {
+        html += '<div class="config-row" style="margin-bottom:16px;">'
+          + '<label class="config-label">Model</label>'
+          + '<select id="ai-model-select" class="config-select">'
+          + p.models.map(m=>'<option value="'+m+'" '+(m===(cfg.model||p.defaultModel)?'selected':'')+'>'+m+'</option>').join('')
+          + '</select></div>';
+      }
+      if (providerId === 'custom') {
+        html += '<div class="config-row" style="margin-bottom:16px;">'
+          + '<label class="config-label">Model Name</label>'
+          + '<input type="text" id="ai-model-input" class="config-input" placeholder="llama3, mistral…" value="'+(cfg.model||'')+'"/>'
+          + '</div>'
+          + '<div class="config-row" style="margin-bottom:16px;">'
+          + '<label class="config-label">Endpoint URL</label>'
+          + '<input type="text" id="ai-endpoint-input" class="config-input" placeholder="http://localhost:11434/v1/chat/completions" value="'+(cfg.customEndpoint||'')+'"/>'
+          + '</div>';
+      }
+    }
+
+    document.getElementById('ai-modal-body').innerHTML = html;
+
+    // Wire preset buttons
+    document.querySelectorAll('.or-preset-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('.or-preset-btn').forEach(b=>b.classList.remove('active'));
+        btn.classList.add('active');
+        AIService.applyPreset(btn.dataset.preset);
+        // Re-render to show updated active models
+        this._renderBody(providerId);
+      });
+    });
+  },
+
+  _renderFunctionTab() {
+    const p      = AIService._providers.openrouter;
+    const cfg    = AIService._config.openrouter || {};
+    const labels = AIService._functionLabels;
+
+    // Popular OpenRouter models for the dropdown
+    const popularModels = [
+      // ── Google Gemini 3.x (current stable) ──
+      'google/gemini-3.5-flash',              // Fast, multimodal, vision
+      'google/gemini-3.1-flash-lite',         // Fastest & cheapest, vision
+      'google/gemini-3.1-pro-preview',                // Flagship: complex reasoning & coding (preview)
+      // ── Anthropic Claude (current) ──
+      'anthropic/claude-haiku-4.5',           // Fastest Claude, great for chat ($1/$5)
+      'anthropic/claude-sonnet-5',          // Best writing & reasoning ($2/$10 intro)
+      'anthropic/claude-opus-4-8',            // Most capable Claude ($5/$25)
+      // ── OpenAI ──
+      'openai/gpt-5-mini',                   // Reliable JSON, cheap grading ($0.25/$2)
+      'openai/gpt-5.4',
+      // ── Meta Llama (open source) ──
+      'meta-llama/llama-3.1-70b-instruct',
+      'meta-llama/llama-3.1-8b-instruct',
+      // ── Mistral ──
+      'mistralai/mistral-7b-instruct',
+      'mistralai/mixtral-8x7b-instruct',
+      // ── DeepSeek ──
+      'deepseek/deepseek-chat',
+    ];
+
+    const rows = Object.entries(labels).map(([fn, info]) => {
+      const current = cfg.functionModels?.[fn] || p.defaults?.[fn] || 'google/gemini-3.5-flash';
+      const options = [current, ...popularModels.filter(m=>m!==current)]
+        .map(m => '<option value="'+m+'" '+(m===current?'selected':'')+'>'+m+'</option>').join('');
+      return '<div class="fn-model-row">'
+        + '<div class="fn-model-info"><div class="fn-model-label">'+info.label+'</div><div class="fn-model-desc">'+info.desc+'</div></div>'
+        + '<select class="config-select fn-model-select" data-fn="'+fn+'" style="min-width:180px;font-size:12px;padding:7px 10px;">'
+        + options
+        + '<option value="_custom">Custom model ID…</option>'
+        + '</select>'
+        + '</div>';
+    }).join('');
+
+    document.getElementById('ai-modal-body').innerHTML =
+      '<p style="font-family:var(--font-body);font-size:13px;color:var(--text-secondary);margin-bottom:16px;line-height:1.6;">Choose which model handles each function. Smaller models are faster and cheaper. Larger models produce better results for complex tasks.</p>'
+      + '<div style="display:flex;flex-direction:column;gap:8px;">' + rows + '</div>'
+      + '<p style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);margin-top:14px;">Find all models at <a href="https://openrouter.ai/models" target="_blank" style="color:var(--accent);">openrouter.ai/models</a>. Paste any model ID into the dropdown as a custom option.</p>';
+
+    // Wire custom model input
+    document.querySelectorAll('.fn-model-select').forEach(sel => {
+      sel.addEventListener('change', () => {
+        if (sel.value === '_custom') {
+          Modal.open(
+            '<h2 style="font-family:var(--font-ui);font-size:17px;font-weight:800;margin-bottom:12px;">Custom Model ID</h2>'
+            + '<p style="font-family:var(--font-mono);font-size:12px;color:var(--text-muted);margin-bottom:14px;">Find model IDs at openrouter.ai/models</p>'
+            + '<input type="text" id="custom-model-id-input" class="config-input" placeholder="e.g. meta-llama/llama-3.1-70b-instruct" style="font-size:14px;padding:12px 14px;margin-bottom:16px;"/>'
+            + '<div style="display:flex;gap:8px;">'
+            + '<button class="btn-primary" id="custom-model-confirm" style="flex:1;justify-content:center;">Set Model</button>'
+            + '<button class="btn-secondary" onclick="Modal.close()">Cancel</button>'
+            + '</div>'
+          );
+          setTimeout(() => {
+            const inp = document.getElementById('custom-model-id-input');
+            inp?.focus();
+            document.getElementById('custom-model-confirm')?.addEventListener('click', () => {
+              const id = inp?.value?.trim();
+              if (!id) return;
+              const opt = document.createElement('option');
+              opt.value = id; opt.textContent = id; opt.selected = true;
+              sel.insertBefore(opt, sel.firstChild);
+              sel.value = id;
+              Modal.close();
+            });
+          }, 0);
+        }
+        AIService.saveFunctionModel(sel.dataset.fn, sel.value);
+      });
+    });
+  },
+
+  _bindEvents() {
+    // Provider buttons
+    document.querySelectorAll('.provider-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('.provider-btn').forEach(b=>b.classList.remove('selected'));
+        btn.classList.add('selected');
+        const pid = btn.dataset.provider;
+        // Show/hide tab bar
+        const tabBar = document.querySelector('.ai-tab-bar');
+        if (tabBar) tabBar.style.display = pid==='openrouter' ? 'flex' : 'none';
+        this._tab = 'main';
+        document.querySelectorAll('.ai-tab').forEach((t,i)=>t.classList.toggle('active',i===0));
+        this._renderBody(pid);
+      });
+    });
+
+    // Tabs (OpenRouter only)
+    document.getElementById('ai-tab-main')?.addEventListener('click', () => {
+      this._tab='main';
+      document.getElementById('ai-tab-main').classList.add('active');
+      document.getElementById('ai-tab-functions').classList.remove('active');
+      this._renderBody('openrouter');
+    });
+    document.getElementById('ai-tab-functions')?.addEventListener('click', () => {
+      this._tab='functions';
+      document.getElementById('ai-tab-functions').classList.add('active');
+      document.getElementById('ai-tab-main').classList.remove('active');
+      this._renderBody('openrouter');
+    });
+
+    // Save
+    document.getElementById('ai-save-btn')?.addEventListener('click', () => this._save());
+
+    // Render initial body - wait for ai-modal-body to be in DOM
+    const bodyEl = document.getElementById('ai-modal-body');
+    if (bodyEl) {
+      this._renderBody(AIService.getActiveProviderKey());
+    } else {
+      setTimeout(() => this._renderBody(AIService.getActiveProviderKey()), 50);
+    }
+  },
+
+  _save() {
+    const provider = document.querySelector('.provider-btn.selected')?.dataset.provider || AIService.getActiveProviderKey();
+    const existing = AIService._config[provider] || {};
+    const keyInput = document.getElementById('ai-key-input');
+    const typed    = keyInput?.value?.trim() || '';
+    // Field is intentionally blank when a key is already saved; keep the stored
+    // key unless the user typed a replacement (the real key is never in the DOM).
+    const key = typed || existing.key || '';
+
+    if (!key && provider !== 'custom') {
+      Toast.error('Please enter your API key in the field above.');
+      keyInput?.focus();
+      return;
+    }
+
+    const model = provider==='custom'
+      ? (document.getElementById('ai-model-input')?.value?.trim()||'')
+      : (document.getElementById('ai-model-select')?.value||'');
+    const endpoint = document.getElementById('ai-endpoint-input')?.value?.trim()||'';
+    const functionModels = existing.functionModels || {};
+
+    AIService.saveConfig(provider, key, model, endpoint, functionModels);
+
+    Modal.close();
+    document.getElementById('api-key-banner')?.remove();
+    document.getElementById('main-content').style.paddingTop='';
+    Toast.success((provider==='openrouter'?'OpenRouter':'AI') + ' configured! You\'re ready to study.');
+  },
+};

--- a/knowledgenode/www/js/ui/BlankRecall.js
+++ b/knowledgenode/www/js/ui/BlankRecall.js
@@ -1,0 +1,510 @@
+/**
+ * BlankRecall.js
+ * The blank-sheet recall canvas — shown BEFORE the recall/apply steps in Guided Flow.
+ * Student writes everything they remember from memory.
+ * Then their attempt is shown alongside the actual notes for self-marking.
+ */
+
+const BlankRecall = {
+  _node:   null,
+  _onPass: null,
+  _mode:   'recall', // 'recall' | 'apply'
+
+  /**
+   * @param {KnowledgeNode} node
+   * @param {'recall'|'apply'} mode
+   * @param {function} onPass  — called when student proceeds to see questions
+   */
+  show(node, mode, onPass) {
+    this._node   = node;
+    this._mode   = mode;
+    this._onPass = onPass;
+    this._renderCanvas();
+  },
+
+  _renderCanvas() {
+    const node    = this._node;
+    const isApply = this._mode === 'application';
+    const container = document.getElementById('step-content');
+    if (!container) return;
+
+    const prompt = isApply
+      ? `Explain how you would apply the concepts from <strong>${this._esc(node.title)}</strong> to a real problem. Write the key steps, formula, and any constraints.`
+      : `Without looking at anything, write down everything you remember about <strong>${this._esc(node.title)}</strong>. Definitions, formulas, steps, exceptions — everything.`;
+
+    const placeholder = isApply
+      ? 'I would start by identifying… then apply the formula… the key constraint is…'
+      : 'From memory: the key concept is… the formula is… the steps are… the exceptions are…';
+
+    container.innerHTML = `
+      <div class="br-wrapper">
+        <div class="br-header">
+          <div class="br-badge">${isApply ? 'Application' : 'Blank-Sheet Recall'} — Write from Memory</div>
+          <h3 class="br-title">${isApply ? 'How would you apply this?' : 'What do you remember?'}</h3>
+          <p class="br-subtitle">${prompt}</p>
+        </div>
+
+        <!-- Timer display -->
+        <div class="br-timer-row">
+          <div class="br-timer" id="br-timer">
+            <span id="br-timer-val">0:00</span>
+          </div>
+          <p class="br-struggle-tip">
+            ⏱ If you get stuck, <strong>wait 30 seconds before giving up</strong>. That struggle is where memory is built.
+          </p>
+        </div>
+
+        <!-- Canvas -->
+        <textarea id="br-canvas" class="br-canvas"
+          placeholder="${placeholder}"
+          autocorrect="on" autocapitalize="sentences" spellcheck="true"></textarea>
+
+        <!-- Word counter -->
+        <div class="br-meta-row">
+          <span class="br-word-count" id="br-word-count">0 words</span>
+          <span class="br-hint">Write freely — spelling doesn't matter</span>
+        </div>
+
+        <!-- Actions -->
+        <div class="br-actions">
+          <button class="btn-primary" id="br-reveal-btn">
+            ✓ I'm done — show me how I did
+          </button>
+          <button class="btn-secondary" id="br-skip-btn">
+            Skip blank-sheet step
+          </button>
+        </div>
+      </div>
+    `;
+
+    // Start timer
+    this._startTimer();
+
+    // Word counter
+    document.getElementById('br-canvas').addEventListener('input', () => {
+      const words = document.getElementById('br-canvas').value.trim().split(/\s+/).filter(Boolean).length;
+      document.getElementById('br-word-count').textContent = `${words} word${words !== 1 ? 's' : ''}`;
+    });
+
+    document.getElementById('br-reveal-btn').addEventListener('click', () => {
+      this._stopTimer();
+      const canvas = document.getElementById('br-canvas');
+      const attempt = (canvas?.value || '').trim();
+      if (!attempt) {
+        Toast.info("Write something first — even a few words. The effort is what counts.");
+        canvas?.focus();
+        return;
+      }
+      try {
+        this._showComparison(attempt);
+      } catch (e) {
+        console.error('[BlankRecall] comparison failed:', e);
+        // Never strand the user — show a minimal comparison, then let them continue.
+        const container = document.getElementById('step-content');
+        if (container) {
+          container.innerHTML =
+            '<div class="br-wrapper"><div class="br-header"><div class="br-badge">Recall Check</div>'
+            + '<h3 class="br-title">Nice work writing that out</h3></div>'
+            + '<div class="br-compare-col"><div class="br-col-label">✍ Your attempt</div>'
+            + '<div class="br-col-body">' + this._esc(attempt) + '</div></div>'
+            + '<div class="br-selfmark"><div class="br-selfmark-title">How did your recall feel?</div>'
+            + '<div class="br-selfmark-btns">'
+            + '<button class="br-mark-btn red" id="brm-low">🔴 Forgot most</button>'
+            + '<button class="br-mark-btn amber" id="brm-mid">🟡 Some</button>'
+            + '<button class="br-mark-btn green" id="brm-high">🟢 Well</button>'
+            + '</div></div></div>';
+          ['brm-low','brm-mid','brm-high'].forEach(id => {
+            document.getElementById(id)?.addEventListener('click', () => this._onPass?.());
+          });
+        } else {
+          this._onPass?.();
+        }
+      }
+    });
+
+    document.getElementById('br-skip-btn').addEventListener('click', () => {
+      this._stopTimer();
+      this._onPass?.();
+    });
+
+    document.getElementById('br-canvas').focus();
+  },
+
+  _showComparison(attempt) {
+    const node      = this._node;
+    const container = document.getElementById('step-content');
+    const isApply   = this._mode === 'application';
+
+    // Score attempt heuristically (keyword matching). Be defensive about node
+    // shape — newer block-based nodes may not have these legacy arrays, and a
+    // formula/definition may be missing fields. Never let this throw.
+    const keyTerms = [
+      ...(Array.isArray(node.definitions) ? node.definitions.map(d => d && (d.term || d.name)) : []),
+      ...(Array.isArray(node.formulas) ? node.formulas.map(f => {
+            const exp = f && (f.expression || f.formula || f.name);
+            return (typeof exp === 'string' && exp.length) ? exp.split(/\s+/)[0] : null;
+          }) : []),
+      ...(Array.isArray(node.procedures) ? node.procedures.slice(0, 3).map(p => (typeof p === 'string' ? p : (p && (p.title || p.name)))) : []),
+      // Fall back to block content for block-based nodes
+      ...(Array.isArray(node.blocks) ? node.blocks.flatMap(b => {
+            if (!b) return [];
+            if (b.term) return [b.term];
+            if (b.title) return [b.title];
+            return [];
+          }) : []),
+    ].filter(t => typeof t === 'string' && t.trim().length);
+
+    const attemptLower = attempt.toLowerCase();
+    const hits    = keyTerms.filter(t => attemptLower.includes(t.toLowerCase().slice(0,5))).length;
+    const total   = Math.max(1, keyTerms.length);
+    const pct     = Math.min(100, Math.round((hits / total) * 100));
+    const color   = pct >= 70 ? 'var(--green)' : pct >= 40 ? 'var(--accent)' : 'var(--red)';
+    const label   = pct >= 70 ? 'Strong recall' : pct >= 40 ? 'Partial recall — good effort' : 'Low recall — that\'s what studying is for';
+
+    container.innerHTML = `
+      <div class="br-wrapper">
+        <div class="br-header">
+          <div class="br-badge">Recall Check</div>
+          <h3 class="br-title">Your attempt vs. your notes</h3>
+        </div>
+
+        <!-- Score -->
+        <div class="br-score-row">
+          <div class="br-score-circle" style="border-color:${color};">
+            <span style="color:${color};font-size:22px;font-weight:700;">${pct}%</span>
+            <span style="font-size:10px;color:var(--text-muted);">coverage</span>
+          </div>
+          <div>
+            <div style="font-family:var(--font-ui);font-size:14px;font-weight:700;color:${color};margin-bottom:4px;">${label}</div>
+            <div style="font-family:var(--font-mono);font-size:12px;color:var(--text-muted);">
+              Matched ${hits} of ${total} key concepts
+            </div>
+          </div>
+        </div>
+
+        <!-- Side by side -->
+        <div class="br-compare">
+          <div class="br-compare-col">
+            <div class="br-col-label">✍ Your attempt</div>
+            <div class="br-col-body">${this._esc(attempt)}</div>
+          </div>
+          <div class="br-compare-col">
+            <div class="br-col-label">📋 Key concepts from notes</div>
+            <div class="br-col-body">
+              ${node.definitions?.length ? `
+                <div class="br-ref-section"><strong>Definitions:</strong>
+                  ${node.definitions.slice(0,3).map(d => `<div class="br-ref-item"><em>${this._esc(d.term)}</em> — ${this._esc(d.description)}</div>`).join('')}
+                </div>` : ''}
+              ${node.formulas?.length ? `
+                <div class="br-ref-section"><strong>Formulas:</strong>
+                  ${node.formulas.slice(0,2).map(f => `<div class="br-ref-item"><code>${this._esc(f.expression)}</code></div>`).join('')}
+                </div>` : ''}
+              ${node.procedures?.length ? `
+                <div class="br-ref-section"><strong>Steps:</strong>
+                  ${node.procedures.slice(0,3).map((s,i) => {
+                    const txt = (typeof s === 'string') ? s : (s && (s.title || s.name) ? (s.title || s.name) : '');
+                    return txt ? `<div class="br-ref-item">${i+1}. ${this._esc(txt)}</div>` : '';
+                  }).join('')}
+                </div>` : ''}
+            </div>
+          </div>
+        </div>
+
+        <!-- Self-mark -->
+        <div class="br-selfmark">
+          <div class="br-selfmark-title">Mark your own recall:</div>
+          <div class="br-selfmark-btns">
+            <button class="br-mark-btn red"    id="brm-low">🔴 Forgot most of it</button>
+            <button class="br-mark-btn amber"  id="brm-mid">🟡 Remembered some</button>
+            <button class="br-mark-btn green"  id="brm-high">🟢 Remembered well</button>
+          </div>
+        </div>
+      </div>
+    `;
+
+    ['brm-low','brm-mid','brm-high'].forEach(id => {
+      document.getElementById(id)?.addEventListener('click', () => {
+        const rating = id === 'brm-low' ? 1 : id === 'brm-mid' ? 2 : 3;
+        // Save recall rating to node
+        this._node.lastRecallRating = { rating, attemptPct: pct, at: Date.now() };
+        nodeStore.save(this._node);
+        this._onPass?.();
+      });
+    });
+  },
+
+  // ─── Timer ────────────────────────────────────────────
+
+  _timerInterval: null,
+  _elapsed: 0,
+
+  _startTimer() {
+    this._elapsed = 0;
+    this._stopTimer();
+    this._timerInterval = setInterval(() => {
+      this._elapsed++;
+      const el = document.getElementById('br-timer-val');
+      if (!el) { this._stopTimer(); return; }
+      const m = Math.floor(this._elapsed / 60);
+      const s = this._elapsed % 60;
+      el.textContent = `${m}:${s.toString().padStart(2,'0')}`;
+    }, 1000);
+  },
+
+  _stopTimer() {
+    clearInterval(this._timerInterval);
+    this._timerInterval = null;
+  },
+
+  // ─── Teach It (Feynman) mode ──────────────────────────
+
+  showTeachIt(node, onPass) {
+    this._node   = node;
+    this._onPass = onPass;
+    this._mode   = 'recall';
+    const container = document.getElementById('step-content');
+    if (!container) return;
+
+    container.innerHTML = `
+      <div class="br-wrapper">
+        <div class="br-header">
+          <div class="br-badge" style="background:rgba(240,165,0,0.15);color:var(--accent-light);">🎓 Teach It — Feynman Technique</div>
+          <h3 class="br-title">Explain it like you're teaching a beginner</h3>
+          <p class="br-subtitle">Imagine someone who knows <strong>nothing</strong> about <strong>${this._esc(node.title)}</strong> is sitting next to you.
+          Explain everything — definitions, how it works, formulas, examples, common mistakes. Write until you'd run out of things to say.</p>
+        </div>
+
+        <div class="br-timer-row">
+          <div class="br-timer"><span id="br-timer-val">0:00</span></div>
+          <p class="br-struggle-tip">⏱ The gaps you hit while explaining are exactly what to study next.</p>
+        </div>
+
+        <div style="position:relative;">
+          <textarea id="br-canvas" class="br-canvas"
+            placeholder="Start with the basics — what is this topic? Why does it matter? Then explain how it works, step by step, as if to someone who has never heard of it… (or tap 🎤 to talk it through)"
+            style="padding-right:48px;"
+            autocorrect="on" autocapitalize="sentences" spellcheck="true"></textarea>
+          <button id="br-mic-btn" title="Speak your explanation" style="position:absolute;right:10px;top:10px;background:none;border:1px solid var(--border);border-radius:8px;padding:4px 8px;font-size:18px;cursor:pointer;color:var(--text-secondary);">🎤</button>
+        </div>
+
+        <div class="br-meta-row">
+          <span class="br-word-count" id="br-word-count">0 words</span>
+          <span class="br-hint">Don't hold back — quantity reveals gaps</span>
+        </div>
+
+        <div class="br-actions">
+          <button class="btn-primary" id="br-reveal-btn" ${!AIService.hasApiKey() ? 'disabled title="Configure AI first"' : ''}>
+            🎓 Evaluate my explanation
+          </button>
+          <button class="btn-secondary" id="br-skip-btn">Skip</button>
+        </div>
+        ${!AIService.hasApiKey() ? '<p style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);text-align:center;margin-top:8px;">Configure your AI key in Settings to get AI evaluation. Or use Blank Recall instead.</p>' : ''}
+      </div>
+    `;
+
+    this._startTimer();
+    const canvas = document.getElementById('br-canvas');
+    const wc = document.getElementById('br-word-count');
+    canvas?.addEventListener('input', () => {
+      const w = canvas.value.trim().split(/\s+/).filter(Boolean).length;
+      wc.textContent = w + ' word' + (w === 1 ? '' : 's');
+    });
+
+    // Voice input — speaking your explanation aloud is the natural way to "teach it".
+    // The Android WebView can't do Web Speech, so we use the native KnowledgeNodeSTT
+    // bridge when present and only fall back to the browser API for desktop testing.
+    document.getElementById('br-mic-btn')?.addEventListener('click', () => {
+      const btn = document.getElementById('br-mic-btn');
+      const ta  = document.getElementById('br-canvas');
+      if (!btn || !ta) return;
+
+      const append = (text) => {
+        if (!text) return;
+        ta.value = (ta.value ? ta.value.trimEnd() + ' ' : '') + text.trim();
+        ta.dispatchEvent(new Event('input'));
+      };
+      const setIdle  = () => { btn.textContent = '🎤'; btn.style.borderColor = 'var(--border)'; btn.dataset.listening = ''; };
+      const setLive  = () => { btn.textContent = '🔴'; btn.style.borderColor = 'var(--red)'; btn.dataset.listening = '1'; };
+      const friendly = (reason) => ({
+        permission:      'Microphone permission is off — enable it for KnowledgeNode in your phone settings.',
+        no_match:        'Didn\'t catch that — tap 🎤 and try again.',
+        speech_timeout:  'Didn\'t hear anything — tap 🎤 and speak.',
+        network:         'Voice typing needs an internet connection.',
+        network_timeout: 'Voice typing needs an internet connection.',
+        busy:            'Still finishing the last bit — give it a second.',
+        unavailable:     'Speech recognition isn\'t available on this device.',
+      }[reason] || 'Voice input stopped.');
+
+      // ── Native bridge (Android) ──────────────────────────────────────────────
+      const STT = window.KnowledgeNodeSTT;
+      if (STT && typeof STT.start === 'function') {
+        // Tapping again while live = stop
+        if (btn.dataset.listening) { try { STT.stop(); } catch {} return; }
+
+        if (typeof STT.isAvailable === 'function' && !STT.isAvailable()) {
+          if (typeof STT.hasPermission === 'function' && !STT.hasPermission()) {
+            Toast.info(friendly('permission'));
+          } else {
+            Toast.info(friendly('unavailable'));
+          }
+          return;
+        }
+
+        // Bind listeners once per session, then clean them up on end
+        const onResult = e => append(e.detail);
+        const onError  = e => { if (e.detail && e.detail !== 'no_match') Toast.info(friendly(e.detail)); };
+        const onEnd    = () => {
+          setIdle();
+          window.removeEventListener('knstt:result', onResult);
+          window.removeEventListener('knstt:error',  onError);
+          window.removeEventListener('knstt:end',    onEnd);
+        };
+        window.addEventListener('knstt:result', onResult);
+        window.addEventListener('knstt:error',  onError);
+        window.addEventListener('knstt:end',    onEnd);
+
+        setLive();
+        try { STT.start('en-ZA'); }
+        catch (err) { onEnd(); Toast.info(friendly('unavailable')); }
+        return;
+      }
+
+      // ── Browser fallback (desktop testing only) ──────────────────────────────
+      const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+      if (!SpeechRecognition) { Toast.info('Voice typing isn\'t supported here — use your keyboard\'s 🎤 instead.'); return; }
+      if (btn.dataset.listening) { setIdle(); return; }
+      const sr = new SpeechRecognition();
+      sr.lang = 'en-ZA';
+      sr.continuous = true;
+      sr.interimResults = false;
+      setLive();
+      sr.onresult = e => {
+        let text = '';
+        for (let i = e.resultIndex; i < e.results.length; i++) {
+          if (e.results[i].isFinal) text += e.results[i][0].transcript + ' ';
+        }
+        append(text);
+      };
+      sr.onerror = () => setIdle();
+      sr.onend   = () => setIdle();
+      sr.start();
+    });
+
+    document.getElementById('br-reveal-btn')?.addEventListener('click', async () => {
+      const attempt = canvas?.value.trim() || '';
+      if (attempt.split(/\s+/).filter(Boolean).length < 10) {
+        Toast.info('Write a bit more before evaluating — even a short explanation helps.');
+        return;
+      }
+      this._stopTimer();
+      await this._showTeachFeedback(attempt);
+    });
+
+    document.getElementById('br-skip-btn')?.addEventListener('click', () => {
+      this._stopTimer();
+      this._onPass?.();
+    });
+  },
+
+  async _showTeachFeedback(attempt) {
+    const node      = this._node;
+    const container = document.getElementById('step-content');
+    if (!container) return;
+
+    // Loading state
+    container.innerHTML = `
+      <div class="br-wrapper" style="text-align:center;padding:40px 20px;">
+        <div style="font-size:32px;margin-bottom:16px;">🎓</div>
+        <div style="font-family:var(--font-ui);font-weight:700;font-size:16px;margin-bottom:8px;">Evaluating your explanation…</div>
+        <div style="font-family:var(--font-mono);font-size:12px;color:var(--text-muted);">Checking what you covered, what you missed, and what to work on</div>
+      </div>`;
+
+    let result;
+    try {
+      const ctx = LearnerContext.forGuidedStudy(node).slice(0, 3000);
+      const prompt = ctx + '\n\nA student was asked to teach this topic to a beginner. Evaluate their explanation.\n\n'
+        + 'STUDENT\'S EXPLANATION:\n"' + attempt + '"\n\n'
+        + 'Evaluate based on the source material above. Be encouraging but honest.\n'
+        + 'Output ONLY valid JSON (no markdown):\n'
+        + '{"score":75,"covered":["specific thing they explained well","another"],"missing":["key concept not mentioned","another"],"incorrect":["anything factually wrong — empty array if nothing wrong"],"encouragement":"one warm sentence acknowledging their effort and the most impressive part of their explanation"}';
+
+      const raw = await AIService._callWithFunction('noteProcessing', [{ role: 'user', content: prompt }], 600);
+      const clean = raw.replace(/```json|```/g, '').trim();
+      result = JSON.parse(clean);
+    } catch(e) {
+      console.warn('[TeachIt] AI eval failed:', e);
+      result = null;
+    }
+
+    if (!result) {
+      // AI unavailable — show self-check comparison
+      this._showComparison(attempt);
+      return;
+    }
+
+    const score  = Math.max(0, Math.min(100, result.score || 0));
+    const color  = score >= 75 ? 'var(--green)' : score >= 45 ? 'var(--accent)' : 'var(--red)';
+    const label  = score >= 75 ? 'Strong teaching — you understand this well' : score >= 45 ? 'Solid foundation — a few gaps to fill' : 'Good start — this is exactly what practice is for';
+
+    const listItems = arr => (arr || []).map(t => `<li style="margin-bottom:6px;">${this._esc(t)}</li>`).join('');
+
+    container.innerHTML = `
+      <div class="br-wrapper">
+        <div class="br-header">
+          <div class="br-badge" style="background:rgba(240,165,0,0.15);color:var(--accent-light);">🎓 Teaching Feedback</div>
+          <h3 class="br-title">How well did you explain it?</h3>
+        </div>
+
+        <div class="br-score-row">
+          <div class="br-score-circle" style="border-color:${color};">
+            <span style="color:${color};font-size:22px;font-weight:700;">${score}%</span>
+            <span style="font-size:10px;color:var(--text-muted);">coverage</span>
+          </div>
+          <div>
+            <div style="font-family:var(--font-ui);font-size:14px;font-weight:700;color:${color};margin-bottom:4px;">${label}</div>
+            ${result.encouragement ? `<div style="font-family:var(--font-body);font-size:13px;color:var(--text-secondary);font-style:italic;">${this._esc(result.encouragement)}</div>` : ''}
+          </div>
+        </div>
+
+        ${result.covered?.length ? `
+        <div style="margin-bottom:14px;">
+          <div style="font-family:var(--font-ui);font-weight:700;font-size:13px;color:var(--green);margin-bottom:6px;">✅ What you explained well</div>
+          <ul style="font-family:var(--font-body);font-size:14px;color:var(--text-primary);padding-left:18px;margin:0;">${listItems(result.covered)}</ul>
+        </div>` : ''}
+
+        ${result.missing?.length ? `
+        <div style="margin-bottom:14px;">
+          <div style="font-family:var(--font-ui);font-weight:700;font-size:13px;color:var(--accent-light);margin-bottom:6px;">⚠️ Key concepts you missed</div>
+          <ul style="font-family:var(--font-body);font-size:14px;color:var(--text-primary);padding-left:18px;margin:0;">${listItems(result.missing)}</ul>
+          <div style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);margin-top:6px;">Study these before your next session.</div>
+        </div>` : ''}
+
+        ${result.incorrect?.length ? `
+        <div style="margin-bottom:14px;">
+          <div style="font-family:var(--font-ui);font-weight:700;font-size:13px;color:var(--red);margin-bottom:6px;">❌ Needs correction</div>
+          <ul style="font-family:var(--font-body);font-size:14px;color:var(--text-primary);padding-left:18px;margin:0;">${listItems(result.incorrect)}</ul>
+        </div>` : ''}
+
+        <div class="br-selfmark">
+          <div class="br-selfmark-title">How did that feel?</div>
+          <div class="br-selfmark-btns">
+            <button class="br-mark-btn red"   id="brm-low">😕 Lots of gaps</button>
+            <button class="br-mark-btn amber" id="brm-mid">🙂 Mostly there</button>
+            <button class="br-mark-btn green" id="brm-high">😎 Nailed it</button>
+          </div>
+        </div>
+      </div>
+    `;
+
+    ['brm-low','brm-mid','brm-high'].forEach(id => {
+      document.getElementById(id)?.addEventListener('click', () => {
+        const rating = id === 'brm-low' ? 1 : id === 'brm-mid' ? 2 : 3;
+        node.lastRecallRating = { rating, attemptPct: score, mode: 'teach', at: Date.now() };
+        nodeStore.save(node);
+        this._onPass?.();
+      });
+    });
+  },
+
+  _esc: s => String(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'),
+};

--- a/knowledgenode/www/js/ui/BlockEngine.js
+++ b/knowledgenode/www/js/ui/BlockEngine.js
@@ -1,0 +1,419 @@
+/**
+ * BlockEngine.js — The Adaptive Canvas core
+ *
+ * A node renders as an ordered list of blocks. Each block type has:
+ *   render(block, node) → HTML string
+ *   (optional) static behaviours wired via the global BlockEngine.* fns
+ *
+ * Block types:
+ *   prose, callout, definition, table, formula, procedure  (static/legacy)
+ *   code        — runnable SQL/JS sandbox (in-browser, sql.js for SQL)
+ *   calc        — interactive calculator (formula or progressive brackets)
+ *   webpreview  — live HTML/CSS/JS preview in a sandboxed iframe
+ *   quiz        — multiple-choice with feedback
+ *   match       — drag/tap matching game (kids)
+ *   diagram     — simple horizontal flow
+ *   flashcards  — quick self-test cards
+ *
+ * All execution is in-browser. The AI only chooses WHICH blocks to emit.
+ */
+const BlockEngine = {
+  _sqlPromise: null,          // memoised sql.js init
+  _state: {},                 // per-block transient runtime state
+
+  esc(s) {
+    return String(s ?? '').replace(/[&<>"]/g, c => ({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;' }[c]));
+  },
+
+  // prose/callout blocks carry AI-generated HTML built from the user's source,
+  // which could be a photographed/shared page — so a prompt-injection in the
+  // source must not become live markup. Run it through the allowlist Sanitizer;
+  // if that module isn't present, fail safe by escaping everything.
+  _safeHtml(html) {
+    if (html == null) return '';
+    return (typeof Sanitizer !== 'undefined') ? Sanitizer.clean(html) : this.esc(html);
+  },
+
+  /** Render an entire node's block list. */
+  renderNode(node) {
+    if (!node.blocks?.length) return '<p style="color:var(--text-muted);font-family:var(--font-mono);font-size:12px;">This node has no blocks yet. Use “＋ Add block” below.</p>';
+    return node.blocks.map(b => this.renderBlock(b, node)).join('');
+  },
+
+  /** Render a single block with its chrome (move/edit/delete controls). */
+  renderBlock(block, node) {
+    const r = this._renderers[block.type];
+    const inner = r ? r.call(this, block, node) : this._renderers.prose.call(this, { ...block, html: '⚠ Unknown block type: ' + block.type }, node);
+    return `<div class="kn-block" data-block-id="${block.id}" data-block-type="${block.type}">
+      <div class="kn-block-controls">
+        <button class="kn-bc" title="Move up"   onclick="BlockEngine.move('${node.id}','${block.id}',-1)">▲</button>
+        <button class="kn-bc" title="Move down" onclick="BlockEngine.move('${node.id}','${block.id}',1)">▼</button>
+        <button class="kn-bc" title="Delete"    onclick="BlockEngine.del('${node.id}','${block.id}')">✕</button>
+      </div>
+      ${inner}
+    </div>`;
+  },
+
+  _shell(kind, title, inner, accent) {
+    const ac = accent ? ` style="--blk-accent:${accent}"` : '';
+    return `<div class="kn-blk-inner"${ac}>
+      <div class="kn-blk-head"><span class="kn-blk-kind">${this.esc(kind)}</span>${title ? `<span class="kn-blk-title">${this.esc(title)}</span>` : ''}</div>
+      <div class="kn-blk-body">${inner}</div></div>`;
+  },
+
+  /* ════════════════════════════════════════════════════
+     RENDERERS
+  ════════════════════════════════════════════════════ */
+  _renderers: {
+    prose(b) {
+      return this._shell('text', b.title, `<div class="kn-prose">${this._safeHtml(b.html)}</div>`);
+    },
+    callout(b) {
+      const tone = b.tone === 'warn' ? 'var(--red)' : 'var(--accent)';
+      return this._shell(b.tone === 'warn' ? 'caution' : 'tip', b.title || 'Note',
+        `<div class="kn-callout" style="border-color:${tone}">${this._safeHtml(b.html)}</div>`);
+    },
+    definition(b) {
+      const items = (b.items || []).map(d => {
+        const corBtn = (typeof AICorrections !== 'undefined')
+          ? AICorrections.renderButton('definition', d.term + ': ' + d.description)
+          : '';
+        return `<div class="kn-def">
+          <div class="kn-def-term" style="display:flex;align-items:center;justify-content:space-between;gap:6px;">
+            <span>${this.esc(d.term)}</span>
+            ${corBtn}
+          </div>
+          ${d.examples ? `<div class="kn-def-ex">Examples: ${this.esc(d.examples)}</div>` : ''}
+          <div class="kn-def-desc">${this.esc(d.description)}</div></div>`;
+      }).join('');
+      return this._shell('definitions', b.title || 'Definitions', items);
+    },
+    table(b) {
+      const cols = b.columns || [];
+      const head = '<tr>' + cols.map(c => `<th>${this.esc(c)}</th>`).join('') + '</tr>';
+      const body = (b.rows || []).map(r => '<tr>' + cols.map((_, i) => `<td>${this.esc(r[i] || '')}</td>`).join('') + '</tr>').join('');
+      return this._shell('table', b.title || 'Table',
+        `<div class="kn-table-wrap"><table class="kn-table"><thead>${head}</thead><tbody>${body}</tbody></table></div>`);
+    },
+    formula(b) {
+      const items = (b.items || []).map(f => `<div class="kn-formula">
+        <div class="kn-formula-expr">${this.esc(f.expression)}</div>
+        <div class="kn-formula-desc">${this.esc(f.description)}</div>
+        ${f.constraints ? `<div class="kn-formula-con">Constraints: ${this.esc(f.constraints)}</div>` : ''}</div>`).join('');
+      return this._shell('formulas', b.title || 'Formulas', items);
+    },
+    procedure(b) {
+      const steps = (b.steps || []).map(s => `<li>${this.esc(s)}</li>`).join('');
+      return this._shell('procedure', b.title || 'Procedure',
+        `${b.appliesTo ? `<div class="kn-applies">Applies to: ${this.esc(b.appliesTo)}</div>` : ''}
+         <ol class="kn-steps">${steps}</ol>
+         ${b.notes ? `<div class="kn-proc-notes">${this.esc(b.notes)}</div>` : ''}`);
+    },
+
+    /* ── DYNAMIC: runnable code ── */
+    code(b) {
+      const id = b.id;
+      this._state[id] = { orig: b.code, setup: b.setup || '', lang: b.lang };
+      return this._shell(b.lang + ' · runnable', b.title || 'Try it', `
+        <textarea class="kn-editor" id="kn_ed_${id}" spellcheck="false">${this.esc(b.code)}</textarea>
+        <div class="kn-run-row">
+          <button class="kn-btn kn-btn-go" onclick="BlockEngine.runCode('${id}')">▶ Run ${b.lang.toUpperCase()}</button>
+          <button class="kn-btn kn-btn-ghost" onclick="BlockEngine.resetCode('${id}')">Reset</button>
+          <span class="kn-run-hint">${b.lang === 'sql' ? 'runs against a sample DB in your browser' : 'runs in your browser'}</span>
+        </div>
+        <div class="kn-out" id="kn_out_${id}" style="display:none">
+          <div class="kn-out-label">Output</div>
+          <div class="kn-out-body" id="kn_outbody_${id}"></div>
+        </div>`);
+    },
+
+    /* ── DYNAMIC: interactive calculator ── */
+    calc(b) {
+      const id = b.id;
+      this._state[id] = b;
+      const inputs = b.inputs || [];
+      if (!inputs.length || !b.formula) {
+        return this._shell('interactive', b.title || 'Calculator',
+          `<p style="color:var(--text-muted);font-family:var(--font-mono);font-size:12px;padding:8px 0;">No inputs configured. Delete this block and add a new Calculator — it will auto-generate from your formulas.</p>`);
+      }
+      const fields = inputs.map(f =>
+        `<div class="kn-calc-row"><label>${this.esc(f.label || f.key)}</label>
+         <input type="number" data-key="${f.key}" value="${f.default ?? 0}" oninput="BlockEngine.recalc('${id}')"></div>`).join('');
+      setTimeout(() => this.recalc(id), 0);
+      return this._shell('interactive', b.title || 'Calculator', `
+        <div class="kn-calc-grid">${fields}</div>
+        <div class="kn-calc-result"><div class="kn-calc-lab">${this.esc(b.resultLabel || 'Result')}</div>
+          <div class="kn-calc-val" id="kn_calcval_${id}">—</div>
+          <div class="kn-calc-break" id="kn_calcbreak_${id}"></div></div>`);
+    },
+
+    /* ── DYNAMIC: live web preview ── */
+    webpreview(b) {
+      const id = b.id;
+      this._state[id] = { orig: b.code };
+      setTimeout(() => this.renderWeb(id), 0);
+      return this._shell('live preview', b.title || 'Live preview', `
+        <div class="kn-split">
+          <textarea class="kn-editor" id="kn_web_${id}" spellcheck="false" oninput="BlockEngine.renderWeb('${id}')">${this.esc(b.code)}</textarea>
+          <iframe class="kn-frame" id="kn_frame_${id}" sandbox="allow-scripts"></iframe>
+        </div>
+        <div class="kn-run-row"><span class="kn-run-hint">edit on the left — preview updates live</span>
+          <button class="kn-btn kn-btn-ghost" onclick="BlockEngine.resetCode('${id}','web')">Reset</button></div>`);
+    },
+
+    /* ── DYNAMIC: quiz ── */
+    quiz(b) {
+      const id = b.id;
+      this._state[id] = b;
+      const opts = (b.options || []).map((o, i) =>
+        `<button class="kn-quiz-opt" onclick="BlockEngine.answerQuiz('${id}',${i})">${this.esc(o)}</button>`).join('');
+      return this._shell('check', b.title || 'Quick check',
+        `<div class="kn-quiz-q">${this.esc(b.q)}</div><div id="kn_qopts_${id}">${opts}</div><div id="kn_qfb_${id}"></div>`);
+    },
+
+    /* ── DYNAMIC: cloze / fill-in-the-blank (active recall) ── */
+    cloze(b) {
+      const id = b.id;
+      // text contains {{answer}} markers; each becomes a typed input.
+      const answers = [];
+      const segments = String(b.text || '').split(/(\{\{[^}]+\}\})/g).map(seg => {
+        const m = seg.match(/^\{\{([^}]+)\}\}$/);
+        if (!m) return this.esc(seg);
+        const i = answers.length;
+        answers.push(m[1].trim());
+        return `<input class="kn-cloze-input" id="kn_cloze_${id}_${i}" data-i="${i}" autocomplete="off" autocapitalize="off" spellcheck="false" placeholder="?" />`;
+      }).join('');
+      this._state[id] = { answers, checked: false };
+      return this._shell('recall', b.title || 'Fill in the blanks',
+        `<div class="kn-cloze-text">${segments}</div>`
+        + `<div class="kn-cloze-actions">`
+        + `<button class="kn-btn kn-btn-go" onclick="BlockEngine.checkCloze('${id}')">Check</button>`
+        + `<button class="kn-btn" onclick="BlockEngine.revealCloze('${id}')">Reveal</button>`
+        + `</div><div id="kn_cloze_fb_${id}" class="kn-cloze-fb"></div>`);
+    },
+
+    /* ── DYNAMIC: match game ── */
+    match(b) {
+      const id = b.id;
+      const pairs = b.pairs || [];
+      this._state[id] = { pairs, sel: null, done: 0 };
+      const shuf = arr => arr.map(v => [Math.random(), v]).sort((a, c) => a[0] - c[0]).map(p => p[1]);
+      const left = pairs.map((p, i) => `<div class="kn-match-item" data-side="L" data-i="${i}" onclick="BlockEngine.matchPick('${id}','L',${i})">${this.esc(p[0])}</div>`).join('');
+      const right = shuf(pairs.map((p, i) => ({ i, t: p[1] }))).map(o => `<div class="kn-match-item" data-side="R" data-i="${o.i}" onclick="BlockEngine.matchPick('${id}','R',${o.i})">${this.esc(o.t)}</div>`).join('');
+      return this._shell('game', b.title || 'Match them up!',
+        `<div class="kn-match-wrap" id="kn_match_${id}"><div class="kn-match-col">${left}</div><div class="kn-match-col">${right}</div></div>`);
+    },
+
+    /* ── diagram ── */
+    diagram(b) {
+      const steps = (b.steps || []).map((s, i) =>
+        `<div class="kn-flownode">${this.esc(s)}</div>${i < b.steps.length - 1 ? '<span class="kn-flowarrow">→</span>' : ''}`).join('');
+      return this._shell('diagram', b.title || 'Flow', `<div class="kn-flowbox">${steps}</div>`);
+    },
+
+    /* ── flashcards ── */
+    flashcards(b) {
+      const id = b.id;
+      this._state[id] = { cards: b.cards || [], i: 0, flipped: false };
+      setTimeout(() => this.renderCard(id), 0);
+      return this._shell('flashcards', b.title || 'Flashcards',
+        `<div class="kn-card" id="kn_card_${id}" onclick="BlockEngine.flipCard('${id}')"></div>
+         <div class="kn-run-row"><button class="kn-btn kn-btn-ghost" onclick="BlockEngine.nextCard('${id}')">Next ▶</button>
+           <span class="kn-run-hint" id="kn_cardcount_${id}"></span></div>`);
+    },
+  },
+
+  /* ════════════════════════════════════════════════════
+     BEHAVIOURS
+  ════════════════════════════════════════════════════ */
+
+  /* sql.js — lazy, memoised */
+  _initSql() {
+    if (this._sqlPromise) return this._sqlPromise;
+    this._sqlPromise = (async () => {
+      if (typeof initSqlJs === 'undefined') throw new Error('SQL engine not loaded. Check your connection.');
+      return await initSqlJs({ locateFile: f => 'https://cdnjs.cloudflare.com/ajax/libs/sql.js/1.8.0/' + f });
+    })();
+    return this._sqlPromise;
+  },
+
+  async runCode(id) {
+    const st = this._state[id];
+    const code = document.getElementById('kn_ed_' + id).value;
+    const out = document.getElementById('kn_out_' + id);
+    const body = document.getElementById('kn_outbody_' + id);
+    out.style.display = 'block'; body.classList.remove('err');
+
+    if (st.lang === 'sql') {
+      body.innerHTML = '<span class="kn-spin"></span> loading database…';
+      try {
+        const SQL = await this._initSql();
+        const db = new SQL.Database();
+        if (st.setup) db.run(st.setup);
+        const res = db.exec(code);
+        if (!res.length) { body.textContent = '✓ Query ran. No rows returned.'; db.close(); return; }
+        const t = res[0];
+        let html = '<table class="kn-res"><thead><tr>' + t.columns.map(c => `<th>${this.esc(c)}</th>`).join('') + '</tr></thead><tbody>';
+        html += t.values.map(r => '<tr>' + r.map(v => `<td>${this.esc(v)}</td>`).join('') + '</tr>').join('');
+        body.innerHTML = html + '</tbody></table>';
+        db.close();
+      } catch (e) { body.classList.add('err'); body.textContent = '✗ ' + e.message; }
+    } else { // js
+      try {
+        const log = [];
+        const orig = console.log;
+        console.log = (...a) => { log.push(a.map(x => typeof x === 'object' ? JSON.stringify(x) : x).join(' ')); orig(...a); };
+        let ret;
+        try { ret = Function('"use strict";return (function(){' + code + '})()')(); }
+        finally { console.log = orig; }
+        const txt = (log.join('\n') + (ret !== undefined ? '\n⇒ ' + (typeof ret === 'object' ? JSON.stringify(ret) : ret) : '')).trim();
+        body.textContent = txt || '✓ ran (no output)';
+      } catch (e) { body.classList.add('err'); body.textContent = '✗ ' + e.message; }
+    }
+  },
+  resetCode(id, kind) {
+    const st = this._state[id];
+    if (kind === 'web') { document.getElementById('kn_web_' + id).value = st.orig; this.renderWeb(id); }
+    else { document.getElementById('kn_ed_' + id).value = st.orig; }
+  },
+
+  recalc(id) {
+    const b = this._state[id];
+    const wrap = document.getElementById('kn_calcval_' + id)?.closest('.kn-block');
+    if (!wrap) return;
+    const inputs = {};
+    wrap.querySelectorAll('input[data-key]').forEach(el => inputs[el.dataset.key] = parseFloat(el.value) || 0);
+    let val, breakdown = [];
+    if (b.brackets) {
+      let income = inputs.income, tax = 0;
+      b.brackets.forEach(([lo, hi, rate]) => {
+        if (income > lo) {
+          const slice = Math.min(income, hi) - lo, t = slice * rate; tax += t;
+          if (slice > 0) breakdown.push([`${lo.toLocaleString()}–${hi > 1e8 ? '+' : hi.toLocaleString()} @ ${rate * 100}%`, Math.round(t).toLocaleString()]);
+        }
+      });
+      val = (b.currency || 'R') + Math.round(tax).toLocaleString();
+      breakdown.push(['Effective rate', income ? (tax / income * 100).toFixed(1) + '%' : '0%']);
+    } else {
+      try {
+        val = Function(...Object.keys(inputs), 'return (' + b.formula + ')')(...Object.values(inputs));
+        if (typeof val === 'number') val = (Math.round(val * 100) / 100) + (b.unit || '');
+      } catch (e) { val = '—'; }
+      breakdown = b.breakdownSteps ? b.breakdownSteps.map(s => {
+        try { return [s.label, Function(...Object.keys(inputs), 'return (' + s.expr + ')')(...Object.values(inputs))]; }
+        catch { return [s.label, '—']; }
+      }) : [];
+    }
+    document.getElementById('kn_calcval_' + id).textContent = val;
+    document.getElementById('kn_calcbreak_' + id).innerHTML =
+      breakdown.map(([k, v]) => `<div class="kn-calc-step"><span>${this.esc(k)}</span><span>${this.esc(v)}</span></div>`).join('');
+  },
+
+  renderWeb(id) {
+    const ta = document.getElementById('kn_web_' + id);
+    const frame = document.getElementById('kn_frame_' + id);
+    if (!ta || !frame) return;
+    frame.srcdoc = ta.value;
+  },
+
+  answerQuiz(id, i) {
+    const b = this._state[id];
+    const opts = document.querySelectorAll('#kn_qopts_' + id + ' .kn-quiz-opt');
+    opts.forEach((o, j) => {
+      o.onclick = null;
+      if (j === b.answer) o.classList.add('correct');
+      if (j === i && i !== b.answer) o.classList.add('wrong');
+    });
+    document.getElementById('kn_qfb_' + id).innerHTML =
+      `<div class="kn-quiz-fb">${i === b.answer ? '✓ ' : '✗ '}${this.esc(b.fb || '')}</div>`;
+  },
+
+  /** Normalize for forgiving comparison: case, surrounding space, trailing punctuation. */
+  _normCloze(s) {
+    return String(s ?? '').trim().toLowerCase().replace(/[.,;:!?]+$/, '').replace(/\s+/g, ' ');
+  },
+
+  checkCloze(id) {
+    const st = this._state[id];
+    if (!st) return;
+    let correct = 0;
+    st.answers.forEach((ans, i) => {
+      const inp = document.getElementById('kn_cloze_' + id + '_' + i);
+      if (!inp) return;
+      // Accept any of several acceptable answers separated by | in the source marker.
+      const accepted = ans.split('|').map(a => this._normCloze(a));
+      const ok = accepted.includes(this._normCloze(inp.value));
+      inp.classList.remove('correct', 'wrong');
+      inp.classList.add(ok ? 'correct' : 'wrong');
+      if (ok) correct++;
+    });
+    st.checked = true;
+    const total = st.answers.length;
+    const fb = document.getElementById('kn_cloze_fb_' + id);
+    if (fb) {
+      const all = correct === total;
+      fb.innerHTML = `<span class="${all ? 'kn-cloze-win' : 'kn-cloze-partial'}">`
+        + `${all ? '✓' : ''} ${correct} / ${total} correct`
+        + `${all ? '' : ' — tap Reveal to see the answers, then try again'}</span>`;
+    }
+  },
+
+  revealCloze(id) {
+    const st = this._state[id];
+    if (!st) return;
+    st.answers.forEach((ans, i) => {
+      const inp = document.getElementById('kn_cloze_' + id + '_' + i);
+      if (!inp) return;
+      // Show the first acceptable answer.
+      inp.value = ans.split('|')[0].trim();
+      inp.classList.remove('wrong');
+      inp.classList.add('revealed');
+    });
+    const fb = document.getElementById('kn_cloze_fb_' + id);
+    if (fb) fb.innerHTML = '<span class="kn-cloze-partial">Answers shown — clear them and test yourself again.</span>';
+  },
+
+  matchPick(id, side, i) {
+    const st = this._state[id];
+    const wrap = document.getElementById('kn_match_' + id);
+    const el = wrap.querySelector(`[data-side="${side}"][data-i="${i}"]`);
+    if (el.classList.contains('done')) return;
+    if (!st.sel) { st.sel = { side, i, el }; el.classList.add('sel'); return; }
+    if (st.sel.side === side) { st.sel.el.classList.remove('sel'); st.sel = { side, i, el }; el.classList.add('sel'); return; }
+    if (st.sel.i === i) {
+      st.sel.el.classList.remove('sel'); st.sel.el.classList.add('done'); el.classList.add('done'); st.done++;
+      if (st.done === st.pairs.length)
+        setTimeout(() => wrap.insertAdjacentHTML('afterend', '<div class="kn-quiz-fb" style="margin-top:10px">🎉 You matched them all! Great job!</div>'), 200);
+    } else {
+      const a = st.sel.el; a.classList.add('wrong'); el.classList.add('wrong');
+      setTimeout(() => { a.classList.remove('wrong', 'sel'); el.classList.remove('wrong'); }, 500);
+    }
+    st.sel = null;
+  },
+
+  renderCard(id) {
+    const st = this._state[id];
+    const c = st.cards[st.i]; if (!c) return;
+    const card = document.getElementById('kn_card_' + id);
+    const count = document.getElementById('kn_cardcount_' + id);
+    if (!card) return;
+    card.innerHTML =
+      `<div class="kn-card-face">${this.esc(st.flipped ? c.back : c.front)}</div>
+       <div class="kn-card-hint">${st.flipped ? 'answer' : 'tap to flip'}</div>`;
+    if (count) count.textContent = `${st.i + 1} / ${st.cards.length}`;
+  },
+  flipCard(id) { this._state[id].flipped = !this._state[id].flipped; this.renderCard(id); },
+  nextCard(id) { const st = this._state[id]; st.i = (st.i + 1) % st.cards.length; st.flipped = false; this.renderCard(id); },
+
+  /* ── block management (delegates to NodeDetailView for re-render) ── */
+  move(nodeId, blockId, dir) {
+    const node = nodeStore.get(nodeId); if (!node) return;
+    node.moveBlock(blockId, dir); nodeStore.save(node);
+    try { NodeDetailView._rerenderBlocks(); } catch(e) {}
+  },
+  del(nodeId, blockId) {
+    const node = nodeStore.get(nodeId); if (!node) return;
+    node.removeBlock(blockId); nodeStore.save(node);
+    try { NodeDetailView._rerenderBlocks(); } catch(e) {}
+  },
+};

--- a/knowledgenode/www/js/ui/BulkImport.js
+++ b/knowledgenode/www/js/ui/BulkImport.js
@@ -1,0 +1,1071 @@
+/**
+ * BulkImport.js
+ * Bulk photo import with manual node organisation.
+ *
+ * GUARDRAILS:
+ *  1. Vault snapshot taken before any processing starts.
+ *  2. Each node is saved to nodeStore immediately after processing — failure
+ *     of a later batch never rolls back earlier ones.
+ *  3. If AI structuring fails for a batch, raw OCR text is saved as a
+ *     plain-text node so no photo content is ever lost.
+ *  4. Worked examples are processed independently; their failure never
+ *     affects the parent node's notes.
+ *  5. The AI prompt instructs strict source-fidelity — only extract what is
+ *     physically present on the page, no elaboration.
+ */
+
+const BulkImport = {
+
+  /* ── State ─────────────────────────────────────────── */
+  _photos:  [],   // [{ file, thumb, type:'notes'|'example' }]
+  _splits:  [],   // sorted indices — split AFTER photos[i] → new segment starts at i+1
+  _configs: [],   // [{ name, subject, chapter }] — one per segment
+
+  /* ── Entry point ────────────────────────────────────── */
+  trigger() {
+    document.getElementById('bulk-import-input')?.click();
+  },
+
+  async start(files) {
+    if (!files || !files.length) return;
+    if (!AIService.hasApiKey()) {
+      Toast.error('Configure AI first in Settings — needed to process each node.');
+      return;
+    }
+
+    // Show loading overlay
+    this._showLoading('Loading ' + files.length + ' photos…');
+
+    this._photos  = [];
+    this._splits  = [];
+    this._configs = [this._emptyConfig()];
+
+    // Pre-fill subject from the most common existing subject
+    const subjects = nodeStore.getAll().map(n => n.subject).filter(Boolean);
+    if (subjects.length) {
+      const freq = {};
+      subjects.forEach(s => { freq[s] = (freq[s] || 0) + 1; });
+      this._configs[0].subject = Object.entries(freq).sort((a,b)=>b[1]-a[1])[0][0];
+    }
+
+    // Generate thumbnails sequentially to avoid memory spikes
+    const arr = Array.from(files);
+    for (let i = 0; i < arr.length; i++) {
+      this._showLoading('Loading photo ' + (i+1) + ' of ' + arr.length + '…');
+      const { thumb, blob } = await this._prepImage(arr[i]);
+      this._photos.push({ file: arr[i], thumb, blob, type: 'notes' });
+    }
+
+    this._render();
+  },
+
+  /* ── Render: organise screen ────────────────────────── */
+  _render() {
+    const total = this._photos.length;
+    const segs  = this._segmentCount();
+
+    // Validate all configs have names
+    const missing = this._configs.filter(c => !c.name.trim()).length;
+
+    const html = `
+<div id="bi-root" data-kn-overlay data-kn-close="#bi-cancel" style="position:fixed;inset:0;background:var(--bg-base);z-index:9000;display:flex;flex-direction:column;overflow:hidden;">
+
+  <!-- Header -->
+  <div style="display:flex;align-items:center;gap:10px;padding:12px 16px;border-bottom:1px solid var(--border);flex-shrink:0;background:var(--bg-raised);">
+    <button id="bi-cancel" style="background:none;border:1px solid var(--border);border-radius:8px;padding:6px 12px;color:var(--text-secondary);font-size:13px;cursor:pointer;">✕ Cancel</button>
+    <div style="flex:1;">
+      <div style="font-family:var(--font-ui);font-weight:800;font-size:15px;">📚 Bulk Import <span style="font-family:var(--font-mono);font-size:10px;color:var(--green);font-weight:600;">v3-fix</span></div>
+      <div id="bi-count" style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);">${total} photos → ${segs} node${segs!==1?'s':''}</div>
+    </div>
+    <button id="bi-process" class="btn-primary" style="font-size:13px;padding:8px 16px;">
+      ▶ Process ${segs} node${segs!==1?'s':''}
+    </button>
+  </div>
+
+  <!-- Instructions -->
+  <div style="padding:10px 16px;background:rgba(240,165,0,0.08);border-bottom:1px solid var(--border);flex-shrink:0;">
+    <div style="font-family:var(--font-mono);font-size:11px;color:var(--accent);line-height:1.6;">
+      Tap <strong>📝/🧮</strong> to toggle Notes vs Worked Example · Adjacent 🧮 pages join into <strong>one</strong> example · Tap <strong>↑↓</strong> to reorder · Tap <strong>✂ Split here</strong> to start a new node
+    </div>
+  </div>
+
+  <!-- Scrollable list -->
+  <div id="bi-list" style="flex:1;overflow-y:auto;padding:12px 12px 80px;">
+    ${this._renderList()}
+  </div>
+</div>`;
+
+    document.body.insertAdjacentHTML('beforeend', html);
+    this._bindEvents();
+  },
+
+  _renderList() {
+    let html = '';
+    let seg = 0;
+
+    for (let i = 0; i < this._photos.length; i++) {
+      // Config card at start of each segment
+      if (i === 0 || this._splits.includes(i - 1)) {
+        if (i > 0) seg++;
+        html += this._renderConfig(seg);
+      }
+
+      html += this._renderPhoto(i, seg);
+
+      // Split button between photos
+      if (i < this._photos.length - 1) {
+        if (this._splits.includes(i)) {
+          // Already a split here — show remove
+          html += `<div data-split-at="${i}" class="bi-split-exists" style="text-align:center;margin:4px 0;">
+            <button data-rmv-split="${i}" style="background:rgba(255,80,80,0.1);border:1px dashed var(--red);border-radius:6px;padding:4px 14px;font-size:11px;color:var(--red);cursor:pointer;">✕ Remove split</button>
+          </div>`;
+        } else {
+          html += `<div style="text-align:center;margin:2px 0;">
+            <button data-add-split="${i}" style="background:none;border:1px dashed var(--border);border-radius:6px;padding:3px 14px;font-size:11px;color:var(--text-muted);cursor:pointer;opacity:0.6;">✂ Split here</button>
+          </div>`;
+        }
+      }
+    }
+    return html;
+  },
+
+  _renderConfig(segIdx) {
+    const c = this._configs[segIdx] || this._emptyConfig();
+    const segColors = ['#f0a500','#4caf50','#2196f3','#9c27b0','#ff5722','#00bcd4','#ff9800','#607d8b'];
+    const col = segColors[segIdx % segColors.length];
+    const subjects = [...new Set(nodeStore.getAll().map(n => n.subject).filter(Boolean))];
+    const subjOpts = subjects.map(s => `<option value="${this._esc(s)}"${s===c.subject?'selected':''}>${this._esc(s)}</option>`).join('');
+
+    return `
+<div class="bi-config-card" data-seg="${segIdx}" style="background:var(--bg-raised);border:2px solid ${col};border-radius:10px;padding:12px 14px;margin:10px 0 4px;">
+  <div style="font-family:var(--font-mono);font-size:10px;font-weight:700;text-transform:uppercase;color:${col};margin-bottom:8px;">📁 Node ${segIdx+1}</div>
+  <input data-cfg="${segIdx}" data-field="name" class="config-input bi-cfg-name" value="${this._esc(c.name)}"
+    placeholder="Node title — e.g. M1 - Accounting Cycle *" style="margin-bottom:6px;border-color:${c.name.trim()?'var(--border)':'var(--red)'};" autocorrect="on" autocapitalize="words"/>
+  ${subjects.length
+    ? `<select data-cfg="${segIdx}" data-field="subject" class="config-select bi-cfg-field" style="margin-bottom:6px;font-size:13px;">
+        <option value="">Subject…</option>${subjOpts}
+        <option value="__custom">+ Custom…</option>
+       </select>`
+    : `<input data-cfg="${segIdx}" data-field="subject" class="config-input bi-cfg-field" value="${this._esc(c.subject)}" placeholder="Subject / Topic" style="margin-bottom:6px;" autocorrect="on"/>`
+  }
+  <input data-cfg="${segIdx}" data-field="chapter" class="config-input bi-cfg-field" value="${this._esc(c.chapter)}" placeholder="Chapter / Module (optional)" autocorrect="on"/>
+</div>`;
+  },
+
+  _renderPhoto(idx, segIdx) {
+    const p = this._photos[idx];
+    const isEx = p.type === 'example';
+    const segColors = ['#f0a500','#4caf50','#2196f3','#9c27b0','#ff5722','#00bcd4','#ff9800','#607d8b'];
+    const col = segColors[segIdx % segColors.length];
+    return `
+<div class="bi-photo-row" data-idx="${idx}" style="display:flex;align-items:center;gap:8px;padding:6px;background:var(--bg-raised);border:1px solid var(--border);border-left:3px solid ${col};border-radius:8px;margin:2px 0;">
+  <button data-toggle="${idx}" title="Toggle: Notes / Worked Example" style="background:${isEx?'rgba(33,150,243,0.15)':'rgba(76,175,80,0.10)'};border:1px solid ${isEx?'#2196f3':'#4caf50'};border-radius:6px;padding:4px 7px;font-size:15px;cursor:pointer;flex-shrink:0;">${isEx?'🧮':'📝'}</button>
+  <img src="${p.thumb}" data-view="${idx}" style="width:48px;height:48px;object-fit:cover;border-radius:6px;flex-shrink:0;cursor:zoom-in;" title="Tap to view full size"/>
+  <div style="flex:1;min-width:0;" data-view="${idx}" style="cursor:pointer;">
+    <div style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);">Photo ${idx+1} — ${isEx?(()=>{const info=this._exampleInfo(idx);const lbl=info?('Example '+info.exNum+(info.pages>1?' · pg '+info.page+'/'+info.pages:'')):'Worked Example';return '<span style="color:#2196f3">🧮 '+lbl+'</span>';})():'<span style="color:#4caf50">Notes</span>'} <span style="color:var(--accent);font-size:10px;">🔍 tap to expand</span></div>
+    <div style="font-family:var(--font-mono);font-size:10px;color:var(--text-muted);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">${this._esc(p.file.name)}</div>
+  </div>
+  <div style="display:flex;flex-direction:column;gap:2px;flex-shrink:0;">
+    <button data-up="${idx}" style="background:none;border:1px solid var(--border);border-radius:4px;padding:2px 7px;font-size:12px;cursor:pointer;color:var(--text-secondary);" ${idx===0?'disabled':''}>↑</button>
+    <button data-dn="${idx}" style="background:none;border:1px solid var(--border);border-radius:4px;padding:2px 7px;font-size:12px;cursor:pointer;color:var(--text-secondary);" ${idx===this._photos.length-1?'disabled':''}>↓</button>
+  </div>
+</div>`;
+  },
+
+  _bindEvents() {
+    const root = document.getElementById('bi-root');
+    if (!root) return;
+
+    root.addEventListener('click', e => {
+      // Cancel
+      if (e.target.id === 'bi-cancel') { this._close(); return; }
+
+      // Process
+      if (e.target.id === 'bi-process') { this._confirmAndProcess(); return; }
+
+      // View full size
+      const view = e.target.closest('[data-view]')?.dataset.view;
+      if (view != null) { this._openViewer(parseInt(view)); return; }
+
+      // Toggle Notes / Worked Example
+      const toggle = e.target.closest('[data-toggle]')?.dataset.toggle;
+      if (toggle != null) {
+        const idx = parseInt(toggle);
+        this._syncConfigsFromDOM();   // keep typed titles before rebuilding the list
+        this._photos[idx].type = this._photos[idx].type === 'notes' ? 'example' : 'notes';
+        this._rerender();
+        return;
+      }
+
+      // Move up
+      const up = e.target.dataset.up;
+      if (up != null) { this._movePhoto(parseInt(up), -1); return; }
+
+      // Move down
+      const dn = e.target.dataset.dn;
+      if (dn != null) { this._movePhoto(parseInt(dn), +1); return; }
+
+      // Add split
+      const addSplit = e.target.dataset.addSplit;
+      if (addSplit != null) {
+        const at = parseInt(addSplit);
+        const segIdx = this._addSplit(at);
+        // Focus the new node name field
+        if (segIdx > -1) setTimeout(() => {
+          const inputs = document.querySelectorAll(`.bi-cfg-name[data-cfg="${segIdx}"]`);
+          inputs[0]?.focus();
+        }, 100);
+        return;
+      }
+
+      // Remove split
+      const rmv = e.target.dataset.rmvSplit;
+      if (rmv != null) {
+        this._removeSplit(parseInt(rmv));
+        return;
+      }
+    });
+
+    // Config field changes
+    root.addEventListener('input', e => {
+      const cfgIdx = e.target.dataset.cfg;
+      const field  = e.target.dataset.field;
+      if (cfgIdx != null && field) {
+        const idx = parseInt(cfgIdx);
+        if (!this._configs[idx]) this._configs[idx] = this._emptyConfig();
+        let val = e.target.value;
+        // Propagate subject to subsequent nodes that haven't been customised
+        if (field === 'subject' && val !== '__custom') {
+          for (let i = idx + 1; i < this._configs.length; i++) {
+            if (!this._configs[i].subject || this._configs[i].subject === this._configs[idx].subject) {
+              this._configs[i].subject = val;
+            }
+          }
+        }
+        if (val !== '__custom') this._configs[idx][field] = val;
+        // Live border feedback on the name field (validation happens on Process)
+        if (field === 'name') {
+          e.target.style.borderColor = val.trim() ? 'var(--border)' : 'var(--red)';
+        }
+      }
+    });
+
+    // Select → custom subject
+    root.addEventListener('change', e => {
+      if (e.target.dataset.field === 'subject' && e.target.value === '__custom') {
+        const v = prompt('Enter subject name:');
+        if (v) {
+          const idx = parseInt(e.target.dataset.cfg);
+          this._configs[idx].subject = v;
+          e.target.outerHTML = `<input data-cfg="${idx}" data-field="subject" class="config-input bi-cfg-field" value="${this._esc(v)}" placeholder="Subject / Topic" style="margin-bottom:6px;" autocorrect="on"/>`;
+        }
+      }
+    });
+  },
+
+  /* ── Confirm and start processing ───────────────────── */
+  // Read the actual input values straight from the DOM. The live `input` event
+  // can miss values on some Android keyboards/IMEs, leaving _configs stale — so
+  // we never trust the cached state at process time, we re-read the fields.
+  _syncConfigsFromDOM() {
+    document.querySelectorAll('#bi-root [data-cfg][data-field]').forEach(el => {
+      const idx = parseInt(el.dataset.cfg);
+      const field = el.dataset.field;
+      if (isNaN(idx) || !field) return;
+      const val = el.value;
+      if (val === '__custom') return; // ignore the "+ Custom…" placeholder option
+      if (!this._configs[idx]) this._configs[idx] = this._emptyConfig();
+      this._configs[idx][field] = val;
+    });
+  },
+
+  async _confirmAndProcess() {
+    // Pull the latest typed values in before validating
+    this._syncConfigsFromDOM();
+
+    const firstEmpty = this._configs.findIndex(c => !c.name.trim());
+    if (firstEmpty !== -1) {
+      Toast.error('Give every node a title before processing.');
+      const field = document.querySelector('.bi-cfg-name[data-cfg="' + firstEmpty + '"]');
+      if (field) {
+        field.style.borderColor = 'var(--red)';
+        field.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        setTimeout(() => field.focus(), 300);
+      }
+      return;
+    }
+
+    const segs = this._buildSegments();
+
+    // Validate: warn if any node has only worked examples (no notes)
+    const notesOnly = [];
+    segs.forEach((s, i) => {
+      if (s.notes.length === 0 && s.exampleGroups.length > 0) {
+        notesOnly.push('Node ' + (i + 1) + ' ("' + (s.config.name || 'Untitled') + '")');
+      }
+    });
+    if (notesOnly.length) {
+      const ok = confirm(notesOnly.join(', ') + ' has only worked-example photos and no notes. '
+        + 'If that node should have notes, tap Cancel and check that its pages show the 📝 (green) icon, then reorder so the notes sit inside that node. '
+        + 'Continue creating it from examples only?');
+      if (!ok) return;
+    }
+
+    this._close();
+    await this._process(segs);
+  },
+
+  /* ── Build segment data from state ─────────────────── */
+  _buildSegments() {
+    const segs = [];
+
+    const segForIdx = (i) => {
+      let s = 0;
+      for (const sp of this._splits) {
+        if (i > sp) s++;
+        else break;
+      }
+      return s;
+    };
+
+    const segCount = this._splits.length + 1;
+    for (let i = 0; i < segCount; i++) {
+      // exampleGroups: array of multi-page examples; each is an array of photos.
+      // Pull the config by the SAME index the list uses, falling back to an
+      // empty one so a segment can never be built against a mismatched name.
+      segs.push({ config: { ...(this._configs[i] || this._emptyConfig()) }, notes: [], exampleGroups: [] });
+    }
+
+    // A run of ADJACENT example photos (within the same node) = ONE worked example.
+    // A notes photo, or a node boundary, ends the current example run.
+    let runSeg = -1;
+    let runGroup = null;
+    this._photos.forEach((p, i) => {
+      const s = segForIdx(i);
+      if (p.type === 'example') {
+        if (runGroup && runSeg === s) {
+          runGroup.push(p);            // same example, next page
+        } else {
+          runGroup = [p];              // start a new example
+          runSeg = s;
+          segs[s].exampleGroups.push(runGroup);
+        }
+      } else {
+        segs[s].notes.push(p);
+        runGroup = null;               // notes page breaks the example run
+        runSeg = -1;
+      }
+    });
+
+    return segs;
+  },
+
+  /* ── Main processing pipeline ───────────────────────── */
+  async _process(segs) {
+    const total = segs.length;
+
+    // GUARDRAIL 1: Vault snapshot before touching anything
+    try {
+      await BackupVault.snapshot('pre-bulk-import');
+      console.log('[BulkImport] Pre-import vault snapshot taken');
+    } catch(e) { console.warn('[BulkImport] Snapshot failed:', e); }
+
+    // Processing screen
+    this._ensureLoaderStyles();
+    const el = document.createElement('div');
+    el.id = 'bi-progress';
+    el.style.cssText = 'position:fixed;inset:0;background:radial-gradient(120% 80% at 50% -10%, rgba(240,165,0,0.10), transparent 60%), var(--bg-base);z-index:9000;display:flex;flex-direction:column;overflow:hidden;';
+    el.innerHTML = `
+      <style>
+        @keyframes bi-spin { to { transform: rotate(360deg); } }
+        @keyframes bi-pulse { 0%,100% { opacity:0.55; } 50% { opacity:1; } }
+        @keyframes bi-rise { from { opacity:0; transform:translateY(8px); } to { opacity:1; transform:translateY(0); } }
+        #bi-progress .bi-ring { width:18px;height:18px;border:2px solid rgba(240,165,0,0.25);border-top-color:var(--accent);border-radius:50%;animation:bi-spin 0.8s linear infinite;flex-shrink:0; }
+        #bi-progress .bi-node-card { animation:bi-rise 0.3s ease both; }
+        #bi-progress .bi-bar-fill { transition:width 0.45s cubic-bezier(.4,0,.2,1); }
+        #bi-progress .bi-active { box-shadow:0 0 0 1px var(--accent-dim), 0 8px 24px rgba(0,0,0,0.35); border-color:var(--accent-dim)!important; }
+      </style>
+
+      <!-- Header -->
+      <div style="padding:22px 20px 16px;flex-shrink:0;">
+        <div style="display:flex;align-items:center;gap:12px;">
+          <div style="display:flex;align-items:center;justify-content:center;flex-shrink:0;">${this._hexLoader(44)}</div>
+          <div style="flex:1;min-width:0;">
+            <div style="font-family:var(--font-ui);font-weight:800;font-size:18px;letter-spacing:-0.01em;">Building your library</div>
+            <div id="bi-prog-sub" style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);margin-top:1px;">Preparing ${total} node${total!==1?'s':''}…</div>
+          </div>
+          <div style="font-family:var(--font-mono);font-size:13px;font-weight:700;color:var(--accent);"><span id="bi-prog-count">0</span>/${total}</div>
+        </div>
+        <!-- Progress bar -->
+        <div style="margin-top:16px;height:6px;background:var(--bg-raised);border-radius:99px;overflow:hidden;">
+          <div id="bi-prog-bar" class="bi-bar-fill" style="height:100%;width:0%;background:linear-gradient(90deg, var(--accent), #ffce5a);border-radius:99px;"></div>
+        </div>
+        <div style="font-family:var(--font-mono);font-size:10px;color:var(--text-muted);margin-top:8px;display:flex;align-items:center;gap:6px;">
+          <span style="display:inline-block;width:6px;height:6px;border-radius:50%;background:var(--accent);animation:bi-pulse 1.4s ease-in-out infinite;"></span>
+          Keep the app open — each node is saved the moment it finishes.
+        </div>
+      </div>
+
+      <div id="bi-prog-list" style="flex:1;overflow-y:auto;padding:4px 16px 24px;"></div>`;
+    document.body.appendChild(el);
+
+    const progList = document.getElementById('bi-prog-list');
+    const setProgress = (done) => {
+      const bar = document.getElementById('bi-prog-bar');
+      const cnt = document.getElementById('bi-prog-count');
+      if (bar) bar.style.width = Math.round((done/total)*100) + '%';
+      if (cnt) cnt.textContent = done;
+    };
+    const results = [];
+
+    for (let i = 0; i < segs.length; i++) {
+      const seg = segs[i];
+      const cfg = seg.config;
+      const rowId = 'bi-row-' + i;
+      const exCount = seg.exampleGroups ? seg.exampleGroups.length : 0;
+      const meta = seg.notes.length + ' note' + (seg.notes.length!==1?'s':'') + (exCount ? ' · ' + exCount + ' example' + (exCount!==1?'s':'') : '');
+
+      // Add a card for this node
+      progList.insertAdjacentHTML('beforeend', `
+        <div id="${rowId}" class="bi-node-card bi-active" style="background:var(--bg-raised);border:1px solid var(--border);border-radius:14px;padding:14px 16px;margin-bottom:10px;display:flex;gap:12px;align-items:flex-start;">
+          <div id="${rowId}-icon" style="margin-top:2px;"><div class="bi-ring"></div></div>
+          <div style="flex:1;min-width:0;">
+            <div style="font-family:var(--font-ui);font-weight:700;font-size:14px;">${this._esc(cfg.name)}</div>
+            <div style="font-family:var(--font-mono);font-size:10px;color:var(--text-muted);margin-top:1px;">${meta}</div>
+            <div id="${rowId}-status" style="font-family:var(--font-mono);font-size:12px;color:var(--accent);margin-top:7px;">⏳ Starting…</div>
+          </div>
+        </div>`);
+      progList.lastElementChild?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+
+      const card = document.getElementById(rowId);
+      const iconEl = document.getElementById(rowId + '-icon');
+      const setStatus = (msg, color='var(--accent)') => {
+        const s = document.getElementById(rowId + '-status');
+        if (s) s.innerHTML = `<span style="color:${color};">${msg}</span>`;
+      };
+
+      document.getElementById('bi-prog-sub').textContent = 'Node ' + (i+1) + ' of ' + total + ' — ' + cfg.name;
+
+      try {
+        const result = await this._processSegment(seg, i+1, total, setStatus);
+        results.push({ name: cfg.name, status: 'ok', nodeId: result.nodeId, examplesAdded: result.examplesAdded, examplesFailed: result.examplesFailed });
+        if (iconEl) iconEl.innerHTML = '<span style="font-size:18px;">✅</span>';
+        card?.classList.remove('bi-active');
+        setStatus('Saved'
+          + (result.examplesAdded ? ' · ' + result.examplesAdded + ' example' + (result.examplesAdded!==1?'s':'') : '')
+          + (result.examplesRescued ? ' (' + result.examplesRescued + ' saved as text)' : '')
+          + (result.examplesFailed ? ' · ⚠️ ' + result.examplesFailed + ' failed' + (result.lastError ? ': ' + result.lastError : '') : ''),
+          'var(--green)');
+      } catch(err) {
+        console.error('[BulkImport] Node failed:', cfg.name, err);
+        results.push({ name: cfg.name, status: 'failed', error: err.message });
+        if (iconEl) iconEl.innerHTML = '<span style="font-size:18px;">❌</span>';
+        card?.classList.remove('bi-active');
+        setStatus('Failed: ' + err.message, 'var(--red)');
+      }
+
+      setProgress(i + 1);
+    }
+
+    // Summary
+    const ok      = results.filter(r => r.status === 'ok').length;
+    const failed  = results.filter(r => r.status === 'failed');
+    document.getElementById('bi-prog-sub').textContent = ok === segs.length ? 'All nodes ready' : 'Finished with some issues';
+    progList.insertAdjacentHTML('beforeend', `
+      <div class="bi-node-card" style="background:linear-gradient(135deg, ${failed.length?'rgba(240,165,0,0.08)':'rgba(52,199,123,0.08)'}, var(--bg-raised));border:1px solid ${failed.length?'var(--accent-dim)':'rgba(52,199,123,0.3)'};border-radius:16px;padding:20px;margin-top:6px;text-align:center;">
+        <div style="font-size:34px;line-height:1;margin-bottom:8px;">${ok === segs.length ? '🎉' : '⚠️'}</div>
+        <div style="font-family:var(--font-ui);font-weight:800;font-size:17px;margin-bottom:6px;">${ok === segs.length ? 'All done!' : 'Partially complete'}</div>
+        <div style="font-family:var(--font-body);font-size:14px;color:var(--text-secondary);line-height:1.5;">${ok} node${ok!==1?'s':''} created successfully${failed.length ? '<br/>' + failed.length + ' failed (saved as plain text where possible)' : ''}.</div>
+        ${failed.length ? '<div style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);margin-top:8px;">Failed: ' + failed.map(r=>this._esc(r.name)).join(', ') + '</div>' : ''}
+        <button id="bi-done" class="btn-primary" style="margin-top:18px;width:100%;padding:13px;font-size:15px;">Go to Library →</button>
+      </div>`);
+    progList.lastElementChild?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+
+    document.getElementById('bi-done')?.addEventListener('click', () => {
+      document.getElementById('bi-progress')?.remove();
+      App.navigateTo('library');
+    });
+  },
+
+  /* ── Process a single segment ───────────────────────── */
+  async _processSegment(seg, segNum, total, setStatus) {
+    const cfg = seg.config;
+    const meta = { subject: cfg.subject || '', chapter: cfg.chapter || '', detail: 'structured', title: cfg.name };
+
+    // Strict anti-hallucination prompt note (injected via processContent meta flag)
+    meta._strictSourceOnly = true;
+
+    const result = { nodeId: null, examplesAdded: 0, examplesFailed: 0 };
+
+    // ── Notes photos ──────────────────────────────────────────────────────────
+    let nodeId = null;
+
+    if (seg.notes.length > 0) {
+      setStatus('📖 Reading ' + seg.notes.length + ' note photo' + (seg.notes.length>1?'s':'') + '…');
+      const base64s = await Promise.all(seg.notes.map(p => this._toBase64(p.blob || p.file)));
+      const types   = seg.notes.map(p => (p.blob && p.blob.type) || p.file.type || 'image/jpeg');
+
+      let rawText = '';
+      try {
+        rawText = base64s.length > 1
+          ? await AIService._extractMultiPageText(base64s, types)
+          : await AIService._extractSingleImageText(base64s[0], types[0]);
+      } catch(e) { console.warn('[BulkImport] OCR failed for notes, continuing:', e); }
+
+      let nodeData = null;
+      try {
+        setStatus('🤖 Structuring notes with AI (' + segNum + '/' + total + ')…');
+        nodeData = await AIService.processContent(base64s, rawText, meta, () => {});
+      } catch(aiErr) {
+        console.warn('[BulkImport] AI structuring failed, falling back to plain text:', aiErr);
+        // GUARDRAIL 3: Never lose content — save as plain text if AI fails
+        setStatus('⚠️ AI failed — saving as plain text (data preserved)…');
+        nodeData = {
+          title: cfg.name,
+          definitions: [], tables: [], formulas: [], procedures: [],
+          commonMistakes: [], summary: '',
+          rawOCR: rawText,
+          userNotes: rawText,
+          processingStatus: 'plain',
+        };
+      }
+
+      // Ensure title matches what user typed
+      nodeData.title = cfg.name;
+
+      // GUARDRAIL 2: Save immediately
+      const node = new KnowledgeNode({ ...nodeData, subject: cfg.subject, chapter: cfg.chapter });
+      nodeStore.save(node);
+      nodeId = node.id;
+      result.nodeId = nodeId;
+
+    } else if (seg.exampleGroups.length > 0) {
+      // No notes — create a stub node to attach examples to
+      const node = new KnowledgeNode({
+        title: cfg.name, subject: cfg.subject, chapter: cfg.chapter,
+        definitions: [], tables: [], formulas: [], procedures: [],
+        commonMistakes: [], summary: '', processingStatus: 'plain',
+      });
+      nodeStore.save(node);
+      nodeId = node.id;
+      result.nodeId = nodeId;
+      setStatus('📁 Node created (examples only)…');
+    }
+
+    // ── Worked examples (each group = one multi-page example) ─────────────────
+    if (seg.exampleGroups.length > 0 && nodeId) {
+      const n = seg.exampleGroups.length;
+      setStatus('🧮 Processing ' + n + ' worked example' + (n>1?'s':'') + '…');
+
+      for (let i = 0; i < seg.exampleGroups.length; i++) {
+        const pages = seg.exampleGroups[i];
+        const exTitle = cfg.name + ' — Example ' + (i+1);
+        try {
+          setStatus('🧮 Example ' + (i+1) + '/' + n + (pages.length>1 ? ' (' + pages.length + ' pages)' : '') + '…');
+
+          const base64s = await Promise.all(pages.map(p => this._toBase64(p.blob || p.file)));
+          const types   = pages.map(p => (p.blob && p.blob.type) || p.file.type || 'image/jpeg');
+
+          const rawEx = await (base64s.length > 1
+            ? AIService._extractMultiPageText(base64s, types)
+            : AIService._extractSingleImageText(base64s[0], types[0])
+          ).catch(() => '');
+
+          // All pages of this example go to the AI together as ONE example.
+          // If structuring fails, we still keep the OCR'd text below.
+          let exData = null;
+          try {
+            exData = await AIService.processContent(base64s, rawEx, {
+              ...meta,
+              title: exTitle,
+              _isWorkedExample: true,
+              _strictSourceOnly: true,
+            }, () => {});
+          } catch (procErr) {
+            console.warn('[BulkImport] Example structuring failed, will save raw text:', procErr);
+            result.lastError = (procErr && procErr.message) || 'structuring failed';
+          }
+
+          const target = nodeStore.get(nodeId);
+          if (target) {
+            if (!target.workedExamples) target.workedExamples = [];
+            if (exData) {
+              target.workedExamples.push({
+                title: exTitle,
+                pages: pages.length,
+                raw: rawEx,
+                steps: exData.procedures || [],
+                summary: exData.summary || rawEx.slice(0, 300),
+              });
+              nodeStore.save(target);
+              result.examplesAdded++;
+            } else if (rawEx && rawEx.trim()) {
+              // GUARDRAIL: never lose the example — save the OCR text as a
+              // plain-text worked example, mirroring the notes fallback.
+              target.workedExamples.push({
+                title: exTitle,
+                pages: pages.length,
+                raw: rawEx,
+                steps: [],
+                summary: rawEx.slice(0, 300),
+                processingStatus: 'plain',
+              });
+              nodeStore.save(target);
+              result.examplesAdded++;
+              result.examplesRescued = (result.examplesRescued || 0) + 1;
+            } else {
+              // Only a true failure: even OCR produced nothing usable.
+              result.examplesFailed++;
+              result.lastError = result.lastError || 'OCR returned no text for this example';
+            }
+          } else {
+            result.examplesFailed++;
+            result.lastError = 'node not found when attaching example';
+          }
+        } catch(e) {
+          // GUARDRAIL 4: Example failure never kills the node
+          console.warn('[BulkImport] Example', i+1, 'failed:', e);
+          result.examplesFailed++;
+          result.lastError = (e && e.message) || 'unknown error';
+        }
+      }
+    }
+
+    return result;
+  },
+
+  /* ── Full-size photo viewer ──────────────────────────── */
+  _viewerIdx: 0,
+  _viewerURL:  null,  // current objectURL — revoked when closed or changed
+
+  _openViewer(idx) {
+    this._viewerIdx = idx;
+    this._renderViewer();
+  },
+
+  _renderViewer() {
+    const idx = this._viewerIdx;
+    const p   = this._photos[idx];
+    if (!p) return;
+
+    // Revoke previous objectURL to free memory
+    if (this._viewerURL) { URL.revokeObjectURL(this._viewerURL); }
+    this._viewerURL = URL.createObjectURL(p.blob || p.file);
+
+    const isEx  = p.type === 'example';
+    const total = this._photos.length;
+    const nodeNum    = this._segForIdx(idx) + 1;
+    const nodeCount  = this._segmentCount();
+    const splitHere  = this._splits.includes(idx);   // split AFTER this photo
+    const canSplit   = idx < total - 1;
+
+    // Remove existing viewer if present
+    document.getElementById('bi-viewer')?.remove();
+
+    const el = document.createElement('div');
+    el.id = 'bi-viewer';
+    el.setAttribute('data-kn-overlay', '');
+    el.setAttribute('data-kn-close', '#biv-close');
+    el.style.cssText = 'position:fixed;inset:0;z-index:9300;background:rgba(0,0,0,0.96);display:flex;flex-direction:column;touch-action:none;';
+
+    el.innerHTML = `
+      <!-- Top bar -->
+      <div style="display:flex;align-items:center;gap:10px;padding:10px 14px;flex-shrink:0;">
+        <button id="biv-close" style="background:rgba(255,255,255,0.1);border:none;border-radius:8px;padding:7px 14px;font-size:14px;color:#fff;cursor:pointer;">✕</button>
+        <div style="flex:1;text-align:center;">
+          <div style="font-family:var(--font-ui);font-weight:700;font-size:14px;color:#fff;">Photo ${idx+1} of ${total}</div>
+          <div style="font-family:var(--font-mono);font-size:11px;color:var(--accent);">📁 Node ${nodeNum} of ${nodeCount}</div>
+          <div style="font-family:var(--font-mono);font-size:10px;color:rgba(255,255,255,0.45);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:60vw;margin:0 auto;">${this._esc(p.file.name)}</div>
+        </div>
+        <button id="biv-sort" style="background:rgba(255,255,255,0.1);border:1px solid rgba(255,255,255,0.2);border-radius:8px;padding:7px 12px;font-size:14px;color:#fff;cursor:pointer;" title="Sort all photos by file name (capture order)">⇅ Sort</button>
+        <button id="biv-toggle" style="background:${isEx?'rgba(33,150,243,0.3)':'rgba(76,175,80,0.3)'};border:1px solid ${isEx?'#2196f3':'#4caf50'};border-radius:8px;padding:7px 12px;font-size:14px;color:#fff;cursor:pointer;" title="Toggle type">
+          ${isEx ? '🧮 Example' : '📝 Notes'}
+        </button>
+      </div>
+
+      <!-- Image -->
+      <div id="biv-img-wrap" style="flex:1;overflow:hidden;display:flex;align-items:center;justify-content:center;position:relative;">
+        <img id="biv-img" src="${this._viewerURL}"
+          onerror="this.onerror=null;if('${p.thumb||''}')this.src='${p.thumb||''}';"
+          style="max-width:100%;max-height:100%;object-fit:contain;user-select:none;transition:transform 0.1s;"
+          draggable="false"/>
+        <!-- Pinch/zoom hint -->
+        <div style="position:absolute;bottom:8px;left:0;right:0;text-align:center;pointer-events:none;">
+          <span style="font-family:var(--font-mono);font-size:10px;color:rgba(255,255,255,0.3);">Pinch to zoom · swipe left/right to navigate</span>
+        </div>
+      </div>
+
+      <!-- Organize controls -->
+      <div style="display:flex;align-items:center;gap:8px;padding:0 16px 4px;flex-shrink:0;">
+        <button id="biv-move-left" style="flex:1;background:rgba(255,255,255,0.08);border:1px solid rgba(255,255,255,0.15);border-radius:8px;padding:9px;font-size:13px;color:#fff;cursor:pointer;${idx===0?'opacity:0.3;':''}" ${idx===0?'disabled':''}>◀ Move</button>
+        <button id="biv-split" style="flex:1.4;background:${splitHere?'rgba(255,80,80,0.18)':'rgba(240,165,0,0.15)'};border:1px ${splitHere?'solid var(--red)':'dashed var(--accent)'};border-radius:8px;padding:9px;font-size:13px;color:${splitHere?'var(--red)':'var(--accent)'};cursor:pointer;${canSplit?'':'opacity:0.3;'}" ${canSplit?'':'disabled'}>${splitHere?'✕ Remove split':'✂ Split after'}</button>
+        <button id="biv-move-right" style="flex:1;background:rgba(255,255,255,0.08);border:1px solid rgba(255,255,255,0.15);border-radius:8px;padding:9px;font-size:13px;color:#fff;cursor:pointer;${idx===total-1?'opacity:0.3;':''}" ${idx===total-1?'disabled':''}>Move ▶</button>
+      </div>
+
+      <!-- Bottom nav -->
+      <div style="display:flex;align-items:center;gap:10px;padding:12px 16px;flex-shrink:0;">
+        <button id="biv-prev" style="flex:1;background:rgba(255,255,255,0.08);border:1px solid rgba(255,255,255,0.15);border-radius:8px;padding:10px;font-size:14px;color:#fff;cursor:pointer;" ${idx===0?'disabled style="opacity:0.3;"':''}>← Prev</button>
+        <div style="text-align:center;min-width:60px;">
+          <div style="font-family:var(--font-mono);font-size:10px;color:rgba(255,255,255,0.4);">${idx+1} / ${total}</div>
+        </div>
+        <button id="biv-next" style="flex:1;background:rgba(255,255,255,0.08);border:1px solid rgba(255,255,255,0.15);border-radius:8px;padding:10px;font-size:14px;color:#fff;cursor:pointer;" ${idx===total-1?'disabled style="opacity:0.3;"':''}>Next →</button>
+      </div>`;
+
+    document.body.appendChild(el);
+
+    // Close
+    document.getElementById('biv-close').onclick = () => this._closeViewer();
+
+    // Toggle type from viewer
+    document.getElementById('biv-toggle').onclick = () => {
+      this._photos[this._viewerIdx].type = this._photos[this._viewerIdx].type === 'notes' ? 'example' : 'notes';
+      this._rerender();     // update list behind viewer
+      this._renderViewer(); // re-render viewer to show new type
+    };
+
+    // Sort ALL photos by file name (capture order) — keeps the current photo in view
+    document.getElementById('biv-sort').onclick = () => this._sortByName();
+
+    // Prev / Next
+    document.getElementById('biv-prev').onclick = () => {
+      if (this._viewerIdx > 0) { this._viewerIdx--; this._renderViewer(); }
+    };
+    document.getElementById('biv-next').onclick = () => {
+      if (this._viewerIdx < this._photos.length - 1) { this._viewerIdx++; this._renderViewer(); }
+    };
+
+    // Move current photo left / right (the viewer follows the photo)
+    document.getElementById('biv-move-left').onclick = () => {
+      const i = this._viewerIdx;
+      if (i === 0) return;
+      this._movePhoto(i, -1);   // swaps photos + adjusts splits, re-renders list
+      this._viewerIdx = i - 1;  // keep viewing the same photo
+      this._renderViewer();
+    };
+    document.getElementById('biv-move-right').onclick = () => {
+      const i = this._viewerIdx;
+      if (i >= this._photos.length - 1) return;
+      this._movePhoto(i, +1);
+      this._viewerIdx = i + 1;
+      this._renderViewer();
+    };
+
+    // Split / merge node boundary after this photo
+    document.getElementById('biv-split').onclick = () => {
+      const i = this._viewerIdx;
+      if (i >= this._photos.length - 1) return;
+      if (this._splits.includes(i)) this._removeSplit(i);
+      else                          this._addSplit(i);
+      this._renderViewer(); // refresh node label + button state (list already updated)
+    };
+
+    // Keyboard (desktop)
+    this._viewerKeyHandler = (e) => {
+      if (e.key === 'ArrowLeft')  document.getElementById('biv-prev')?.click();
+      if (e.key === 'ArrowRight') document.getElementById('biv-next')?.click();
+      if (e.key === 'Escape')     this._closeViewer();
+    };
+    document.addEventListener('keydown', this._viewerKeyHandler);
+
+    // Swipe gesture (mobile)
+    let touchStartX = null;
+    el.addEventListener('touchstart', e => { touchStartX = e.touches[0].clientX; }, { passive: true });
+    el.addEventListener('touchend', e => {
+      if (touchStartX === null) return;
+      const dx = e.changedTouches[0].clientX - touchStartX;
+      touchStartX = null;
+      if (Math.abs(dx) < 40) return; // not a swipe
+      if (dx < 0) document.getElementById('biv-next')?.click(); // swipe left = next
+      else         document.getElementById('biv-prev')?.click(); // swipe right = prev
+    }, { passive: true });
+
+    // Pinch-to-zoom (basic)
+    let scale = 1, lastDist = null;
+    const img = document.getElementById('biv-img');
+    el.addEventListener('touchmove', e => {
+      if (e.touches.length !== 2) return;
+      const dx = e.touches[0].clientX - e.touches[1].clientX;
+      const dy = e.touches[0].clientY - e.touches[1].clientY;
+      const dist = Math.sqrt(dx*dx + dy*dy);
+      if (lastDist !== null) {
+        scale = Math.max(1, Math.min(4, scale * (dist / lastDist)));
+        img.style.transform = `scale(${scale})`;
+      }
+      lastDist = dist;
+    }, { passive: true });
+    el.addEventListener('touchend', e => {
+      if (e.touches.length < 2) lastDist = null;
+      // Double-tap to reset zoom
+    });
+  },
+
+  _closeViewer() {
+    if (this._viewerURL) { URL.revokeObjectURL(this._viewerURL); this._viewerURL = null; }
+    if (this._viewerKeyHandler) { document.removeEventListener('keydown', this._viewerKeyHandler); this._viewerKeyHandler = null; }
+    document.getElementById('bi-viewer')?.remove();
+  },
+
+  _viewerKeyHandler: null,
+
+  /* ── Helpers ─────────────────────────────────────────── */
+  _segmentCount() { return this._splits.length + 1; },
+
+  _emptyConfig() { return { name: '', subject: '', chapter: '' }; },
+
+  // Which segment (node) a photo index currently belongs to
+  _segForIdx(i) {
+    let s = 0;
+    for (const sp of this._splits) { if (i > sp) s++; else break; }
+    return s;
+  },
+
+  // For an example photo: which example number it is within its node, plus its
+  // page position within that (possibly multi-page) example. null for notes.
+  _exampleInfo(idx) {
+    if (this._photos[idx]?.type !== 'example') return null;
+    const seg = this._segForIdx(idx);
+    let exNum = 0, inRun = false, runStart = -1;
+    for (let i = 0; i < this._photos.length; i++) {
+      if (this._segForIdx(i) !== seg) continue;
+      if (this._photos[i].type === 'example') {
+        if (!inRun) { inRun = true; exNum++; runStart = i; }
+        if (i === idx) {
+          let pages = 0, page = 0;
+          for (let j = runStart;
+               j < this._photos.length && this._segForIdx(j) === seg && this._photos[j].type === 'example';
+               j++) {
+            pages++;
+            if (j === idx) page = pages;
+          }
+          return { exNum, page, pages };
+        }
+      } else {
+        inRun = false;
+      }
+    }
+    return null;
+  },
+
+  // Sort ALL photos by file name using natural/numeric order (so 1000109885.jpg
+  // sorts before 1000109886.jpg, and ...9 before ...10). Gallery exports usually
+  // carry capture order in the file name, so this restores that order in one tap.
+  // Splits define node boundaries by photo index — reordering invalidates them, so
+  // sorting resets to a single node. We confirm first if any splits exist.
+  _sortByName() {
+    if (this._photos.length < 2) return;
+    this._syncConfigsFromDOM();   // keep the typed title before resetting to one node
+
+    if (this._splits.length) {
+      const ok = confirm('Sorting reorders every photo by file name and resets your node splits back to one node. Continue?');
+      if (!ok) return;
+    }
+
+    // Remember the photo currently on screen so we can keep viewing it after sorting
+    const current = this._photos[this._viewerIdx];
+
+    const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
+    this._photos.sort((a, b) => collator.compare(a.file.name || '', b.file.name || ''));
+
+    // Order changed → splits/configs no longer map to anything meaningful
+    this._splits = [];
+    this._configs = [this._configs[0] || this._emptyConfig()];
+
+    if (current) {
+      const newIdx = this._photos.indexOf(current);
+      if (newIdx !== -1) this._viewerIdx = newIdx;
+    }
+
+    this._rerender();      // refresh the list behind the viewer
+    this._renderViewer();  // refresh the viewer (new position / node label)
+    Toast.info('Sorted ' + this._photos.length + ' photos by name.');
+  },
+
+
+  // Returns the index of the newly created config, or -1 if a split already existed.
+  _addSplit(at) {
+    if (this._splits.includes(at)) return -1;
+    this._syncConfigsFromDOM();   // capture typed titles before reindexing configs
+    this._splits.push(at);
+    this._splits.sort((a, b) => a - b);
+    const segIdx = this._splits.indexOf(at) + 1;
+    const prev = this._configs[segIdx - 1] || this._emptyConfig();
+    this._configs.splice(segIdx, 0, { name: '', subject: prev.subject, chapter: '' });
+    this._rerender();
+    return segIdx;
+  },
+
+  // Remove the split after photo `at`, merging the two nodes back together.
+  _removeSplit(at) {
+    if (!this._splits.includes(at)) return;
+    this._syncConfigsFromDOM();   // capture typed titles before reindexing configs
+    const segIdx = this._splits.indexOf(at) + 1;
+    this._splits = this._splits.filter(s => s !== at);
+    this._configs.splice(segIdx, 1);
+    this._rerender();
+  },
+
+  _movePhoto(idx, dir) {
+    const newIdx = idx + dir;
+    if (newIdx < 0 || newIdx >= this._photos.length) return;
+    this._syncConfigsFromDOM();   // keep typed titles when the list rebuilds
+    // Swap the two adjacent photos. Splits are POSITIONAL node boundaries
+    // ("new node starts after photo i"), so they must stay where they are —
+    // the photo simply flows across the boundary to the other node. The old
+    // index-remapping here moved boundaries to the wrong place and left the
+    // per-node titles (_configs) attached to the wrong group, which is what
+    // made notes-filled nodes report as "0 notes / examples only".
+    [this._photos[idx], this._photos[newIdx]] = [this._photos[newIdx], this._photos[idx]];
+    this._rerender();
+    this._highlightPhotoRow(newIdx);   // flash + scroll so the moved photo is easy to track
+  },
+
+  // Briefly glow a photo row and bring it into view (used after a reorder)
+  _highlightPhotoRow(idx) {
+    requestAnimationFrame(() => {
+      const row = document.querySelector('.bi-photo-row[data-idx="' + idx + '"]');
+      if (!row) return;
+      row.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      const prevBg = row.style.background;
+      row.style.transition = 'box-shadow 0.2s ease, background 0.2s ease';
+      row.style.boxShadow  = '0 0 0 2px var(--accent), 0 0 16px rgba(240,165,0,0.55)';
+      row.style.background = 'rgba(240,165,0,0.16)';
+      setTimeout(() => { row.style.boxShadow = ''; row.style.background = prevBg; }, 900);
+    });
+  },
+
+  _rerender() {
+    const list = document.getElementById('bi-list');
+    if (!list) return;
+    list.innerHTML = this._renderList();
+
+    // Keep the header count + Process button in sync with the real node count.
+    // Previously these were only set on first render, so adding splits left the
+    // header stuck on "1 node" while the list showed several.
+    const total = this._photos.length;
+    const segs  = this._segmentCount();
+    const countEl = document.getElementById('bi-count');
+    if (countEl) countEl.textContent = total + ' photos → ' + segs + ' node' + (segs !== 1 ? 's' : '');
+    const procBtn = document.getElementById('bi-process');
+    if (procBtn) procBtn.textContent = '▶ Process ' + segs + ' node' + (segs !== 1 ? 's' : '');
+    // Re-bind config events (delegated from root, should still work)
+  },
+
+  _close() {
+    document.getElementById('bi-root')?.remove();
+    this._photos = [];
+    this._splits = [];
+    this._configs = [];
+  },
+
+  _showLoading(msg) {
+    this._ensureLoaderStyles();
+    let el = document.getElementById('bi-loading');
+    if (!el) {
+      el = document.createElement('div');
+      el.id = 'bi-loading';
+      el.style.cssText = 'position:fixed;inset:0;background:var(--bg-base);z-index:9100;display:flex;flex-direction:column;align-items:center;justify-content:center;overflow:hidden;';
+      el.innerHTML = `
+        <div style="position:absolute;width:340px;height:340px;border-radius:50%;background:radial-gradient(circle, rgba(240,165,0,0.16), transparent 65%);filter:blur(20px);animation:kn-aurora 6s ease-in-out infinite;pointer-events:none;"></div>
+        <div style="position:relative;display:flex;flex-direction:column;align-items:center;animation:kn-fade-rise 0.4s ease both;">
+          ${this._hexLoader(78)}
+          <div style="font-family:var(--font-ui);font-weight:800;font-size:17px;letter-spacing:-0.01em;margin-top:22px;">Bulk Import</div>
+          <div id="bi-loading-msg" style="font-family:var(--font-mono);font-size:13px;color:var(--text-muted);margin-top:6px;">${this._esc(msg)}</div>
+        </div>`;
+      document.body.appendChild(el);
+    } else {
+      const m = document.getElementById('bi-loading-msg');
+      if (m) m.textContent = msg;
+    }
+
+    // Remove loading when switching to main UI
+    setTimeout(() => {
+      if (!this._photos.length) return;
+      document.getElementById('bi-loading')?.remove();
+    }, 100);
+  },
+
+  // Decode the picked file ONCE and hold a capped-resolution, in-memory JPEG copy.
+  // Two goals at the same time:
+  //   • Stability — an in-memory blob never goes stale the way the Android picker's
+  //     content:// File can, so the viewer and processing stay reliable.
+  //   • Memory — 40+ full-resolution phone photos (8–12 MP each) held at once will
+  //     OOM a low-end WebView, which is the main cause of bulk-import crashes. The
+  //     whole pipeline (OCR + the AI vision call) already downscales to ≤2000px /
+  //     ≤4MB, so a ~2200px JPEG copy loses nothing downstream while using a fraction
+  //     of the heap. Fall back to a lossless copy only if decoding fails.
+  async _prepImage(file) {
+    let blob;
+    try {
+      blob = await this._downscaleToBlob(file);
+    } catch (e) {
+      try {
+        const buf = await file.arrayBuffer();
+        blob = new Blob([buf], { type: file.type || 'image/jpeg' });
+      } catch (e2) {
+        blob = file; // extremely unlikely; fall back to the original reference
+      }
+    }
+    const thumb = await this._thumbFromBlob(blob);
+    return { thumb, blob };
+  },
+
+  // Re-encode an image File/Blob to a capped-resolution JPEG Blob held in memory.
+  // Decoding happens one photo at a time (start() awaits each), so peak memory is
+  // a single decode, not the whole batch.
+  _downscaleToBlob(file, maxEdge = 2200, quality = 0.85) {
+    return new Promise((resolve, reject) => {
+      const url = URL.createObjectURL(file);
+      const img = new Image();
+      img.onload = () => {
+        const w = img.width, h = img.height;
+        if (!w || !h) { URL.revokeObjectURL(url); reject(new Error('bad image dimensions')); return; }
+        const ratio = Math.min(maxEdge / w, maxEdge / h, 1);
+        const c = document.createElement('canvas');
+        c.width  = Math.max(1, Math.round(w * ratio));
+        c.height = Math.max(1, Math.round(h * ratio));
+        c.getContext('2d').drawImage(img, 0, 0, c.width, c.height);
+        URL.revokeObjectURL(url);
+        c.toBlob(
+          b => b ? resolve(b) : reject(new Error('toBlob returned null')),
+          'image/jpeg', quality
+        );
+      };
+      img.onerror = () => { URL.revokeObjectURL(url); reject(new Error('image decode failed')); };
+      img.src = url;
+    });
+  },
+
+  _thumbFromBlob(blob) {
+    return new Promise(resolve => {
+      const url = URL.createObjectURL(blob);
+      const img = new Image();
+      img.onload = () => {
+        const max = 80;
+        const ratio = Math.min(max / img.width, max / img.height, 1);
+        const c = document.createElement('canvas');
+        c.width  = Math.max(1, Math.round(img.width  * ratio));
+        c.height = Math.max(1, Math.round(img.height * ratio));
+        c.getContext('2d').drawImage(img, 0, 0, c.width, c.height);
+        URL.revokeObjectURL(url);
+        resolve(c.toDataURL('image/jpeg', 0.7));
+      };
+      img.onerror = () => { URL.revokeObjectURL(url); resolve(''); };
+      img.src = url;
+    });
+  },
+
+  async _toBase64(file) {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload  = e => resolve(e.target.result.split(',')[1]);
+      reader.onerror = reject;
+      reader.readAsDataURL(file);
+    });
+  },
+
+  // Loader visuals are shared app-wide via KNLoader
+  _ensureLoaderStyles() { KNLoader.ensureStyles(); },
+  _hexLoader(size = 64) { return KNLoader.hex(size); },
+
+  _esc: s => String(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'),
+};

--- a/knowledgenode/www/js/ui/CompetencyView.js
+++ b/knowledgenode/www/js/ui/CompetencyView.js
@@ -1,0 +1,823 @@
+/**
+ * CompetencyView.js — Subject competency test + effectiveness report
+ *
+ * Three combined formats:
+ *  1. Timed Quiz — mock exam with a countdown timer
+ *  2. AI Graded  — open-answer questions graded by AI with detailed feedback
+ *  3. Report Card — visual strengths vs gaps across all subjects
+ */
+
+const CompetencyView = {
+  _mode: 'report',       // 'report'|'timed'|'ai-quiz'
+  _subject: 'all',
+  _session: [],          // questions for current test
+  _idx: 0,
+  _answers: [],
+  _timer: null,
+  _timeLeft: 0,
+  _started: false,
+
+  init() { /* called from app.js */ },
+
+  /** Entry point used by Study Plan / Dashboard "🏆 Test" buttons.
+   *  Navigates to the competency view with a subject preselected and shows
+   *  the report card scoped to that subject. The user can then run a timed
+   *  quiz or AI exam from the mode buttons. */
+  open(subject, mode) {
+    this._subject = subject || 'all';
+    this._mode    = mode || 'report';
+    if (typeof App !== 'undefined' && App.navigateTo) App.navigateTo('competency');
+    else this.refresh(); // fallback if router unavailable
+    try {
+      const nodes = nodeStore.getAll().filter(n => n.processingStatus === 'ready');
+      const filtered = this._subject === 'all' ? nodes : nodes.filter(n => n.subject === this._subject);
+      if (!filtered.length) { Toast.error('No notes found for this subject yet.'); return; }
+      if (this._mode === 'report') this._showReport(filtered, nodes);
+    } catch (e) {
+      console.error('CompetencyView.open failed:', e);
+    }
+  },
+
+  refresh() {
+    const nodes = nodeStore.getAll().filter(n => n.processingStatus === 'ready');
+    this._renderShell(nodes);
+  },
+
+  _renderShell(nodes) {
+    const container = document.getElementById('competency-body');
+    if (!container) return;
+
+    const subjects = [...new Set(nodes.map(n=>n.subject).filter(Boolean))];
+    const subjectOptions = ['all', ...subjects].map(s =>
+      `<option value="${s}" ${s===this._subject?'selected':''}>${s==='all'?'All Subjects':s}</option>`
+    ).join('');
+
+    container.innerHTML = `
+      <!-- Mode selector -->
+      <div class="competency-modes">
+        <button class="comp-mode-btn ${this._mode==='report'?'active':''}"  data-mode="report">📊 Report Card</button>
+        <button class="comp-mode-btn ${this._mode==='timed'?'active':''}"   data-mode="timed">⏱ Timed Quiz</button>
+        <button class="comp-mode-btn ${this._mode==='ai-quiz'?'active':''}" data-mode="ai-quiz">⬡ AI Exam</button>
+      </div>
+
+      <div class="competency-toolbar">
+        <select id="comp-subject" class="config-select" style="max-width:220px;">${subjectOptions}</select>
+        <button class="btn-primary" id="comp-start-btn">
+          ${this._mode==='report'?'Generate Report':this._mode==='timed'?'▶ Start Timed Quiz':'▶ Start AI Exam'}
+        </button>
+      </div>
+
+      <div id="comp-content"></div>
+    `;
+
+    container.querySelectorAll('.comp-mode-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        this._mode = btn.dataset.mode;
+        container.querySelectorAll('.comp-mode-btn').forEach(b=>b.classList.remove('active'));
+        btn.classList.add('active');
+        document.getElementById('comp-start-btn').textContent =
+          this._mode==='report'?'Generate Report':this._mode==='timed'?'▶ Start Timed Quiz':'▶ Start AI Exam';
+        document.getElementById('comp-content').innerHTML = '';
+      });
+    });
+
+    document.getElementById('comp-subject').addEventListener('change', e => { this._subject = e.target.value; });
+
+    document.getElementById('comp-start-btn').addEventListener('click', () => {
+      this._subject = document.getElementById('comp-subject').value;
+      const filtered = this._subject==='all' ? nodes : nodes.filter(n=>n.subject===this._subject);
+      if (!filtered.length) { Toast.error('No nodes in selected subject.'); return; }
+      if (this._mode==='report')   this._showReport(filtered, nodes);
+      else if (this._mode==='timed')   this._startTimedQuiz(filtered);
+      else if (this._mode==='ai-quiz') this._startAIExam(filtered);
+    });
+
+    // Show report by default if nodes exist
+    if (nodes.length && !this._started) { this._showReport(nodes, nodes); }
+  },
+
+  // ─── 1. REPORT CARD ───────────────────────────────────
+
+  _showReport(filteredNodes, allNodes) {
+    const el = document.getElementById('comp-content');
+
+    // Per-subject breakdown
+    const subjects = {};
+    filteredNodes.forEach(n => {
+      const s = n.subject || 'Uncategorised';
+      if (!subjects[s]) subjects[s] = { nodes:[], totalQ:0, masterySum:0, due:0, weakTopics:[] };
+      subjects[s].nodes.push(n);
+      subjects[s].totalQ   += n.questions.length;
+      subjects[s].masterySum += n.masteryScore;
+      subjects[s].due      += n.dueQuestions().length;
+      if (n.masteryScore < 50) subjects[s].weakTopics.push(n.title);
+    });
+
+    const overallMastery = filteredNodes.length
+      ? Math.round(filteredNodes.reduce((s,n)=>s+n.masteryScore,0)/filteredNodes.length)
+      : 0;
+
+    const grade = this._grade(overallMastery);
+
+    const subjectCards = Object.entries(subjects).map(([subj, data]) => {
+      const avg = Math.round(data.masterySum / data.nodes.length);
+      const g   = this._grade(avg);
+      return `
+        <div class="comp-subject-card">
+          <div class="comp-subject-header">
+            <div>
+              <div class="comp-subject-name">${this._esc(subj)}</div>
+              <div class="comp-subject-meta">${data.nodes.length} nodes · ${data.totalQ} questions</div>
+            </div>
+            <div class="comp-grade ${g.cls}">${g.letter}</div>
+          </div>
+          <div class="comp-bar-row">
+            <div class="mastery-bar-track" style="flex:1;height:8px;">
+              <div class="mastery-bar-fill" style="width:${avg}%;height:8px;"></div>
+            </div>
+            <span style="font-family:var(--font-mono);font-size:12px;color:var(--accent);min-width:36px;text-align:right;">${avg}%</span>
+          </div>
+          ${data.weakTopics.length ? `
+            <div class="comp-weak-topics">
+              <span style="color:var(--red);font-family:var(--font-mono);font-size:10px;text-transform:uppercase;letter-spacing:0.08em;">Needs attention:</span>
+              ${data.weakTopics.map(t=>`<span class="comp-topic-pill weak">${this._esc(t)}</span>`).join('')}
+            </div>` : `
+            <div style="font-family:var(--font-mono);font-size:11px;color:var(--green);margin-top:8px;">✓ All topics above 50% mastery</div>`}
+          ${data.due > 0 ? `<div style="font-family:var(--font-mono);font-size:11px;color:var(--accent);margin-top:6px;">⚠ ${data.due} cards due for review</div>` : ''}
+          <div class="comp-node-list">
+            ${data.nodes.sort((a,b)=>a.masteryScore-b.masteryScore).map(n=>`
+              <div class="comp-node-row">
+                <span class="comp-node-name">${this._esc(n.title)}</span>
+                <div class="mastery-bar-track" style="width:80px;height:4px;"><div class="mastery-bar-fill" style="width:${n.masteryScore}%;height:4px;background:${n.masteryScore<40?'var(--red)':n.masteryScore<70?'var(--accent)':'var(--green)'};"></div></div>
+                <span style="font-family:var(--font-mono);font-size:10px;color:var(--text-muted);min-width:28px;">${n.masteryScore}%</span>
+              </div>`).join('')}
+          </div>
+        </div>`;
+    }).join('');
+
+    // Recommendations
+    const weakSubjects = Object.entries(subjects).filter(([,d])=>Math.round(d.masterySum/d.nodes.length)<50).map(([s])=>s);
+    const recommendations = weakSubjects.length
+      ? `Focus immediate attention on: <strong>${weakSubjects.join(', ')}</strong>. These subjects are below 50% mastery and should be prioritised in your study plan.`
+      : overallMastery >= 80
+        ? 'Excellent preparation! Keep up the spaced repetition reviews to maintain retention before your exam.'
+        : 'Good progress. Continue with daily reviews and focus on application questions to push mastery higher.';
+
+    el.innerHTML = `
+      <div class="comp-overall-card">
+        <div class="comp-overall-left">
+          <div class="comp-overall-grade ${grade.cls}">${grade.letter}</div>
+          <div>
+            <div style="font-family:var(--font-ui);font-size:22px;font-weight:800;">${grade.label}</div>
+            <div style="font-family:var(--font-mono);font-size:12px;color:var(--text-muted);">Overall Mastery: ${overallMastery}%</div>
+          </div>
+        </div>
+        <canvas id="comp-radar" width="200" height="200"></canvas>
+      </div>
+      <div class="comp-recommendation">${recommendations}</div>
+      <div class="comp-subjects-grid">${subjectCards}</div>
+    `;
+
+    // Draw radar / bar chart
+    setTimeout(() => this._drawRadar(subjects), 50);
+  },
+
+  _drawRadar(subjects) {
+    const canvas = document.getElementById('comp-radar');
+    if (!canvas) return;
+    const ctx  = canvas.getContext('2d');
+    const cx   = 100, cy = 100, r = 75;
+    const entries = Object.entries(subjects);
+    if (!entries.length) return;
+
+    ctx.clearRect(0, 0, 200, 200);
+
+    // Draw grid circles
+    [25,50,75,100].forEach(pct => {
+      ctx.beginPath();
+      ctx.arc(cx, cy, r * pct/100, 0, Math.PI*2);
+      ctx.strokeStyle = 'rgba(255,255,255,0.06)';
+      ctx.lineWidth = 1;
+      ctx.stroke();
+    });
+
+    if (entries.length < 3) {
+      // Fall back to horizontal bars for fewer than 3 subjects
+      entries.forEach(([s,d], i) => {
+        const avg = Math.round(d.masterySum / d.nodes.length);
+        const y   = 30 + i * 50;
+        ctx.fillStyle = 'rgba(240,165,0,0.15)';
+        ctx.fillRect(10, y, (180 * avg/100), 28);
+        ctx.fillStyle = 'var(--accent)';
+        ctx.font = '11px DM Mono, monospace';
+        ctx.fillText(`${s.slice(0,12)}: ${avg}%`, 14, y+18);
+      });
+      return;
+    }
+
+    const step = (Math.PI * 2) / entries.length;
+
+    // Draw spokes
+    entries.forEach((_, i) => {
+      const a = -Math.PI/2 + i*step;
+      ctx.beginPath();
+      ctx.moveTo(cx, cy);
+      ctx.lineTo(cx + Math.cos(a)*r, cy + Math.sin(a)*r);
+      ctx.strokeStyle = 'rgba(255,255,255,0.08)';
+      ctx.stroke();
+    });
+
+    // Draw data polygon
+    ctx.beginPath();
+    entries.forEach(([,d], i) => {
+      const avg = Math.round(d.masterySum / d.nodes.length);
+      const a   = -Math.PI/2 + i*step;
+      const pr  = r * avg/100;
+      i===0 ? ctx.moveTo(cx+Math.cos(a)*pr, cy+Math.sin(a)*pr)
+            : ctx.lineTo(cx+Math.cos(a)*pr, cy+Math.sin(a)*pr);
+    });
+    ctx.closePath();
+    ctx.fillStyle = 'rgba(240,165,0,0.2)';
+    ctx.fill();
+    ctx.strokeStyle = 'var(--accent)';
+    ctx.lineWidth = 2;
+    ctx.stroke();
+
+    // Labels
+    ctx.fillStyle = document.documentElement.classList.contains('light-theme') ? '#333' : '#ccc';
+    ctx.font = '10px DM Mono, monospace';
+    ctx.textAlign = 'center';
+    entries.forEach(([s,d], i) => {
+      const avg = Math.round(d.masterySum / d.nodes.length);
+      const a   = -Math.PI/2 + i*step;
+      const lx  = cx + Math.cos(a)*(r+14);
+      const ly  = cy + Math.sin(a)*(r+14);
+      ctx.fillText(s.slice(0,8), lx, ly);
+      ctx.fillText(`${avg}%`, lx, ly+12);
+    });
+  },
+
+  // ─── 2. TIMED QUIZ ────────────────────────────────────
+
+  _startTimedQuiz(nodes) {
+    // Timed quiz answers one item at a time, so matching sets stay per-item
+    // (still tappable) rather than grouped into one big table.
+    this._session = this._buildSession(nodes, 10, false);
+    if (!this._session.length) { Toast.error('No questions available.'); return; }
+    this._idx     = 0;
+    this._answers = [];
+    this._started = true;
+
+    const totalSeconds = this._session.length * 60; // 1 min per question
+    this._timeLeft = totalSeconds;
+    this._renderTimedQuiz();
+  },
+
+  /** True if a subject has analysed past papers (examiner signal). */
+  _hasPastPaper(subject) {
+    try {
+      const raw = localStorage.getItem('kn_exam_style_' + String(subject || '').toLowerCase().replace(/\s+/g, '_'));
+      return !!(raw && (JSON.parse(raw).papers || []).length);
+    } catch (e) { return false; }
+  },
+
+  /**
+   * Build a mock-exam question set that actually prepares the learner, instead
+   * of a pure random draw. Each question is scored by how VALUABLE it is to be
+   * tested on right now, then selected with subject BREADTH and some variety:
+   *   • struggled-with questions (the weak-spot log) are weighted up — you most
+   *     need to test what you keep getting wrong;
+   *   • questions due/overdue for review are weighted up (retrieval when it
+   *     matters most);
+   *   • never-tested questions get a modest boost (don't leave gaps);
+   *   • subjects with analysed past papers get a boost (the examiner's turf);
+   *   • a random jitter keeps repeated exams from being identical.
+   * A per-topic cap stops any one topic from dominating, so the paper stays
+   * representative of the whole syllabus. Same {q, node} shape as before.
+   */
+  _buildSession(nodes, max, group) {
+    if (group === undefined) group = true;
+    const now = Date.now();
+    // Matching sets: any selected member pulls in its whole two-column set as a
+    // single paper slot (so the exam shows the real match-and-pair table).
+    const qGroup = new Map();          // question id → group payload
+    if (group && window.MatchGroup) {
+      (nodes || []).forEach(n => { MatchGroup.indexByQuestion(n).forEach((g, qid) => qGroup.set(qid, { g, node: n })); });
+    }
+    const scored = [];
+    (nodes || []).forEach(n => {
+      const weak = new Map((n.weakQuestions || []).map(w => [w.id, w.count || 1]));
+      const examBoost = this._hasPastPaper(n.subject) ? 0.4 : 0;
+      (n.questions || []).forEach(q => {
+        const s = n.srsState && n.srsState[q.id];
+        let score = 1;
+        if (weak.has(q.id))                       score += 0.5 * Math.min(3, weak.get(q.id)); // struggled
+        if (s && s.nextReview && s.nextReview <= now) score += 0.4;                            // due/overdue
+        if (!s || (s.repetitions || 0) === 0)     score += 0.25;                               // never tested
+        score += examBoost;                                                                    // examiner topics
+        score *= 0.75 + Math.random() * 0.5;                                                    // variety
+        scored.push({ q, node: n, score });
+      });
+    });
+    if (!scored.length) return [];
+    scored.sort((a, b) => b.score - a.score);
+
+    // Breadth: cap how many any single topic may contribute (when there's choice).
+    const nodeCount = new Set(scored.map(x => x.node.id)).size;
+    const perNodeCap = Math.max(1, Math.ceil(max / Math.max(1, Math.min(nodeCount, max))));
+    const picked = [], perNode = {}, chosen = new Set(), groupsAdded = new Set();
+    // Emit a slot for a scored item — a match-set member emits its whole group
+    // once (counting as one paper slot); everything else emits itself.
+    const emit = (it) => {
+      const gi = qGroup.get(it.q.id);
+      if (gi) {
+        if (groupsAdded.has(gi.g.key)) return false;
+        groupsAdded.add(gi.g.key);
+        gi.g.prompts.forEach(p => chosen.add(p.q.id));
+        picked.push({ q: gi.g.prompts[0].q, node: gi.node, match: gi.g });
+        return true;
+      }
+      chosen.add(it.q.id);
+      picked.push({ q: it.q, node: it.node });
+      return true;
+    };
+    for (const it of scored) {
+      if (picked.length >= max) break;
+      if (chosen.has(it.q.id)) continue;
+      if ((perNode[it.node.id] || 0) >= perNodeCap) continue;
+      if (emit(it)) perNode[it.node.id] = (perNode[it.node.id] || 0) + 1;
+    }
+    // Fill any shortfall (e.g. very few topics) ignoring the cap, best score first.
+    if (picked.length < max) {
+      for (const it of scored) {
+        if (picked.length >= max) break;
+        if (chosen.has(it.q.id)) continue;
+        emit(it);
+      }
+    }
+    return picked;
+  },
+
+  _renderTimedQuiz() {
+    const el  = document.getElementById('comp-content');
+    const total = this._session.length;
+    el.innerHTML = `
+      <div class="quiz-shell">
+        <div class="quiz-header">
+          <span class="quiz-counter" id="quiz-counter">Question ${this._idx+1} of ${total}</span>
+          <div class="quiz-timer" id="quiz-timer">⏱ ${this._formatTime(this._timeLeft)}</div>
+        </div>
+        <div class="quiz-progress-track"><div class="quiz-progress-fill" id="quiz-prog" style="width:${(this._idx/total)*100}%"></div></div>
+        <div id="quiz-card" class="quiz-card"></div>
+      </div>`;
+    this._renderTimedQuestion();
+    this._startTimer();
+  },
+
+  _renderTimedQuestion() {
+    const el  = document.getElementById('quiz-card');
+    const item = this._session[this._idx];
+    if (!item) { this._clearTimer(); this._showTimedResults(); return; }
+
+    el.innerHTML = `
+      <div class="quiz-node-tag">${this._esc(item.node.title)}</div>
+      ${this._answerBlock(item.q, '', 'timed-answer', 'Type your answer…')}
+      <div class="quiz-actions">
+        <button class="btn-primary" id="timed-submit">Submit →</button>
+        <button class="btn-secondary" id="timed-skip">Skip</button>
+      </div>`;
+
+    this._wireMatchTaps(item.q, 'timed-answer');
+    document.getElementById('timed-submit').addEventListener('click', () => {
+      const ans = document.getElementById('timed-answer').value.trim();
+      this._answers.push({ item, answer: ans, skipped: false });
+      this._idx++;
+      this._renderTimedQuestion();
+    });
+    document.getElementById('timed-skip').addEventListener('click', () => {
+      this._answers.push({ item, answer: '', skipped: true });
+      this._idx++;
+      this._renderTimedQuestion();
+    });
+  },
+
+  _startTimer() {
+    this._clearTimer();
+    this._timer = setInterval(() => {
+      this._timeLeft--;
+      const el = document.getElementById('quiz-timer');
+      if (el) {
+        el.textContent = `⏱ ${this._formatTime(this._timeLeft)}`;
+        el.classList.toggle('low', this._timeLeft <= 30); // red + pulse in final 30s
+      }
+      if (this._timeLeft <= 0) { this._clearTimer(); this._showTimedResults(); }
+    }, 1000);
+  },
+
+  _clearTimer() { if (this._timer) { clearInterval(this._timer); this._timer = null; } },
+  _formatTime(s) { return `${Math.floor(s/60)}:${String(s%60).padStart(2,'0')}`; },
+
+  async _showTimedResults() {
+    this._clearTimer();
+    const graded = await this._gradeAll(this._answers, 'Marking your paper…');
+    this._renderGradedResults(graded, 'Timed Quiz Results');
+  },
+
+  /** Mark a whole set of answers in one pass, exam-style. Free instant checks
+   *  (MCQ letters, exact matches) run first so those cost no AI credits; the
+   *  rest of the paper is marked in ONE batched AI call (chunked for long
+   *  papers), falling back to per-question grading only if a batch fails. */
+  async _gradeAll(answers, headline) {
+    const el = document.getElementById('comp-content');
+    el.innerHTML = `<div style="text-align:center;padding:40px 20px;"><div class="hex-ring" style="margin:0 auto 20px;"></div><p style="font-family:var(--font-mono);color:var(--accent);">${this._esc(headline || 'Marking…')}</p><p id="comp-marking" style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);margin-top:8px;"></p></div>`;
+    const setProgress = (t) => { const p = document.getElementById('comp-marking'); if (p) p.textContent = t; };
+
+    // Pass 1 — free: skipped answers and confident instant matches.
+    const graded = new Array(answers.length);
+    const pending = []; // indexes that genuinely need AI judgement
+    answers.forEach((a, i) => {
+      if (a.skipped || !a.answer) { graded[i] = { ...a, result: { score:0, feedback:'Skipped.', correct:false, keyPointsMissed:[] } }; return; }
+      const quick = (typeof LocalGrader !== 'undefined')
+        ? LocalGrader.match(a.answer, LocalGrader.acceptedFor(a.item.q))
+        : { verdict: 'unknown' };
+      if (quick.verdict === 'correct') {
+        graded[i] = { ...a, result: { score:95, correct:true, feedback:'Instant check: matches the model answer. No AI credits used. ⚡', keyPointsMissed:[] } };
+        return;
+      }
+      pending.push(i);
+    });
+
+    // Pass 2 — one batched marking call per chunk of 8 (not one per question).
+    const CHUNK = 8;
+    for (let c = 0; c < pending.length; c += CHUNK) {
+      const chunk = pending.slice(c, c + CHUNK);
+      setProgress('Marking answers ' + (c + 1) + '–' + Math.min(c + CHUNK, pending.length) + ' of ' + pending.length + '…');
+      let done = false;
+      if (AIService.hasApiKey()) {
+        try {
+          const results = await AIService.gradeBatch(chunk.map(i => ({
+            question: answers[i].item.q.question, modelAnswer: answers[i].item.q.answer,
+            studentAnswer: answers[i].answer, subject: answers[i].item.node.subject,
+          })));
+          chunk.forEach((ansIdx, k) => {
+            const r = results[k] || {};
+            graded[ansIdx] = { ...answers[ansIdx], result: {
+              score: Math.max(0, Math.min(100, Math.round(r.score || 0))),
+              correct: !!r.correct, feedback: r.feedback || '',
+              keyPointsMissed: Array.isArray(r.keyPointsMissed) ? r.keyPointsMissed : [],
+            } };
+          });
+          done = true;
+        } catch (e) { /* batch failed — fall through to per-question below */ }
+      }
+      if (!done) {
+        for (const i of chunk) {
+          const a = answers[i];
+          try {
+            const r = AIService.hasApiKey()
+              ? await AIService.checkAnswer(a.item.q.question, a.item.q.answer, a.answer, a.item.node.subject)
+              : this._mockGrade(a.answer, a.item.q.answer);
+            graded[i] = { ...a, result: r };
+          } catch { graded[i] = { ...a, result: { score:50, feedback:'Could not grade — check answer manually.', correct: null, keyPointsMissed:[] } }; }
+        }
+      }
+    }
+    return graded;
+  },
+
+  // ─── 3. AI EXAM ───────────────────────────────────────
+
+  async _startAIExam(nodes) {
+    this._session = this._buildSession(nodes, 8);
+    if (!this._session.length) { Toast.error('No questions available.'); return; }
+    this._idx     = 0;
+    this._answers = [];
+    this._started = true;
+    this._renderAIExamQuestion();
+  },
+
+  /** Is a paper slot answered? Match slots count if any pair is assigned. */
+  _slotFilled(i) {
+    const a = this._answers[i];
+    if (!a) return false;
+    if (a.match) return (a.letters || []).some(Boolean);
+    return !!a.answer;
+  },
+
+  /** Render a whole matching set as an interactive two-column table: the
+   *  Column-A prompts (each a tappable row with an assign badge) above the
+   *  Column-B answer bank. Tap a prompt, then tap its match. Reads like the
+   *  paper worksheet; graded pair-by-pair for free. */
+  _matchCard(group, letters) {
+    const rows = group.prompts.map((p, k) => {
+      const L = letters[k] || '';
+      return `<button type="button" class="mp-row" data-prompt="${k}"
+        style="display:flex;align-items:center;gap:12px;width:100%;text-align:left;padding:12px 14px;margin:6px 0;border-radius:12px;cursor:pointer;
+        border:1.5px solid var(--border);background:var(--bg-raised);color:var(--text);font-size:15px;line-height:1.4;transition:border-color .12s,background .12s;">
+        <span class="mp-badge" style="flex:0 0 auto;display:inline-flex;align-items:center;justify-content:center;width:30px;height:30px;border-radius:9px;font-family:var(--font-mono);font-weight:700;font-size:14px;
+          border:1.5px solid ${L ? 'var(--accent)' : 'var(--border)'};background:${L ? 'var(--accent)' : 'transparent'};color:${L ? '#fff' : 'var(--text-muted)'};">${L || '?'}</span>
+        <span style="flex:1;">${this._esc(p.prompt)}</span></button>`;
+    }).join('');
+    const bank = group.options.map(o =>
+      `<button type="button" class="mp-opt" data-letter="${o.letter}"
+        style="display:flex;align-items:flex-start;gap:10px;width:100%;text-align:left;padding:11px 13px;margin:5px 0;border-radius:11px;cursor:pointer;
+        border:1.5px solid var(--border);background:var(--bg-elevated,var(--bg-raised));color:var(--text);font-size:14px;line-height:1.4;transition:border-color .12s,background .12s;">
+        <span style="flex:0 0 auto;display:inline-flex;align-items:center;justify-content:center;width:24px;height:24px;border-radius:50%;font-family:var(--font-mono);font-weight:700;font-size:12px;border:1.5px solid var(--border);color:var(--text-muted);">${o.letter}</span>
+        <span style="flex:1;padding-top:2px;">${this._esc(o.text)}</span></button>`).join('');
+    const instr = group.instruction || 'Match each item on the left to the correct option below.';
+    return `
+      <div class="quiz-question" style="margin-bottom:4px;">${this._esc(instr)}</div>
+      <p id="mp-hint" style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);margin:4px 0 10px;">Tap an item, then tap its match. Tap again to change it.</p>
+      <div style="font-family:var(--font-mono);font-size:10px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:var(--accent);margin:2px 0;">Column A</div>
+      <div id="mp-rows">${rows}</div>
+      <div style="font-family:var(--font-mono);font-size:10px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:var(--accent);margin:16px 0 2px;">Column B</div>
+      <div id="mp-bank">${bank}</div>`;
+  },
+
+  /** Wire the two-column matcher: choose an active prompt, then assign a letter.
+   *  State is saved live into this._answers[idx] so navigation preserves it. */
+  _wireMatch(idx, item) {
+    const group = item.match;
+    const cur = this._answers[idx] && this._answers[idx].letters ? this._answers[idx].letters.slice() : [];
+    const letters = group.prompts.map((_, k) => cur[k] || '');
+    this._answers[idx] = { item, match: true, letters, skipped: !letters.some(Boolean) };
+    const firstEmpty = () => { const i = letters.findIndex(l => !l); return i < 0 ? 0 : i; };
+    let active = firstEmpty();
+
+    const rows = () => Array.from(document.querySelectorAll('#mp-rows .mp-row'));
+    const paintRows = () => rows().forEach((el, k) => {
+      const on = k === active, L = letters[k] || '';
+      el.style.borderColor = on ? 'var(--accent)' : 'var(--border)';
+      el.style.background  = on ? 'var(--accent-soft)' : 'var(--bg-raised)';
+      const badge = el.querySelector('.mp-badge');
+      if (badge) {
+        badge.textContent = L || '?';
+        badge.style.borderColor = L ? 'var(--accent)' : (on ? 'var(--accent)' : 'var(--border)');
+        badge.style.background  = L ? 'var(--accent)' : 'transparent';
+        badge.style.color       = L ? '#fff' : 'var(--text-muted)';
+      }
+    });
+    const save = () => { this._answers[idx].letters = letters.slice(); this._answers[idx].skipped = !letters.some(Boolean); };
+
+    document.getElementById('mp-rows')?.addEventListener('click', (e) => {
+      const r = e.target.closest('[data-prompt]'); if (!r) return;
+      active = parseInt(r.dataset.prompt, 10); paintRows();
+    });
+    document.getElementById('mp-bank')?.addEventListener('click', (e) => {
+      const b = e.target.closest('[data-letter]'); if (!b) return;
+      if (active == null || active < 0) active = firstEmpty();
+      letters[active] = b.dataset.letter.toUpperCase();
+      save();
+      const nextEmpty = letters.findIndex(l => !l);
+      if (nextEmpty >= 0) active = nextEmpty;       // auto-advance to the next blank
+      paintRows();
+    });
+    paintRows();
+  },
+
+  /** Build the answer area for one question. Lettered-option / matching
+   *  questions become tappable choices (Column B); everything else keeps the
+   *  free-text box. A hidden #ai-answer always holds the value so the existing
+   *  save + grading path is unchanged. */
+  _answerBlock(q, savedAnswer, id, placeholder) {
+    id = id || 'ai-answer'; placeholder = placeholder || 'Write a thorough answer…';
+    const parsed = (window.MatchOptions && MatchOptions.parse) ? MatchOptions.parse(q.question) : null;
+    if (!parsed) {
+      return `<div class="quiz-question">${window.KNText ? KNText.html(q.question) : this._esc(q.question)}</div>`
+        + `<textarea id="${id}" class="config-input" rows="5" placeholder="${placeholder}">${this._esc(savedAnswer || '')}</textarea>`;
+    }
+    const chosen = MatchOptions.letterOf(parsed, savedAnswer);
+    const stemHtml = parsed.stem
+      ? `<div class="quiz-question">${window.KNText ? KNText.html(parsed.stem) : this._esc(parsed.stem)}</div>`
+      : '';
+    const opts = parsed.options.map(o => {
+      const on = o.letter === chosen;
+      return `<button type="button" class="match-opt${on ? ' is-picked' : ''}" data-letter="${o.letter}"
+        style="display:flex;align-items:flex-start;gap:10px;width:100%;text-align:left;padding:12px 14px;margin:6px 0;border-radius:12px;cursor:pointer;
+        border:1.5px solid ${on ? 'var(--accent)' : 'var(--border)'};background:${on ? 'var(--accent-soft)' : 'var(--bg-raised)'};
+        color:var(--text);font-size:15px;line-height:1.4;transition:border-color .12s,background .12s;">
+        <span style="flex:0 0 auto;display:inline-flex;align-items:center;justify-content:center;width:26px;height:26px;border-radius:50%;font-family:var(--font-mono);font-weight:700;font-size:13px;
+          border:1.5px solid ${on ? 'var(--accent)' : 'var(--border)'};background:${on ? 'var(--accent)' : 'transparent'};color:${on ? '#fff' : 'var(--text-muted)'};">${o.letter}</span>
+        <span style="flex:1;padding-top:2px;">${this._esc(o.text)}</span></button>`;
+    }).join('');
+    return stemHtml
+      + `<p style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);margin:4px 0 8px;">Tap the matching option:</p>`
+      + `<div id="match-opts">${opts}</div>`
+      + `<textarea id="${id}" style="display:none;">${this._esc(savedAnswer || '')}</textarea>`;
+  },
+
+  /** Wire the tappable matching options for a rendered question. `answerId` is
+   *  the hidden field the choice is written into (#ai-answer or #timed-answer).
+   *  No-op when the current question isn't a lettered-option set. */
+  _wireMatchTaps(q, answerId) {
+    const parsed = (window.MatchOptions && MatchOptions.parse) ? MatchOptions.parse(q.question) : null;
+    const host = document.getElementById('match-opts');
+    if (!parsed || !host) return;
+    host.addEventListener('click', (e) => {
+      const b = e.target.closest('[data-letter]');
+      if (!b) return;
+      const hidden = document.getElementById(answerId);
+      if (hidden) hidden.value = MatchOptions.answerFor(parsed, b.dataset.letter);
+      host.querySelectorAll('.match-opt').forEach(el => {
+        const on = el === b;
+        el.classList.toggle('is-picked', on);
+        el.style.borderColor = on ? 'var(--accent)' : 'var(--border)';
+        el.style.background  = on ? 'var(--accent-soft)' : 'var(--bg-raised)';
+        const dot = el.firstElementChild;
+        if (dot) {
+          dot.style.borderColor = on ? 'var(--accent)' : 'var(--border)';
+          dot.style.background  = on ? 'var(--accent)' : 'transparent';
+          dot.style.color       = on ? '#fff' : 'var(--text-muted)';
+        }
+      });
+    });
+  },
+
+  /** Full-paper exam: answer EVERY question first (with back/forward and a
+   *  jump strip, answers preserved), then submit the whole exam for marking
+   *  in one go — like a real exam. No feedback or model answers mid-paper. */
+  _renderAIExamQuestion() {
+    const el    = document.getElementById('comp-content');
+    const total = this._session.length;
+    if (this._idx < 0) this._idx = 0;
+    if (this._idx >= total) this._idx = total - 1;
+    const item  = this._session[this._idx];
+    if (!item) return;
+    const saved  = this._answers[this._idx];
+    const answered = this._session.reduce((n, _, i) => n + (this._slotFilled(i) ? 1 : 0), 0);
+    const isLast = this._idx === total - 1;
+
+    const chips = this._session.map((_, i) => {
+      const has = this._slotFilled(i);
+      const cur = i === this._idx;
+      return `<button data-q="${i}" style="min-width:32px;padding:5px 0;border-radius:8px;font-family:var(--font-mono);font-size:11px;cursor:pointer;border:1px solid ${cur?'var(--accent)':'var(--border)'};background:${has?'var(--accent-soft)':'var(--bg-raised)'};color:${cur?'var(--accent)':has?'var(--accent)':'var(--text-muted)'};font-weight:${cur?'700':'400'};">${i+1}</button>`;
+    }).join('');
+
+    el.innerHTML = `
+      <div class="quiz-shell">
+        <div class="quiz-header">
+          <span class="quiz-counter">Question ${this._idx+1} of ${total}</span>
+          <span class="quiz-node-tag">${this._esc(item.node.title)}</span>
+        </div>
+        <div class="quiz-progress-track"><div class="quiz-progress-fill" style="width:${(answered/total)*100}%"></div></div>
+        <div id="ai-jump" style="display:flex;gap:6px;flex-wrap:wrap;margin:12px 0;">${chips}</div>
+        <p style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);margin-bottom:12px;">Answer the whole paper first — it is marked in one go when you submit at the end, like a real exam. Leave a question blank to skip it.</p>
+        <div class="quiz-card">
+          ${item.match ? this._matchCard(item.match, (saved && saved.letters) || []) : this._answerBlock(item.q, saved && saved.answer ? saved.answer : '')}
+          <div class="quiz-actions">
+            ${this._idx > 0 ? '<button class="btn-secondary" id="ai-prev">← Back</button>' : ''}
+            <button class="btn-primary" id="ai-next">${isLast ? '📤 Submit exam for marking' : 'Next →'}</button>
+          </div>
+        </div>
+      </div>`;
+
+    const saveCurrent = () => {
+      if (item.match) return;   // match slots are saved live on each tap
+      const ans = document.getElementById('ai-answer')?.value.trim() || '';
+      this._answers[this._idx] = { item, answer: ans, skipped: !ans };
+    };
+    if (item.match) this._wireMatch(this._idx, item);
+    else this._wireMatchTaps(item.q, 'ai-answer');
+    document.getElementById('ai-prev')?.addEventListener('click', () => { saveCurrent(); this._idx--; this._renderAIExamQuestion(); });
+    document.getElementById('ai-next')?.addEventListener('click', () => {
+      saveCurrent();
+      if (isLast) { this._finishAIExam(); }
+      else { this._idx++; this._renderAIExamQuestion(); }
+    });
+    document.getElementById('ai-jump')?.addEventListener('click', (e) => {
+      const c = e.target.closest('[data-q]');
+      if (!c) return;
+      saveCurrent();
+      this._idx = parseInt(c.dataset.q, 10);
+      this._renderAIExamQuestion();
+    });
+  },
+
+  async _finishAIExam() {
+    // Every slot gets an entry so the whole paper is accounted for.
+    this._session.forEach((item, i) => {
+      if (this._answers[i]) return;
+      this._answers[i] = item.match
+        ? { item, match: true, letters: item.match.prompts.map(() => ''), skipped: true }
+        : { item, answer: '', skipped: true };
+    });
+    // Count blanks: unassigned match pairs + skipped open questions.
+    let blank = 0;
+    this._session.forEach((item, i) => {
+      const a = this._answers[i];
+      if (item.match) blank += (a.letters || []).filter(l => !l).length;
+      else if (!a.answer) blank += 1;
+    });
+    if (blank > 0 && !confirm(blank + ' answer' + (blank === 1 ? ' is' : 's are') + ' blank. Submit the exam anyway?')) {
+      this._renderAIExamQuestion();
+      return;
+    }
+
+    // Grade match pairs on-device and DEFINITIVELY (a matching choice is either
+    // the right letter or it isn't — no AI credits, ever); send only genuinely
+    // open questions to the batched grader.
+    const finalGraded = [];
+    const openList = [], openPos = [];
+    this._session.forEach((item, i) => {
+      const a = this._answers[i];
+      if (item.match) {
+        const g = item.match;
+        g.prompts.forEach((p, k) => {
+          const L = (a.letters && a.letters[k]) || '';
+          const correctL = window.MatchGroup ? MatchGroup.correctLetter(g, p.answer) : null;
+          const correct  = !!(L && correctL && L === correctL);
+          finalGraded.push({
+            item: { q: { question: p.prompt, answer: p.answer }, node: item.node },
+            answer: L ? MatchGroup.answerFor(g, L) : '',
+            skipped: !L,
+            result: {
+              score: correct ? 100 : 0,
+              correct: L ? correct : false,
+              feedback: !L ? 'Skipped.' : correct ? 'Correct match. ⚡ No AI credits used.' : 'Not the right match.',
+              keyPointsMissed: [],
+            },
+          });
+        });
+      } else {
+        openPos.push(finalGraded.length);
+        finalGraded.push(null);
+        openList.push(a);
+      }
+    });
+
+    if (openList.length) {
+      const gradedOpen = await this._gradeAll(openList, 'Marking your exam…');
+      gradedOpen.forEach((g, j) => { finalGraded[openPos[j]] = g; });
+    }
+    this._renderGradedResults(finalGraded, 'AI Exam Results');
+  },
+
+  // ─── Shared results renderer ──────────────────────────
+
+  _renderGradedResults(graded, title) {
+    const el      = document.getElementById('comp-content');
+    const total   = graded.length;
+    const avg     = total ? Math.round(graded.reduce((s,a)=>s+(a.result?.score||0),0)/total) : 0;
+    const passed  = graded.filter(a=>(a.result?.score||0)>=70).length;
+    const grade   = this._grade(avg);
+
+    const rows = graded.map((a, i) => {
+      const score = a.result?.score || 0;
+      const color = score>=70?'var(--green)':score>=40?'var(--accent)':'var(--red)';
+      return `
+        <div style="background:var(--bg-raised);border:1px solid var(--border);border-left:3px solid ${color};border-radius:var(--radius-md);padding:14px 18px;margin-bottom:10px;">
+          <div style="display:flex;justify-content:space-between;align-items:flex-start;gap:12px;flex-wrap:wrap;margin-bottom:8px;">
+            <div style="font-family:var(--font-body);font-size:14px;color:var(--text-primary);flex:1;">${i+1}. ${window.KNText ? KNText.html(a.item.q.question) : this._esc(a.item.q.question)}</div>
+            <span style="font-family:var(--font-mono);font-size:13px;color:${color};font-weight:600;flex-shrink:0;">${score}/100</span>
+          </div>
+          ${a.skipped?'<span style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);">Skipped</span>':''}
+          ${!a.skipped&&a.answer?`<div style="font-family:var(--font-body);font-size:13px;color:var(--text-secondary);font-style:italic;margin-bottom:6px;">"${this._esc(a.answer.slice(0,120))}${a.answer.length>120?'…':''}"</div>`:''}
+          ${a.result?.feedback?`<div style="font-family:var(--font-body);font-size:13px;color:var(--text-primary);">${this._esc(a.result.feedback)}</div>`:''}
+          ${score<70&&a.item.q.answer?`<div style="margin-top:8px;padding-top:8px;border-top:1px solid var(--border-soft);font-family:var(--font-body);font-size:13px;color:var(--text-secondary);"><span style="font-family:var(--font-mono);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--green);">Model answer</span><br>${window.KNText?KNText.html(a.item.q.answer):this._esc(a.item.q.answer)}</div>`:''}
+        </div>`;
+    }).join('');
+
+    el.innerHTML = `
+      <div class="comp-overall-card" style="margin-bottom:24px;">
+        <div class="comp-overall-left">
+          <div class="comp-grade comp-grade-lg ${grade.cls}">${grade.letter}</div>
+          <div>
+            <div style="font-family:var(--font-ui);font-size:20px;font-weight:800;">${title}</div>
+            <div style="font-family:var(--font-mono);font-size:13px;color:var(--accent);">${avg}/100 average · ${passed}/${total} passed (≥70%)</div>
+          </div>
+        </div>
+        <button class="btn-secondary" id="comp-retry-btn">↺ Try Again</button>
+      </div>
+      <div class="notes-section-title">Question Breakdown</div>
+      ${rows}
+    `;
+    document.getElementById('comp-retry-btn').addEventListener('click', () => {
+      this._started = false; this.refresh();
+    });
+  },
+
+  // ─── Helpers ──────────────────────────────────────────
+
+  _grade(pct) {
+    if (pct >= 90) return { letter:'A+', label:'Outstanding',  cls:'grade-a-plus' };
+    if (pct >= 80) return { letter:'A',  label:'Excellent',    cls:'grade-a'      };
+    if (pct >= 70) return { letter:'B',  label:'Good',         cls:'grade-b'      };
+    if (pct >= 60) return { letter:'C',  label:'Satisfactory', cls:'grade-c'      };
+    if (pct >= 50) return { letter:'D',  label:'Needs Work',   cls:'grade-d'      };
+    return                { letter:'F',  label:'Critical Gap', cls:'grade-f'      };
+  },
+
+  _mockGrade(student, correct) {
+    const words  = correct.toLowerCase().split(/\s+/);
+    const hits   = words.filter(w => w.length>3 && student.toLowerCase().includes(w)).length;
+    const score  = Math.min(100, Math.round((hits / Math.max(words.length, 1)) * 130));
+    return {
+      correct:       score >= 60,
+      score,
+      feedback:      score>=70 ? 'Good answer — key concepts covered.' : score>=40 ? 'Partially correct. See model answer for gaps.' : 'Needs improvement. Review this topic carefully.',
+      keyPointsMissed: score < 70 ? ['See model answer above'] : [],
+    };
+  },
+
+  _esc: s => String(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'),
+};

--- a/knowledgenode/www/js/ui/CompetencyView.js
+++ b/knowledgenode/www/js/ui/CompetencyView.js
@@ -522,7 +522,7 @@ const CompetencyView = {
       `<button type="button" class="mp-opt" data-letter="${o.letter}"
         style="display:flex;align-items:flex-start;gap:10px;width:100%;text-align:left;padding:11px 13px;margin:5px 0;border-radius:11px;cursor:pointer;
         border:1.5px solid var(--border);background:var(--bg-elevated,var(--bg-raised));color:var(--text);font-size:14px;line-height:1.4;transition:border-color .12s,background .12s;">
-        <span style="flex:0 0 auto;display:inline-flex;align-items:center;justify-content:center;width:24px;height:24px;border-radius:50%;font-family:var(--font-mono);font-weight:700;font-size:12px;border:1.5px solid var(--border);color:var(--text-muted);">${o.letter}</span>
+        <span style="flex:0 0 auto;display:inline-flex;align-items:center;justify-content:center;min-width:28px;height:24px;padding:0 5px;border-radius:7px;font-family:var(--font-mono);font-weight:700;font-size:12px;border:1.5px solid var(--border);color:var(--text-muted);">${o.letter})</span>
         <span style="flex:1;padding-top:2px;">${this._esc(o.text)}</span></button>`).join('');
     const instr = group.instruction || 'Match each item on the left to the correct option below.';
     return `
@@ -596,8 +596,8 @@ const CompetencyView = {
         style="display:flex;align-items:flex-start;gap:10px;width:100%;text-align:left;padding:12px 14px;margin:6px 0;border-radius:12px;cursor:pointer;
         border:1.5px solid ${on ? 'var(--accent)' : 'var(--border)'};background:${on ? 'var(--accent-soft)' : 'var(--bg-raised)'};
         color:var(--text);font-size:15px;line-height:1.4;transition:border-color .12s,background .12s;">
-        <span style="flex:0 0 auto;display:inline-flex;align-items:center;justify-content:center;width:26px;height:26px;border-radius:50%;font-family:var(--font-mono);font-weight:700;font-size:13px;
-          border:1.5px solid ${on ? 'var(--accent)' : 'var(--border)'};background:${on ? 'var(--accent)' : 'transparent'};color:${on ? '#fff' : 'var(--text-muted)'};">${o.letter}</span>
+        <span style="flex:0 0 auto;display:inline-flex;align-items:center;justify-content:center;min-width:30px;height:26px;padding:0 5px;border-radius:8px;font-family:var(--font-mono);font-weight:700;font-size:13px;
+          border:1.5px solid ${on ? 'var(--accent)' : 'var(--border)'};background:${on ? 'var(--accent)' : 'transparent'};color:${on ? '#fff' : 'var(--text-muted)'};">${o.letter})</span>
         <span style="flex:1;padding-top:2px;">${this._esc(o.text)}</span></button>`;
     }).join('');
     return stemHtml

--- a/knowledgenode/www/js/ui/Dashboard.js
+++ b/knowledgenode/www/js/ui/Dashboard.js
@@ -1,0 +1,399 @@
+/**
+ * Dashboard.js v2 — Combined Progress + Study Plan view
+ * Shows: today's plan, stats, heatmap, subject mastery, quick actions
+ */
+const Dashboard = {
+  init() {},
+
+  refresh() {
+    const container = document.getElementById('dashboard-body');
+    if (!container) return;
+
+    const nodes  = nodeStore.getAll().filter(n => n.processingStatus === 'ready');
+    const streak = StreakTracker.getStats();
+    const plan   = PlanStore.getActive();
+
+    // Single-pass computation — avoids calling dueQuestions() and
+    // iterating sessionLog separately for stats, subjects, and weekly activity.
+    const now     = Date.now();
+    const weekAgo = now - 7 * 86400000;
+    const subjects = {};
+    const activeDays = new Set();
+    let totalMastery = 0, totalQuestions = 0, totalDue = 0;
+    let weekReviews = 0, weekSessions = 0;
+
+    // True single pass — compute subjects, mastery, due, and weekly activity together.
+    // dueQuestions() iterates srsState internally; we inline it here to avoid calling
+    // it twice (once in the loop, once in getStats which was already called above).
+    for (const n of nodes) {  // `now` already declared above
+      const subj = n.subject || 'Uncategorised';
+      // Inline due check: same logic as dueQuestions() but without creating an array
+      let due = 0;
+      for (const q of n.questions) {
+        const srs = n.srsState[q.id];
+        if (srs && srs.repetitions > 0 && srs.nextReview <= now) due++;
+      }
+      if (!subjects[subj]) subjects[subj] = { nodes:0, mastery:0, questions:0, due:0 };
+      subjects[subj].nodes++;
+      subjects[subj].mastery   += n.masteryScore;
+      subjects[subj].questions += n.questions.length;
+      subjects[subj].due       += due;
+      totalMastery   += n.masteryScore;
+      totalQuestions += n.questions.length;
+      totalDue       += due;
+      for (const ev of (n.sessionLog || [])) {
+        if (ev.ts && ev.ts >= weekAgo) {
+          activeDays.add(ev.date || new Date(ev.ts).toLocaleDateString());
+          if (ev.type === 'review' || ev.kind === 'review') weekReviews++;
+          else weekSessions++;
+        }
+      }
+    }
+
+    const stats = {
+      total:   nodes.length,
+      mastery: nodes.length ? Math.round(totalMastery / nodes.length) : 0,
+      due:     totalDue,
+    };
+
+    const subjectRows = Object.entries(subjects).map(([s, v]) => {
+      const avg = v.nodes ? Math.round(v.mastery / v.nodes) : 0;
+      return `
+        <div class="dash-subject-row">
+          <div class="dash-subject-name">${this._esc(s)}</div>
+          <div class="dash-subject-stats">
+            <span class="dash-pill">${v.nodes} nodes</span>
+            ${v.due > 0 ? `<span class="dash-pill due">${v.due} due</span>` : ''}
+          </div>
+          <div class="dash-subject-bar-wrap">
+            <div class="mastery-bar-track" style="height:5px;flex:1;">
+              <div class="mastery-bar-fill" style="width:${avg}%;height:5px;"></div>
+            </div>
+            <span style="font-family:var(--font-mono);font-size:11px;color:var(--accent);min-width:32px;text-align:right;">${avg}%</span>
+            <button class="dash-test-btn" onclick="CompetencyView.open('${this._esc(s)}')">🏆</button>
+            ${(typeof PastPaperDrill !== 'undefined' && PastPaperDrill.count(s)) ? `<button class="dash-test-btn" title="Practice real past-paper questions" onclick="PastPaperDrill.open('${this._esc(s)}')">📝</button>` : ''}
+          </div>
+        </div>`;
+    }).join('') || '<p style="color:var(--text-muted);font-family:var(--font-mono);font-size:13px;padding:12px 0;">No subjects yet.</p>';
+
+    // Today's plan section
+    const todaySection = plan ? this._renderTodayPlan(plan) : `
+      <div class="dash-no-plan">
+        <p>No active study plan.</p>
+        <button class="btn-primary" style="margin-top:12px;font-size:13px;" data-action="new-plan">+ Create Study Plan</button>
+      </div>`;
+
+    // ── Exam readiness — evidence-based, always shown once you have topics ──
+    // Uses the ExamReadiness engine (free, on-device): multi-signal score +
+    // prioritised next actions. Works with or without a study plan.
+    let readinessBanner = '';
+    if (typeof ExamReadiness !== 'undefined' && nodes.length) {
+      const r = ExamReadiness.assess(nodes, plan);
+      const toneColor = r.band.tone === 'good' ? 'var(--green,#4ade80)'
+                      : r.band.tone === 'low'  ? 'var(--red,#f87171)'
+                      : 'var(--accent)';
+      const countdown = r.daysToExam == null ? ''
+        : (r.daysToExam === 0 ? 'TODAY' : r.daysToExam + ' day' + (r.daysToExam===1?'':'s') + ' to go');
+      const chip = (label, val) => val == null ? '' :
+        `<div style="flex:1;min-width:64px;text-align:center;">
+           <div style="font-family:var(--font-mono);font-size:14px;font-weight:700;color:${val>=70?'var(--green,#4ade80)':val>=40?'var(--accent)':'var(--red,#f87171)'};">${val}%</div>
+           <div style="font-family:var(--font-mono);font-size:9px;text-transform:uppercase;letter-spacing:.06em;color:var(--text-muted);">${label}</div>
+         </div>`;
+      const actions = r.actions.map((a, i) =>
+        `<button class="dash-readiness-action" ${a.nodeId ? `data-open-node="${a.nodeId}"` : `data-readiness="${a.kind}"`}
+           style="display:flex;gap:10px;align-items:flex-start;width:100%;text-align:left;background:var(--bg-base);border:1px solid var(--border-soft);border-radius:10px;padding:10px 12px;margin-top:8px;cursor:pointer;color:var(--text-primary);font-family:var(--font-body);font-size:13px;line-height:1.5;">
+           <span style="color:${toneColor};font-weight:800;flex-shrink:0;">${i+1}.</span>
+           <span style="flex:1;">${this._esc(a.text)}</span>
+           ${a.lift > 0 ? `<span style="flex-shrink:0;font-family:var(--font-mono);font-size:10px;color:var(--text-muted);">+${a.lift}%</span>` : ''}
+         </button>`).join('');
+
+      readinessBanner = `
+        <div class="dash-section" style="border:1px solid ${toneColor};border-radius:var(--radius-lg);padding:16px 18px;background:var(--bg-raised);">
+          <div style="display:flex;align-items:baseline;justify-content:space-between;flex-wrap:wrap;gap:8px;margin-bottom:12px;">
+            <span style="font-family:var(--font-ui);font-size:15px;font-weight:800;color:var(--text-primary);">🎯 Exam Readiness · <span style="color:${toneColor};">${r.band.label}</span></span>
+            ${countdown ? `<span style="font-family:var(--font-mono);font-size:13px;color:${toneColor};font-weight:700;">${countdown}</span>` : ''}
+          </div>
+          <div style="display:flex;align-items:center;gap:10px;margin-bottom:12px;">
+            <div class="mastery-bar-track" style="height:8px;flex:1;">
+              <div class="mastery-bar-fill" style="width:${r.score}%;height:8px;background:${toneColor};"></div>
+            </div>
+            <span style="font-family:var(--font-mono);font-size:16px;color:${toneColor};font-weight:800;min-width:44px;text-align:right;">${r.score}%</span>
+          </div>
+          <div style="display:flex;gap:6px;margin-bottom:6px;padding:8px 4px;background:var(--bg-base);border-radius:10px;">
+            ${chip('Coverage', r.signals.coverage)}${chip('Mastery', r.signals.mastery)}${chip('Retention', r.signals.retention)}${chip('Exam fit', r.signals.alignment)}
+          </div>
+          <div style="font-family:var(--font-mono);font-size:10px;text-transform:uppercase;letter-spacing:.06em;color:var(--text-muted);margin:10px 0 2px;">Do these next — highest impact first</div>
+          ${actions}
+        </div>`;
+    }
+
+    const weekSection = `
+      <div class="dash-section">
+        <div class="dash-section-title" style="margin-bottom:14px;">📈 This Week</div>
+        <div class="dash-stats-row">
+          <div class="dash-stat-card">
+            <div class="dash-stat-val">${activeDays.size}</div>
+            <div class="dash-stat-label">Active Days</div>
+          </div>
+          <div class="dash-stat-card">
+            <div class="dash-stat-val">${weekReviews + weekSessions}</div>
+            <div class="dash-stat-label">Study Events</div>
+          </div>
+          <div class="dash-stat-card">
+            <div class="dash-stat-val">${streak.longest}</div>
+            <div class="dash-stat-label">Best Streak</div>
+          </div>
+        </div>
+        <div style="margin-top:14px;">${StreakTracker.buildHeatmap ? StreakTracker.buildHeatmap() : ''}</div>
+      </div>`;
+
+    container.innerHTML = `
+      ${readinessBanner}
+      <!-- ASK YOUR COACH -->
+      <button class="coach-cta" data-action="open-coach">
+        <span class="coach-cta-orb">⬡</span>
+        <span class="coach-cta-text"><strong>Ask your study coach</strong><span>Where should I start? What's weak? How do I use my time?</span></span>
+        <span class="coach-cta-arrow">→</span>
+      </button>
+      <!-- TODAY'S PLAN -->
+      <div class="dash-section">
+        <div class="dash-section-title" style="display:flex;align-items:center;justify-content:space-between;margin-bottom:14px;">
+          <span>📅 Today's Study Plan</span>
+          ${plan ? `<div style="display:flex;gap:8px;">
+            <button class="btn-secondary" style="font-size:11px;padding:6px 12px;" data-action="studyplan">Full Plan →</button>
+            <button class="btn-secondary" style="font-size:11px;padding:6px 12px;" data-action="new-plan">New Plan</button>
+          </div>` : ''}
+        </div>
+        ${todaySection}
+      </div>
+
+      <!-- STATS ROW -->
+      <div class="dash-stats-row">
+        <div class="dash-stat-card accent">
+          <div class="dash-stat-icon"><span class="streak-fire">📅</span></div>
+          <div class="dash-stat-val"><span class="streak-count">${streak.streak}</span></div>
+          <div class="dash-stat-label">Day Streak</div>
+        </div>
+        <div class="dash-stat-card">
+          <div class="dash-stat-val">${stats.total}</div>
+          <div class="dash-stat-label">Total Nodes</div>
+        </div>
+        <div class="dash-stat-card">
+          <div class="dash-stat-val">${stats.mastery}%</div>
+          <div class="dash-stat-label">Avg Mastery</div>
+        </div>
+        <div class="dash-stat-card ${stats.due > 0 ? 'warn' : ''}">
+          <div class="dash-stat-val">${stats.due}</div>
+          <div class="dash-stat-label">Cards Due</div>
+        </div>
+        <div class="dash-stat-card">
+          <div class="dash-stat-val">${nodes.reduce((s,n)=>s+n.questions.length,0)}</div>
+          <div class="dash-stat-label">Questions</div>
+        </div>
+        <div class="dash-stat-card">
+          <div class="dash-stat-val">${streak.longest}</div>
+          <div class="dash-stat-label">Best Streak</div>
+        </div>
+      </div>
+
+      <!-- HEATMAP -->
+      <div class="dash-section">
+        <div class="dash-section-title">Study Activity — Last 12 Weeks</div>
+        ${StreakTracker.buildHeatmap()}
+      </div>
+
+      <!-- THIS WEEK -->
+      ${nodes.length ? weekSection : ''}
+
+      <!-- SUBJECTS -->
+      ${nodes.length ? `
+      <div class="dash-section">
+        <div class="dash-section-title">Mastery by Subject</div>
+        ${subjectRows}
+      </div>
+
+      <!-- DONUT -->
+      <div class="dash-section">
+        <div class="dash-section-title">Mastery Distribution</div>
+        <canvas id="mastery-donut" width="200" height="200" style="display:block;margin:0 auto;max-width:200px;"></canvas>
+        <div class="dash-legend" id="donut-legend"></div>
+      </div>` : ''}
+
+      <!-- QUICK ACTIONS -->
+      <div class="dash-section">
+        <div class="dash-section-title">Quick Actions</div>
+        <div style="display:flex;gap:10px;flex-wrap:wrap;">
+          <button class="btn-primary" data-action="start-review" style="font-size:13px;">↺ Start Review</button>
+          <button class="btn-secondary" data-action="upload" style="font-size:13px;">↑ Upload Notes</button>
+          <button class="btn-secondary" data-action="new-plan" style="font-size:13px;">📅 New Plan</button>
+        </div>
+      </div>
+    `;
+
+    // double-rAF guarantees canvas is in the painted DOM before drawing
+    if (nodes.length) requestAnimationFrame(() => requestAnimationFrame(() => this._drawDonut(nodes)));
+    StreakTracker.render();
+
+    // Single event delegation — prevents listener stacking on every refresh.
+    // Set once on the stable container element, never re-bound.
+    if (!this._delegated) {
+      this._delegated = true;
+      container.addEventListener('change', e => {
+        const cb = e.target.closest('.task-check');
+        if (!cb) return;
+        const activePlan = PlanStore.getActive();
+        if (!activePlan) return;
+        const day  = activePlan.days.find(d => d.date === cb.dataset.dayDate);
+        const task = day?.tasks.find(t => t.id === cb.dataset.taskId);
+        if (task) {
+          task.done   = cb.checked;
+          task.doneAt = cb.checked ? Date.now() : null;
+          PlanStore.save(activePlan);
+          if (cb.checked) StreakTracker.recordActivity();
+          this.refresh();
+        }
+      });
+      container.addEventListener('click', e => {
+        const launchBtn = e.target.closest('.task-launch-btn');
+        if (launchBtn) {
+          const { nodeId, activity } = launchBtn.dataset;
+          if (nodeId?.startsWith('competency_')) {
+            CompetencyView.open(nodeId.replace('competency_', ''));
+          } else if (nodeId) {
+            NodeDetailView.open(nodeId);
+            if (activity === 'recall' || activity === 'application') {
+              setTimeout(() => {
+                NodeDetailView._currentSection = 'questions';
+                document.querySelectorAll('.detail-nav-btn').forEach((b,i) => b.classList.toggle('active', i===1));
+                NodeDetailView._renderSection();
+              }, 150);
+            }
+          }
+          return;
+        }
+        const compBtn = e.target.closest('[data-competency]');
+        if (compBtn) { CompetencyView.open(compBtn.dataset.competency); return; }
+        // Exam-readiness action rows: open the named topic, or route by kind.
+        const openNode = e.target.closest('[data-open-node]');
+        if (openNode) { if (typeof NodeDetailView !== 'undefined') NodeDetailView.open(openNode.dataset.openNode); return; }
+        const rd = e.target.closest('[data-readiness]');
+        if (rd) {
+          ({ start:  () => App.navigateTo('library'),
+             review: () => App.navigateTo('review'),
+             drill:  () => App.navigateTo('review'),
+             add:    () => App.navigateTo('upload'),
+             maintain: () => App.navigateTo('review'),
+          })[rd.dataset.readiness]?.();
+          return;
+        }
+        const action = e.target.closest('[data-action]')?.dataset.action;
+        if (!action) return;
+        ({ 'open-coach': () => StudyCoach.open(),
+           'create-plan': () => StudyPlanBuilder.open(),
+           'new-plan': () => StudyPlanBuilder.open(),
+           'start-review': () => App.navigateTo('review'),
+           'upload': () => App.navigateTo('upload'),
+           'studyplan': () => App.navigateTo('studyplan'),
+        })[action]?.();
+      });
+    }
+  },
+
+  _renderTodayPlan(plan) {
+    const today     = StudyPlan._dateStr(new Date());
+    const todayPlan = plan.days.find(d => d.date === today);
+    const daysLeft  = plan.daysRemaining;
+    const pct       = plan.progressPct;
+
+    const planHeader = `
+      <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:12px;flex-wrap:wrap;gap:8px;">
+        <div>
+          <div style="font-family:var(--font-ui);font-size:14px;font-weight:700;color:var(--text-primary);">${this._esc(plan.title)}</div>
+          <div style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);">${daysLeft} days to exam · ${pct}% complete</div>
+        </div>
+        <div class="progress-track" style="width:120px;height:5px;">
+          <div class="progress-fill" style="width:${pct}%;height:5px;"></div>
+        </div>
+      </div>`;
+
+    if (!todayPlan || !todayPlan.tasks.length) {
+      return planHeader + `<div style="font-family:var(--font-mono);font-size:13px;color:var(--text-muted);padding:12px 0;">No tasks scheduled for today. 🎉</div>`;
+    }
+
+    const actIcon = t => ({ review:'📖', recall:'🔁', application:'🧩', summary:'📝', lecture:'🎓', competency:'🏆' }[t] || '📌');
+    const tasks = todayPlan.tasks.map(task => `
+      <div class="plan-task ${task.done ? 'done' : ''}">
+        <input type="checkbox" class="task-check"
+               data-day-date="${todayPlan.date}" data-task-id="${task.id}"
+               ${task.done ? 'checked' : ''}
+               style="accent-color:var(--accent);width:18px;height:18px;flex-shrink:0;cursor:pointer;"/>
+        <div style="flex:1;min-width:0;">
+          <div style="font-family:var(--font-ui);font-size:13px;font-weight:600;
+               color:${task.done ? 'var(--text-muted)' : 'var(--text-primary)'};
+               ${task.done ? 'text-decoration:line-through;' : ''}">
+            ${actIcon(task.activityType)} ${this._esc(task.nodeTitle)}
+          </div>
+          <div style="font-family:var(--font-mono);font-size:10px;color:var(--text-muted);">
+            ${task.activityType} · ${task.estimatedMins} min
+          </div>
+        </div>
+        ${!task.done ? `
+          <button class="task-launch-btn btn-secondary"
+                  data-node-id="${task.nodeId}" data-activity="${task.activityType}"
+                  style="font-size:11px;padding:5px 10px;flex-shrink:0;">
+            ${task.nodeId?.startsWith('competency_') ? '🏆 Test' : 'Open'}
+          </button>` : '<span style="color:var(--green);font-size:16px;">✓</span>'}
+      </div>`).join('');
+
+    const done  = todayPlan.tasks.filter(t=>t.done).length;
+    const total = todayPlan.tasks.length;
+    return planHeader + `
+      <div style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);margin-bottom:10px;">
+        ${done}/${total} tasks · ${todayPlan.totalMins} min total
+      </div>
+      <div style="display:flex;flex-direction:column;">${tasks}</div>`;
+  },
+
+  _drawDonut(nodes) {
+    const canvas = document.getElementById('mastery-donut');
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    const cx = 100, cy = 100, r = 80, inner = 52;
+    const bands = [
+      { label:'New (0%)',        color:'#2a2e38', count:0 },
+      { label:'Learning 1–40%', color:'#f0615a', count:0 },
+      { label:'Good 41–79%',    color:'#f0a500', count:0 },
+      { label:'Mastered 80%+',  color:'#3ecf82', count:0 },
+    ];
+    nodes.forEach(n => {
+      if (n.masteryScore === 0)      bands[0].count++;
+      else if (n.masteryScore <= 40) bands[1].count++;
+      else if (n.masteryScore <= 79) bands[2].count++;
+      else                           bands[3].count++;
+    });
+    const total = nodes.length;
+    let angle   = -Math.PI / 2;
+    ctx.clearRect(0, 0, 200, 200);
+    bands.forEach(b => {
+      if (!b.count) return;
+      const slice = (b.count / total) * Math.PI * 2;
+      ctx.beginPath(); ctx.moveTo(cx, cy);
+      ctx.arc(cx, cy, r, angle, angle + slice);
+      ctx.closePath(); ctx.fillStyle = b.color; ctx.fill();
+      angle += slice;
+    });
+    const bg = document.documentElement.classList.contains('light-theme') ? '#f0f2f5' : '#080a0d';
+    ctx.beginPath(); ctx.arc(cx, cy, inner, 0, Math.PI*2);
+    ctx.fillStyle = bg; ctx.fill();
+    ctx.fillStyle = '#f0a500';
+    ctx.font = 'bold 18px DM Mono, monospace';
+    ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
+    ctx.fillText(Math.round(nodes.reduce((s,n)=>s+n.masteryScore,0)/total)+'%', cx, cy);
+    const legend = document.getElementById('donut-legend');
+    if (legend) legend.innerHTML = bands.filter(b=>b.count).map(b =>
+      `<div class="dash-legend-item"><span style="background:${b.color};width:10px;height:10px;border-radius:2px;display:inline-block;"></span>${b.label} (${b.count})</div>`
+    ).join('');
+  },
+
+  _esc: s => String(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'),
+};

--- a/knowledgenode/www/js/ui/Dashboard.js
+++ b/knowledgenode/www/js/ui/Dashboard.js
@@ -27,9 +27,11 @@ const Dashboard = {
     // it twice (once in the loop, once in getStats which was already called above).
     for (const n of nodes) {  // `now` already declared above
       const subj = n.subject || 'Uncategorised';
-      // Inline due check: same logic as dueQuestions() but without creating an array
+      // Inline due check: same logic as dueQuestions() but without creating an
+      // array. Full calculations are exam material and never served by review,
+      // so they must not be counted as due here either.
       let due = 0;
-      for (const q of n.questions) {
+      for (const q of n.reviewableQuestions()) {
         const srs = n.srsState[q.id];
         if (srs && srs.repetitions > 0 && srs.nextReview <= now) due++;
       }

--- a/knowledgenode/www/js/ui/Guide.js
+++ b/knowledgenode/www/js/ui/Guide.js
@@ -1,0 +1,288 @@
+/**
+ * Guide.js — In-app comprehensive guide
+ *
+ * The first-run tour (Onboarding.showTour) stays short on purpose.
+ * This is the *full* reference: opened on demand from Settings, the
+ * More menu, the header "how it works" link, and the welcome screen.
+ *
+ * Renders a full-screen scrollable overlay that reuses the app's
+ * existing CSS custom properties (--accent, --bg-*, --font-*), so it
+ * always matches the active theme. Styles are scoped under
+ * #kng-guide-overlay and injected once.
+ *
+ * Public API:
+ *   Guide.open()   — show the guide
+ *   Guide.close()  — hide it
+ */
+
+const Guide = {
+  _stylesInjected: false,
+
+  open() {
+    if (document.getElementById('kng-guide-overlay')) return;
+    this._injectStyles();
+
+    const ov = document.createElement('div');
+    ov.id = 'kng-guide-overlay';
+    ov.setAttribute('data-kn-overlay', '');
+    ov.setAttribute('data-kn-close', '#kng-guide-close');
+    ov.setAttribute('role', 'dialog');
+    ov.setAttribute('aria-label', 'KnowledgeNode guide');
+    ov.innerHTML = `
+      <div class="kng-bar">
+        <div class="kng-bar-title"><span class="kng-hex">⬡</span> The Complete Guide</div>
+        <button class="kng-close" id="kng-guide-close" aria-label="Close guide">✕</button>
+      </div>
+      <div class="kng-scroll">${this._content()}</div>`;
+    document.body.appendChild(ov);
+    // Background scroll is locked automatically by ScrollLock (detects #kng-guide-overlay).
+
+    const close = () => this.close();
+    document.getElementById('kng-guide-close')?.addEventListener('click', close);
+    this._escHandler = (e) => { if (e.key === 'Escape') close(); };
+    document.addEventListener('keydown', this._escHandler);
+
+    // Smooth-scroll the inner anchors
+    ov.querySelectorAll('[data-jump]').forEach(b => {
+      b.addEventListener('click', () => {
+        const t = ov.querySelector('#' + b.dataset.jump);
+        if (t) t.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      });
+    });
+  },
+
+  close() {
+    const ov = document.getElementById('kng-guide-overlay');
+    if (!ov) return;
+    ov.style.opacity = '0';
+    if (this._escHandler) document.removeEventListener('keydown', this._escHandler);
+    setTimeout(() => ov.remove(), 200);
+  },
+
+  /* ───────────────────────── content ───────────────────────── */
+  _content() {
+    return `
+    <div class="kng-wrap">
+
+      <header class="kng-hero">
+        <div class="kng-mark"><span>K</span></div>
+        <div class="kng-eyebrow">Study smarter · remember more</div>
+        <h1 class="kng-h1">How KnowledgeNode works</h1>
+        <p class="kng-lede">Everything the app does — and how to use it from your very first note.</p>
+      </header>
+
+      <div class="kng-thesis">
+        <p><span class="kng-dim">Most students re-read and highlight. It feels productive but barely builds memory.</span> KnowledgeNode is built on one finding research keeps confirming: <strong class="kng-acc">you learn by retrieving, not reviewing.</strong> Every feature exists to make you pull knowledge out of your head before you ever see the answer.</p>
+      </div>
+
+      <!-- 01 -->
+      <section class="kng-sec" id="kng-loop">
+        <div class="kng-shead"><span class="kng-num">01</span><h2>The study loop</h2></div>
+        <p class="kng-sub">One method, repeated. The engine under everything else.</p>
+        <div class="kng-loop">
+          <div class="kng-lstep"><span class="kng-lic">📖</span><span class="kng-llb">Read</span></div>
+          <div class="kng-lstep"><span class="kng-lic">💡</span><span class="kng-llb">Understand</span></div>
+          <div class="kng-lstep"><span class="kng-lic">✍</span><span class="kng-llb">Recall</span></div>
+          <div class="kng-lstep"><span class="kng-lic">❓</span><span class="kng-llb">Test</span></div>
+          <div class="kng-lstep kng-acc-step"><span class="kng-lic">🔁</span><span class="kng-llb">Repeat</span></div>
+        </div>
+        <p>You don't have to memorise it — the app walks you through it. But it explains why KnowledgeNode keeps asking you to <strong>write before you read</strong>, and why some cards vanish for days while others keep returning.</p>
+      </section>
+
+      <!-- 02 -->
+      <section class="kng-sec">
+        <div class="kng-shead"><span class="kng-num">02</span><h2>Three steps to get started</h2></div>
+        <p class="kng-sub">A checklist at the bottom of the screen tracks these until all three are done.</p>
+        <div class="kng-steps">
+          <div class="kng-step"><div class="kng-sn">1</div><div><div class="kng-st">Add your first notes</div><div class="kng-sd">Photograph a page, drag in a PDF, or type. The AI builds your first <strong>node</strong>. Scan <strong>one topic at a time</strong> — e.g. "Gross Income" as one node, not a whole module.</div></div></div>
+          <div class="kng-step"><div class="kng-sn">2</div><div><div class="kng-st">Set your exam date</div><div class="kng-sd">Open <strong>Study Plan</strong> and enter your deadline. The app builds a day-by-day schedule backward from it, balancing new topics against review.</div></div></div>
+          <div class="kng-step"><div class="kng-sn">3</div><div><div class="kng-st">Do your first study session</div><div class="kng-sd">Tap <strong>Study</strong> and follow the guided flow — Orient → Read → Recall → Practice. That's the whole loop, on rails.</div></div></div>
+        </div>
+      </section>
+
+      <!-- 03 -->
+      <section class="kng-sec">
+        <div class="kng-shead"><span class="kng-num">03</span><h2>Getting around</h2></div>
+        <p class="kng-sub">Six destinations. The bottom bar holds the daily ones; the rest live under More (≡).</p>
+        <div class="kng-grid">
+          <div class="kng-card"><div class="kng-ct"><span>↑</span>Add Notes</div><p>Turn a photo, PDF, or text into a structured node.</p></div>
+          <div class="kng-card"><div class="kng-ct"><span>▶</span>Study Session</div><p>The guided loop for whatever you should learn next.</p></div>
+          <div class="kng-card"><div class="kng-ct"><span>↺</span>Review</div><p>Spaced-repetition cards — only what's due today.</p></div>
+          <div class="kng-card"><div class="kng-ct"><span>⊞</span>Library</div><p>Every node. Open one to read, edit, reshape, or print.</p></div>
+          <div class="kng-card"><div class="kng-ct"><span>📅</span>Study Plan</div><p>Exam countdown, schedule, and competency by topic.</p></div>
+          <div class="kng-card"><div class="kng-ct"><span>◉</span>Progress</div><p>Mastery, streak, and where your weak spots hide.</p></div>
+        </div>
+      </section>
+
+      <!-- 04 -->
+      <section class="kng-sec">
+        <div class="kng-shead"><span class="kng-num">04</span><h2>Inside a node</h2></div>
+        <p class="kng-sub">The AI doesn't dump text — it pulls your notes into the pieces you actually study.</p>
+        <div class="kng-rows">
+          <div class="kng-row"><span class="kng-ric">📖</span><div><div class="kng-rt">Definitions, formulas, tables &amp; procedures</div><div class="kng-rd">Terms with examples, formulas with constraints, step-by-step procedures and tables — kept faithful to your source.</div></div></div>
+          <div class="kng-row"><span class="kng-ric">⚠️</span><div><div class="kng-rt">Common mistakes &amp; summary</div><div class="kng-rd">The traps on this topic, plus a tight summary to skim before an exam.</div></div></div>
+          <div class="kng-row"><span class="kng-ric">❓</span><div><div class="kng-rt">Auto-generated questions</div><div class="kng-rd">Recall questions (from the material) and application questions (use it somewhere new) for every node.</div></div></div>
+          <div class="kng-row"><span class="kng-ric">🛡️</span><div><div class="kng-rt">Faithfulness check</div><div class="kng-rd">If the AI adds anything not grounded in your source it <strong>flags it</strong> rather than inventing facts — and never silently deletes your content.</div></div></div>
+          <div class="kng-row"><span class="kng-ric">🎓</span><div><div class="kng-rt">Your level</div><div class="kng-rd">Primary, High School, College, or Professional — same content, explained at your depth.</div></div></div>
+          <div class="kng-row"><span class="kng-ric">🗂️</span><div><div class="kng-rt">Note templates</div><div class="kng-rd">Switch any node between <strong>Standard, Cornell, Outline, or Feynman</strong> — the AI rewrites it in place.</div></div></div>
+        </div>
+        <div class="kng-tip"><span class="kng-tk">Select to act</span><p>Highlight text in a node and a toolbar appears: make a <strong>Question</strong>, <strong>Recall</strong> or <strong>Apply</strong> card, add a <strong>Definition</strong>, <strong>Mark</strong> it, or <strong>Correct the AI</strong>.</p></div>
+      </section>
+
+      <!-- 05 -->
+      <section class="kng-sec">
+        <div class="kng-shead"><span class="kng-num">05</span><h2>Ways to study</h2></div>
+        <p class="kng-sub">A guided session strings these together, but each is worth knowing.</p>
+        <div class="kng-rows">
+          <div class="kng-row"><span class="kng-ric">🧭</span><div><div class="kng-rt">Guided session</div><div class="kng-rd">The full loop on rails — Orient → Read → Recall → Practice. Keep tapping forward.</div></div></div>
+          <div class="kng-row"><span class="kng-ric">✍</span><div><div class="kng-rt">Blank recall</div><div class="kng-rd">Write everything you remember <em>before</em> seeing the notes. That effort is where memory is built.</div></div></div>
+          <div class="kng-row"><span class="kng-ric">💡</span><div><div class="kng-rt">Understanding check</div><div class="kng-rd">Quick questions that confirm a concept clicked before you move on.</div></div></div>
+          <div class="kng-row"><span class="kng-ric">🎙️</span><div><div class="kng-rt">Lecture mode</div><div class="kng-rd">The AI writes a flowing, plain-language lecture on the node — like a tutor talking it through.</div></div></div>
+          <div class="kng-row"><span class="kng-ric">🗣️</span><div><div class="kng-rt">Socratic tutor</div><div class="kng-rd">Instead of answers, it asks the questions that lead you to the answer yourself.</div></div></div>
+          <div class="kng-row"><span class="kng-ric">↺</span><div><div class="kng-rt">Review (spaced repetition)</div><div class="kng-rd">SM-2 decides when each card returns. Rate how it felt; the app handles the timing.</div></div></div>
+        </div>
+        <div class="kng-ratings">
+          <div class="kng-rate"><span class="kng-dot" style="background:var(--red)"></span><b>Again</b> — forgot, comes back soon</div>
+          <div class="kng-rate"><span class="kng-dot" style="background:var(--accent)"></span><b>Hard</b> — shaky, short interval</div>
+          <div class="kng-rate"><span class="kng-dot" style="background:var(--blue)"></span><b>Good</b> — got it, interval grows</div>
+          <div class="kng-rate"><span class="kng-dot" style="background:var(--green)"></span><b>Easy</b> — instant, fades out</div>
+        </div>
+      </section>
+
+      <!-- 06 -->
+      <section class="kng-sec">
+        <div class="kng-shead"><span class="kng-num">06</span><h2>Let the AI take the wheel</h2></div>
+        <p class="kng-sub">When you don't want to decide what to study, hand it over — both under More (≡).</p>
+        <div class="kng-grid">
+          <div class="kng-card"><div class="kng-ct"><span>⬡</span>AI Director</div><p>Reads your whole library, weighs your exam date and weak spots, and dictates what to study today.</p></div>
+          <div class="kng-card"><div class="kng-ct"><span>💬</span>Study coach</div><p>Ask anything — "what should I do with 20 minutes?", "am I on track?" It knows your progress.</p></div>
+        </div>
+        <div class="kng-rows" style="margin-top:14px">
+          <div class="kng-row"><span class="kng-ric">🧩</span><div><div class="kng-rt">Adaptive blocks</div><div class="kng-rd">Restructures a topic into the best mix of study blocks for how you learn it — more practice where you're weak.</div></div></div>
+          <div class="kng-row"><span class="kng-ric">🌱</span><div><div class="kng-rt">Reactive reshaping</div><div class="kng-rd">Struggling mid-review? The node grows a simpler scaffold and an easier question on the spot.</div></div></div>
+        </div>
+      </section>
+
+      <!-- 07 -->
+      <section class="kng-sec">
+        <div class="kng-shead"><span class="kng-num">07</span><h2>Your data &amp; setup</h2></div>
+        <p class="kng-sub">Everything stays on your device. A few things worth knowing.</p>
+        <div class="kng-rows">
+          <div class="kng-row"><span class="kng-ric">💾</span><div><div class="kng-rt">Stored in your browser</div><div class="kng-rd">Your nodes live in this browser only — nothing uploaded to an account. Rolling backups happen as you go.</div></div></div>
+          <div class="kng-row"><span class="kng-ric">📤</span><div><div class="kng-rt">Backup &amp; moving devices</div><div class="kng-rd">No auto-sync. Use <strong>Settings → Export</strong> for a JSON file, then <strong>Import</strong> it elsewhere to carry everything over.</div></div></div>
+          <div class="kng-row"><span class="kng-ric">🤖</span><div><div class="kng-rt">How AI is powered</div><div class="kng-rd">Works out of the box if a key ships with the app. Otherwise add your own in <strong>Settings → Configure AI</strong> (kept in your browser). No key? A full <strong>demo mode</strong> still lets you explore.</div></div></div>
+          <div class="kng-row"><span class="kng-ric">📶</span><div><div class="kng-rt">Offline · timer · streak · themes</div><div class="kng-rd">Installable and usable offline, with a built-in study timer, a streak, and a light/dark theme toggle — all under More.</div></div></div>
+        </div>
+      </section>
+
+      <!-- 08 -->
+      <section class="kng-sec">
+        <div class="kng-shead"><span class="kng-num">08</span><h2>Quick answers</h2></div>
+        <details><summary>How big should one node be?</summary><div class="kng-ans">One topic — about what a single sub-heading covers. Small nodes are easier to recall, schedule, and master.</div></details>
+        <details><summary>What do I do each day?</summary><div class="kng-ans">Open <strong>Study Session</strong> for new material and <strong>Review</strong> for what's due. Or tap <strong>AI Director</strong> and follow its plan. Ten focused minutes beats an hour of re-reading.</div></details>
+        <details><summary>Why write before seeing the answer?</summary><div class="kng-ans">Trying to retrieve — even failing — is what cements memory. Reading first feels easier but teaches little. Trust the struggle.</div></details>
+        <details><summary>The AI got something wrong — can I fix it?</summary><div class="kng-ans">Yes. Highlight the text and tap <strong>Correct AI</strong>, or edit the node in the Library. Your corrections stick.</div></details>
+        <details><summary>Will I lose my work?</summary><div class="kng-ans">It saves continuously in your browser. Before clearing data or switching devices, run <strong>Settings → Export</strong> for a backup.</div></details>
+      </section>
+
+      <footer class="kng-foot">
+        <div class="kng-fhex">⬡</div>
+        <p>Add a node · set your date · study the loop. That's it.</p>
+      </footer>
+
+    </div>`;
+  },
+
+  /* ───────────────────────── styles ───────────────────────── */
+  _injectStyles() {
+    if (this._stylesInjected) return;
+    this._stylesInjected = true;
+    const css = `
+#kng-guide-overlay{position:fixed;inset:0;z-index:100000;background:var(--bg-base);display:flex;flex-direction:column;transition:opacity .2s ease;animation:kng-fade .25s ease;
+  padding:env(safe-area-inset-top) env(safe-area-inset-right) 0 env(safe-area-inset-left);}
+@keyframes kng-fade{from{opacity:0}to{opacity:1}}
+#kng-guide-overlay .kng-bar{flex:none;display:flex;align-items:center;justify-content:space-between;
+  padding:14px 18px;border-bottom:1px solid var(--border);background:var(--bg-surface);}
+#kng-guide-overlay .kng-bar-title{font-family:var(--font-ui);font-weight:700;font-size:15px;color:var(--text-primary);display:flex;align-items:center;gap:8px;}
+#kng-guide-overlay .kng-hex{color:var(--accent);font-size:16px;}
+#kng-guide-overlay .kng-close{background:transparent;border:1px solid var(--border);color:var(--text-secondary);
+  width:34px;height:34px;border-radius:9px;font-size:15px;cursor:pointer;line-height:1;transition:all .15s;}
+#kng-guide-overlay .kng-close:hover{border-color:var(--border-bright);color:var(--text-primary);}
+#kng-guide-overlay .kng-scroll{flex:1;overflow-y:auto;-webkit-overflow-scrolling:touch;padding-bottom:env(safe-area-inset-bottom);}
+#kng-guide-overlay .kng-wrap{max-width:680px;margin:0 auto;padding:0 22px;font-family:var(--font-body);color:var(--text-primary);line-height:1.7;font-size:16px;}
+
+#kng-guide-overlay .kng-hero{text-align:center;padding:42px 0 14px;}
+#kng-guide-overlay .kng-mark{width:52px;height:52px;margin:0 auto 18px;background:var(--accent);border-radius:13px;
+  display:flex;align-items:center;justify-content:center;box-shadow:0 6px 22px var(--accent-glow);
+  font-family:var(--font-ui);font-weight:900;font-size:24px;color:#000;}
+#kng-guide-overlay .kng-eyebrow{font-family:var(--font-mono);font-size:10.5px;font-weight:700;letter-spacing:.16em;text-transform:uppercase;color:var(--accent);margin-bottom:12px;}
+#kng-guide-overlay .kng-h1{font-family:var(--font-ui);font-weight:900;letter-spacing:-.02em;font-size:clamp(28px,7vw,40px);line-height:1.08;margin-bottom:12px;}
+#kng-guide-overlay .kng-lede{color:var(--text-secondary);font-style:italic;font-size:16.5px;max-width:34ch;margin:0 auto;}
+
+#kng-guide-overlay .kng-thesis{border:1px solid var(--border);border-radius:18px;background:linear-gradient(180deg,var(--bg-raised),var(--bg-surface));padding:22px 20px;margin-top:14px;}
+#kng-guide-overlay .kng-thesis p{font-size:16.5px;}
+#kng-guide-overlay .kng-dim{color:var(--text-muted);}
+#kng-guide-overlay .kng-acc{color:var(--accent-light);font-family:var(--font-ui);font-weight:700;}
+
+#kng-guide-overlay .kng-sec{padding:38px 0 2px;}
+#kng-guide-overlay .kng-shead{display:flex;align-items:baseline;gap:12px;}
+#kng-guide-overlay .kng-num{font-family:var(--font-mono);font-size:12px;font-weight:700;color:var(--accent);border:1px solid var(--accent-dim);border-radius:6px;padding:2px 7px;flex:none;}
+#kng-guide-overlay h2{font-family:var(--font-ui);font-weight:800;font-size:clamp(21px,5.5vw,27px);letter-spacing:-.01em;line-height:1.15;}
+#kng-guide-overlay .kng-sub{color:var(--text-secondary);font-style:italic;margin:6px 0 20px;font-size:15.5px;}
+#kng-guide-overlay p+p{margin-top:12px;}
+#kng-guide-overlay strong{color:var(--text-primary);font-weight:700;}
+
+#kng-guide-overlay .kng-loop{display:flex;gap:7px;flex-wrap:wrap;justify-content:center;margin:18px 0 18px;}
+#kng-guide-overlay .kng-lstep{flex:1 1 78px;min-width:74px;text-align:center;border:1px solid var(--border);border-radius:10px;background:var(--bg-card);padding:13px 6px;}
+#kng-guide-overlay .kng-lic{font-size:21px;display:block;margin-bottom:6px;}
+#kng-guide-overlay .kng-llb{font-family:var(--font-ui);font-size:12px;font-weight:700;}
+#kng-guide-overlay .kng-acc-step{border-color:var(--accent-dim);background:var(--accent-soft);}
+#kng-guide-overlay .kng-acc-step .kng-llb{color:var(--accent-light);}
+
+#kng-guide-overlay .kng-steps{display:flex;flex-direction:column;gap:15px;}
+#kng-guide-overlay .kng-step{display:flex;gap:14px;align-items:flex-start;}
+#kng-guide-overlay .kng-sn{flex:none;width:32px;height:32px;border-radius:9px;background:var(--accent);color:#000;font-family:var(--font-ui);font-weight:900;font-size:15px;display:flex;align-items:center;justify-content:center;box-shadow:0 4px 14px var(--accent-glow);}
+#kng-guide-overlay .kng-st{font-family:var(--font-ui);font-weight:700;font-size:16px;margin-bottom:2px;}
+#kng-guide-overlay .kng-sd{color:var(--text-secondary);font-size:15px;}
+
+#kng-guide-overlay .kng-grid{display:grid;grid-template-columns:1fr 1fr;gap:12px;}
+#kng-guide-overlay .kng-card{border:1px solid var(--border);border-radius:10px;background:var(--bg-surface);padding:15px 15px;}
+#kng-guide-overlay .kng-ct{display:flex;align-items:center;gap:9px;font-family:var(--font-ui);font-weight:700;font-size:15px;margin-bottom:6px;}
+#kng-guide-overlay .kng-ct span{font-size:17px;color:var(--accent);}
+#kng-guide-overlay .kng-card p{font-size:14px;color:var(--text-secondary);line-height:1.55;}
+
+#kng-guide-overlay .kng-rows .kng-row{display:flex;gap:14px;padding:15px 0;border-bottom:1px solid var(--border-soft);}
+#kng-guide-overlay .kng-rows .kng-row:last-child{border-bottom:none;}
+#kng-guide-overlay .kng-ric{font-size:20px;flex:none;width:28px;text-align:center;margin-top:1px;}
+#kng-guide-overlay .kng-rt{font-family:var(--font-ui);font-weight:700;font-size:15.5px;margin-bottom:2px;}
+#kng-guide-overlay .kng-rd{color:var(--text-secondary);font-size:14.5px;}
+
+#kng-guide-overlay .kng-tip{border-left:3px solid var(--accent);background:var(--accent-soft);border-radius:0 10px 10px 0;padding:13px 16px;margin-top:18px;}
+#kng-guide-overlay .kng-tk{font-family:var(--font-mono);font-size:10px;font-weight:700;letter-spacing:.12em;text-transform:uppercase;color:var(--accent);display:block;margin-bottom:4px;}
+#kng-guide-overlay .kng-tip p{font-size:14.5px;}
+
+#kng-guide-overlay .kng-ratings{display:grid;grid-template-columns:1fr 1fr;gap:9px;margin-top:18px;}
+#kng-guide-overlay .kng-rate{border:1px solid var(--border);border-radius:9px;padding:11px 13px;background:var(--bg-surface);font-family:var(--font-mono);font-size:12px;color:var(--text-muted);}
+#kng-guide-overlay .kng-rate b{font-family:var(--font-ui);color:var(--text-primary);font-size:14px;}
+#kng-guide-overlay .kng-dot{display:inline-block;width:9px;height:9px;border-radius:50%;margin-right:7px;vertical-align:middle;}
+
+#kng-guide-overlay details{border-bottom:1px solid var(--border-soft);}
+#kng-guide-overlay summary{cursor:pointer;list-style:none;padding:14px 28px 14px 0;position:relative;font-family:var(--font-ui);font-weight:600;font-size:15.5px;color:var(--text-primary);}
+#kng-guide-overlay summary::-webkit-details-marker{display:none;}
+#kng-guide-overlay summary::after{content:'+';position:absolute;right:2px;top:11px;font-size:20px;color:var(--accent);}
+#kng-guide-overlay details[open] summary::after{content:'\\2013';}
+#kng-guide-overlay .kng-ans{padding:0 0 15px;color:var(--text-secondary);font-size:15px;}
+
+#kng-guide-overlay .kng-foot{text-align:center;padding:40px 0 60px;border-top:1px solid var(--border);margin-top:44px;}
+#kng-guide-overlay .kng-fhex{color:var(--accent);font-size:19px;margin-bottom:10px;}
+#kng-guide-overlay .kng-foot p{font-family:var(--font-mono);font-size:12px;color:var(--text-muted);}
+
+@media(max-width:540px){#kng-guide-overlay .kng-grid,#kng-guide-overlay .kng-ratings{grid-template-columns:1fr;}}
+@media(prefers-reduced-motion:reduce){#kng-guide-overlay{animation:none;}}
+`;
+    const tag = document.createElement('style');
+    tag.id = 'kng-guide-styles';
+    tag.textContent = css;
+    document.head.appendChild(tag);
+  },
+};

--- a/knowledgenode/www/js/ui/GuidedView.js
+++ b/knowledgenode/www/js/ui/GuidedView.js
@@ -1,0 +1,1214 @@
+/**
+ * GuidedView.js — Final AI Study Session
+ *
+ * Feels like a teacher walking you through the material.
+ * Each step has a clear purpose, warm coaching language,
+ * and AI assistance woven in at every stage.
+ *
+ * Steps per node:
+ *   1. Prime       — AI primes your brain for this topic (30s orientation)
+ *   2. Understand  — Understanding check gate (what you already know)
+ *   3. Notes       — Read structured notes with AI floater available
+ *   4. Recall      — Blank-sheet recall from memory
+ *   5. Questions   — Answer questions, AI grades + hints on demand
+ *   6. Reflect     — What stuck, what didn't, what's next
+ */
+const GuidedView = {
+  _nodes:          [],
+  _nodeIndex:      0,
+  _stepIndex:      0,
+  _stepsCompleted: new Set(),
+  _sessionStart:   null,
+  _aiMode:         true,
+  _speech:         null,
+  _forceStartNodeId: null,
+  _inSession:       false, // set true in _render, false at completion and on navigate
+
+  /** Tell the guided flow to start at a specific node next time it opens,
+   *  overriding resume. Used by the AI Director so its recommendation and
+   *  the actual starting point agree. */
+  startAtNode(nodeId) { this._forceStartNodeId = nodeId; },
+
+  _DEFAULT_STEPS: ['prime','understand','notes','recall','questions','reflect'],
+  // Question-driven topics (built from Revision Questions / a past paper —
+  // a question bank with no structured notes) skip the notes-reading steps:
+  // there is nothing to read, so the session goes straight to practicing.
+  _QDRIVEN_STEPS: ['prime','questions','reflect'],
+  _STEPS: ['prime','understand','notes','recall','questions','reflect'],
+
+  _isQuestionDriven(node) {
+    if (!node || !(node.questions || []).length) return false;
+    const hasStructure = (node.definitions||[]).length || (node.tables||[]).length
+      || (node.formulas||[]).length || (node.procedures||[]).length
+      || (node.blocks||[]).length || (node.workedExamples||[]).length
+      || (node.summary||'').trim().length > 0;
+    return !hasStructure;
+  },
+
+  _stepsFor(node) {
+    return this._isQuestionDriven(node) ? this._QDRIVEN_STEPS : this._DEFAULT_STEPS;
+  },
+
+  /* ── Speech helper ─────────────────────────────────── */
+  _speak(text, onEnd) {
+    this._stopSpeech();
+    const clean = String(text || '').replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+    if (!clean) return;
+
+    // Native TTS bridge on Android (Capacitor)
+    if (typeof window.KnowledgeNodeTTS !== 'undefined') {
+      this._speech = true;
+      this._updateSpeechBtns(true);
+      if (typeof SpeechPill !== 'undefined') SpeechPill.show();
+      const handler = () => {
+        this._knttsListener = null;
+        this._speech = null;
+        this._updateSpeechBtns(false);
+        if (typeof SpeechPill !== 'undefined') SpeechPill.hide();
+        if (onEnd) onEnd();
+      };
+      this._knttsListener = handler;
+      window.addEventListener('kntts:done', handler, { once: true });
+      window.KnowledgeNodeTTS.speak(clean, 0.92, 1.0);
+      return;
+    }
+
+    if (!window.speechSynthesis || !window.SpeechSynthesisUtterance) {
+      Toast.info('Your browser does not support read-aloud. Try the lecture, or Chrome/Edge.');
+      return;
+    }
+
+    // Split into small chunks so long notes don't trip mobile "synthesis-failed".
+    const chunks = clean.match(/[^.!?]+[.!?]*\s*/g) || [clean];
+    const queue = [];
+    let buf = '';
+    for (const s of chunks) {
+      if ((buf + s).length > 200 && buf) { queue.push(buf.trim()); buf = ''; }
+      buf += s;
+    }
+    if (buf.trim()) queue.push(buf.trim());
+
+    const voices = window.speechSynthesis.getVoices();
+    const voice = voices.length
+      ? (voices.find(v => v.lang.startsWith('en') && /Google|Natural|Online|Samsung/.test(v.name))
+        || voices.find(v => v.lang.startsWith('en')) || voices[0])
+      : null;
+
+    let i = 0;
+    const speakNext = () => {
+      if (i >= queue.length) { this._speech = null; this._updateSpeechBtns(false); if (typeof SpeechPill !== 'undefined') SpeechPill.hide(); if (onEnd) onEnd(); return; }
+      const u = new SpeechSynthesisUtterance(queue[i]);
+      u.rate = 0.92; u.lang = 'en-US';
+      if (voice) u.voice = voice;
+      u.onend   = () => { i++; if (this._speech) speakNext(); };
+      u.onerror = (e) => {
+        if (e.error === 'interrupted' || e.error === 'canceled') return;
+        console.warn('[GuidedView] Speech:', e.error);
+        i++;
+        if (i < queue.length && this._speech) speakNext();
+        else { this._speech = null; this._updateSpeechBtns(false); if (typeof SpeechPill !== 'undefined') SpeechPill.hide(); }
+      };
+      this._speech = u;
+      window.speechSynthesis.speak(u);
+    };
+
+    this._speech = true; // marker so _stopSpeech can halt the queue
+    speakNext();
+    this._updateSpeechBtns(true);
+    if (typeof SpeechPill !== 'undefined') SpeechPill.show();
+
+    // Safety net: if nothing started speaking within 1.5s (rare mobile stall),
+    // reset the button so it isn't stuck on "Stop".
+    setTimeout(() => {
+      if (this._speech && !window.speechSynthesis.speaking && !window.speechSynthesis.pending) {
+        this._stopSpeech();
+        Toast.info('Read-aloud didn\'t start — try “Listen as a lecture” instead.');
+      }
+    }, 1500);
+  },
+
+  _stopSpeech() {
+    if (this._knttsListener) {
+      window.removeEventListener('kntts:done', this._knttsListener);
+      this._knttsListener = null;
+    }
+    if (typeof window.KnowledgeNodeTTS !== 'undefined') window.KnowledgeNodeTTS.stop();
+    if (window.speechSynthesis) window.speechSynthesis.cancel();
+    this._speech = null;
+    this._updateSpeechBtns(false);
+    if (typeof SpeechPill !== 'undefined') SpeechPill.hide();
+  },
+
+  _updateSpeechBtns(playing) {
+    document.querySelectorAll('.gf-speak-btn').forEach(btn => {
+      const idle = btn.dataset.idleLabel || '🔊 Read aloud';
+      if (!btn.dataset.idleLabel) btn.dataset.idleLabel = btn.textContent.trim() || idle;
+      btn.textContent = playing ? '⏹ Stop reading' : btn.dataset.idleLabel;
+      btn.dataset.playing = playing ? '1' : '';
+    });
+  },
+
+  _bindSpeakBtn(btnId, getText) {
+    const btn = document.getElementById(btnId);
+    if (!btn) return;
+    btn.addEventListener('click', () => {
+      if (btn.dataset.playing) { this._stopSpeech(); return; }
+      const text = getText();
+      if (!text) { Toast.info('Nothing to read yet — wait for the AI to finish loading.'); return; }
+      this._speak(text);
+    });
+  },
+
+  _STEP_META: {
+    prime:      { icon:'🎯', label:'Orient',    desc:'Set your focus' },
+    understand: { icon:'🧠', label:'Check',     desc:'What you know' },
+    notes:      { icon:'📋', label:'Study',     desc:'Read & absorb' },
+    recall:     { icon:'✍',  label:'Recall',    desc:'From memory' },
+    questions:  { icon:'❓', label:'Practice',  desc:'Test yourself' },
+    reflect:    { icon:'✅', label:'Reflect',   desc:'Lock it in' },
+  },
+
+  init() {
+    this._container = document.getElementById('guided-container');
+    this._empty     = document.getElementById('guided-empty');
+    this._tabs      = document.getElementById('step-tabs');
+    this._content   = document.getElementById('step-content');
+    this._prevBtn   = document.getElementById('guided-prev');
+    this._nextBtn   = document.getElementById('guided-next');
+
+    this._prevBtn.addEventListener('click', () => this._prevStep());
+    this._nextBtn.addEventListener('click', () => this._advance());
+    this._tabs.addEventListener('click', e => {
+      const tab = e.target.closest('.step-tab');
+      if (!tab || tab.classList.contains('locked')) return;
+      const idx = this._STEPS.indexOf(tab.dataset.step);
+      // Allow jumping to any step already reached (current or completed) — not just backwards
+      if (idx >= 0 && (idx <= this._stepIndex || this._stepsCompleted.has(idx))) this._goToStep(idx);
+    });
+  },
+
+  refresh() {
+    // Guard: background nodeStore.change events must not reset an active session
+    if (this._inSession) return;
+    // Sync profile from the first node to be studied
+    const nodes = nodeStore.getAll();
+    if (nodes.length > 0 && nodes[0].learnerProfile) {
+      AIService.setProfile(nodes[0].learnerProfile);
+    }
+    this._nodes = nodeStore.getAll().filter(n => n.processingStatus === 'ready');
+    if (!this._nodes.length) {
+      this._inSession = false;
+      document.getElementById('guided-page-header')?.style.setProperty('display', '');
+      this._container.classList.add('hidden');
+      this._empty.classList.remove('hidden');
+      return;
+    }
+    this._empty.classList.add('hidden');
+    this._container.classList.remove('hidden');
+
+    // If something (e.g. the AI Director) asked us to start at a specific node,
+    // honour that and skip resume — so the recommendation and behaviour agree.
+    let restored = false;
+    if (this._forceStartNodeId) {
+      const idx = this._nodes.findIndex(n => n.id === this._forceStartNodeId);
+      this._forceStartNodeId = null;
+      if (idx !== -1) {
+        this._nodeIndex = idx;
+        this._stepIndex = 0;
+        this._stepsCompleted = new Set();
+        try { localStorage.removeItem('kn_guided_progress'); } catch(e) {}
+        this._sessionStart = Date.now();
+        this._aiMode = AIService.hasApiKey();
+        this._render();
+        return;
+      }
+    }
+
+    // Restore last guided position if it's recent and still valid
+    try {
+      const saved = JSON.parse(localStorage.getItem('kn_guided_progress') || 'null');
+      if (saved && typeof saved.nodeIndex === 'number' && typeof saved.stepIndex === 'number') {
+        // Match by node ID so it survives library reordering
+        const idx = this._nodes.findIndex(n => n.id === saved.nodeId);
+        if (idx !== -1 && saved.stepIndex > 0 && saved.stepIndex < this._stepsFor(this._nodes[idx]).length) {
+          this._nodeIndex = idx;
+          this._stepIndex = saved.stepIndex;
+          this._stepsCompleted = new Set(saved.completed || []);
+          restored = true;
+        }
+      }
+    } catch(e) { /* ignore corrupt progress */ }
+
+    if (!restored) {
+      this._nodeIndex      = Math.min(this._nodeIndex, this._nodes.length - 1);
+      this._stepIndex      = 0;
+      this._stepsCompleted = new Set();
+    }
+    this._sessionStart   = Date.now();
+    this._aiMode         = AIService.hasApiKey();
+    this._inSession      = true;
+    this._render();
+
+    if (restored && !this._resumeToastShown) {
+      this._resumeToastShown = true;
+      const stepName = this._STEP_META[this._STEPS[this._stepIndex]]?.label || 'where you left off';
+      setTimeout(() => Toast.info('Resumed at "' + stepName + '".'), 300);
+    }
+  },
+
+  /* ─── RENDER SHELL ─────────────────────────────────── */
+  _render() {
+    const node  = this._nodes[this._nodeIndex];
+    if (!node) return;
+    this._STEPS = this._stepsFor(node); // session shape adapts to the topic
+    if (this._stepIndex >= this._STEPS.length) this._stepIndex = this._STEPS.length - 1;
+    const step  = this._STEPS[this._stepIndex];
+
+    // Hide the page-level "Study Session" header/subtitle while a session is
+    // active — it's orientation copy for the empty state, not for mid-session.
+    document.getElementById('guided-page-header')?.style.setProperty('display', 'none');
+
+    // Persist current position so the session resumes here next time
+    try {
+      localStorage.setItem('kn_guided_progress', JSON.stringify({
+        nodeId:    node.id,
+        nodeIndex: this._nodeIndex,
+        stepIndex: this._stepIndex,
+        completed: [...this._stepsCompleted],
+        savedAt:   Date.now(),
+      }));
+    } catch(e) { /* best-effort */ }
+
+    // Always refresh the content element reference (defensive against re-init)
+    this._content = document.getElementById('step-content');
+
+    // Progress bar — step counts can differ per node (question-driven topics
+    // have fewer steps), so sum the real counts instead of multiplying.
+    const stepCount = n => this._stepsFor(n).length;
+    const total   = this._nodes.reduce((sum, n) => sum + stepCount(n), 0);
+    const current = this._nodes.slice(0, this._nodeIndex).reduce((sum, n) => sum + stepCount(n), 0) + this._stepIndex + 1;
+    document.getElementById('guided-progress-fill').style.width = ((current/total)*100) + '%';
+    document.getElementById('guided-progress-label').textContent =
+      'Node ' + (this._nodeIndex+1) + ' of ' + this._nodes.length +
+      ' — Step ' + (this._stepIndex+1) + ' of ' + this._STEPS.length;
+
+    // Node header
+    document.getElementById('guided-node-badge').textContent = node.subject || 'Node';
+    document.getElementById('guided-node-title').textContent = node.title;
+    document.getElementById('guided-node-meta').textContent  =
+      (() => { const d = new Date(node.createdAt); return isNaN(d) ? '' : d.toLocaleDateString(); })();
+
+    // Tabs — rebuild each render so they stay in sync
+    this._tabs.innerHTML = this._STEPS.map((s, i) => {
+      const m      = this._STEP_META[s];
+      const done   = this._stepsCompleted.has(i);
+      const active = i === this._stepIndex;
+      // Only lock steps the student has never reached — completed steps are always tappable
+      const locked = i > this._stepIndex && !done;
+      return '<button class="step-tab' + (active?' active':'') + (locked?' locked':'') + (done?' done':'') + '" data-step="' + s + '">'
+        + '<span class="step-tab-icon">' + (done ? '✓' : m.icon) + '</span>'
+        + '<span class="step-tab-label">' + m.label + '</span>'
+        + '</button>';
+    }).join('');
+
+    // Nav
+    this._prevBtn.disabled = this._nodeIndex === 0 && this._stepIndex === 0;
+    const isLast = this._stepIndex === this._STEPS.length - 1;
+    const isLastNode = this._nodeIndex === this._nodes.length - 1;
+    this._nextBtn.style.display = 'block';
+    this._nextBtn.textContent = isLast
+      ? (isLastNode ? '🎉 Complete Session' : 'Next Topic →')
+      : 'Continue →';
+
+    SelectToAction.setNode(node);
+    try {
+      this._renderStep(node, step);
+    } catch(e) {
+      console.error('[GuidedView] render step "' + step + '" failed:', e);
+      if (this._content) {
+        this._content.innerHTML =
+          '<div style="padding:24px;text-align:center;">'
+          + '<p style="font-family:var(--font-body);font-size:14px;color:var(--text-secondary);margin-bottom:16px;">This step couldn\'t display, but you can keep going.</p>'
+          + '<button class="btn-primary" id="gf-skip-broken" style="padding:12px 20px;">Continue →</button>'
+          + '</div>';
+        document.getElementById('gf-skip-broken')?.addEventListener('click', () => this._advance());
+      }
+    }
+
+    // Scroll active tab into view (so "Recall", "Reflect" are never clipped)
+    setTimeout(() => {
+      const activeTab = this._tabs.querySelector('.step-tab.active');
+      if (activeTab) activeTab.scrollIntoView({ behavior:'smooth', block:'nearest', inline:'center' });
+    }, 50);
+
+    // Scroll to top — instant on mobile for reliability
+    const mc = document.getElementById('main-content');
+    if (mc) { mc.scrollTop = 0; }
+    window.scrollTo(0, 0);
+  },
+
+  /* ─── STEP RENDERERS ────────────────────────────────── */
+  _renderStep(node, step) {
+    switch(step) {
+      case 'prime':      this._renderPrime(node);     break;
+      case 'understand': this._renderUnderstand(node);break;
+      case 'notes':      this._renderNotes(node);     break;
+      case 'recall':     this._renderRecall(node);    break;
+      case 'questions':  this._renderQuestions(node); break;
+      case 'reflect':    this._renderReflect(node);   break;
+    }
+  },
+
+  /* ── STEP 1: PRIME ──────────────────────────────────── */
+  _renderPrime(node) {
+    const hasAI      = this._aiMode;
+    const defs       = (node.definitions||[]).slice(0,3).map(d=>d.term).join(', ');
+    const keyTerms   = defs || 'the core concepts';
+    const lastActivity = LearnerMemory.getNodeActivitySummary(node);
+    const weakText   = LearnerMemory.getWeakQuestionsText(node);
+    const mastery    = node.masteryScore ?? null;
+
+    // Personalised returning-learner banner
+    const returningBanner = lastActivity
+      ? '<div class="gf-prime-row" style="background:var(--accent-soft);border:1px solid var(--accent-dim);border-radius:var(--radius-md);padding:12px 14px;">'
+        + '<span class="gf-prime-icon">📊</span>'
+        + '<div><strong>Last time you studied this</strong>'
+        + '<p style="color:var(--text-secondary);">' + this._esc(lastActivity) + '</p>'
+        + (mastery !== null ? '<p style="font-family:var(--font-mono);font-size:11px;color:var(--accent);margin-top:4px;">Current mastery: ' + mastery + '%</p>' : '')
+        + '</div></div>'
+      : '';
+
+    const weakBanner = weakText
+      ? '<div class="gf-prime-row" style="background:var(--red-dim,rgba(255,80,80,.08));border:1px solid rgba(255,80,80,.2);border-radius:var(--radius-md);padding:12px 14px;">'
+        + '<span class="gf-prime-icon">⚠️</span>'
+        + '<div><strong>Focus areas from last session</strong>'
+        + '<p style="color:var(--text-secondary);font-size:13px;">' + this._esc(weakText.replace(/- /g,'')) + '</p>'
+        + '</div></div>'
+      : '';
+
+    const qDriven = this._isQuestionDriven(node);
+    const qDrivenBanner = qDriven
+      ? '<div class="gf-prime-row" style="background:var(--accent-soft);border:1px solid var(--accent-dim);border-radius:var(--radius-md);padding:12px 14px;">'
+        + '<span class="gf-prime-icon">📚</span>'
+        + '<div><strong>Question-driven session</strong>'
+        + '<p style="color:var(--text-secondary);font-size:13px;">This topic is a revision question bank (' + (node.questions||[]).length + ' questions), so the session adapts: no notes pages — you go straight into practicing. Anything you miss gets flagged under Mastery → “Review in your textbook”.</p>'
+        + '</div></div>'
+      : '';
+
+    this._content.innerHTML =
+      '<div class="gf-card gf-prime">'
+      + '<div class="gf-step-badge">Step 1 — Orient Your Mind</div>'
+      + '<h3 class="gf-title">Let\'s begin</h3>'
+      + '<p class="gf-subtitle">' + (qDriven
+          ? 'Quick orientation, then straight into your revision questions.'
+          : 'Before we dive in, take 30 seconds to prepare your brain. This makes everything that follows stick better.') + '</p>'
+
+      + '<div class="gf-prime-block">'
+      + qDrivenBanner
+      + returningBanner
+      + weakBanner
+      + '<div class="gf-prime-row"><span class="gf-prime-icon">🎯</span>'
+      + '<div><strong>What you\'re learning</strong><p>' + this._esc(node.subject || 'Academic Study') + ' — ' + this._esc(node.chapter || node.title) + '</p></div></div>'
+
+      + '<div class="gf-prime-row"><span class="gf-prime-icon">🔑</span>'
+      + '<div><strong>Key terms you\'ll encounter</strong><p>' + this._esc(keyTerms) + '</p></div></div>'
+
+      + '<div class="gf-prime-row"><span class="gf-prime-icon">💭</span>'
+      + '<div><strong>Take 30 seconds right now</strong>'
+      + '<p>Think: what do you <em>already</em> know about this topic? Even a vague feeling counts.</p></div></div>'
+      + '</div>'
+
+      + (hasAI
+          ? '<div id="gf-prime-ai" class="gf-ai-block">'
+            + '<div class="gf-ai-label" style="display:flex;align-items:center;justify-content:space-between;">'
+            + '<span>⬡ Teacher\'s Introduction</span>'
+            + '<button class="gf-speak-btn btn-secondary" id="gf-prime-speak" style="font-size:11px;padding:4px 10px;">🔊 Read aloud</button>'
+            + '</div>'
+            + '<div id="gf-prime-ai-text" class="gf-ai-text"><div class="aif-loading"><div class="aif-dot"></div><div class="aif-dot"></div><div class="aif-dot"></div></div></div>'
+            + '</div>'
+          : '<div class="gf-ai-block gf-ai-offline">'
+            + '<div class="gf-ai-label">📖 Topic Overview</div>'
+            + '<p class="gf-ai-text">' + this._esc(node.summary || 'Read through this topic carefully. Pay attention to definitions, formulas, and the step-by-step procedures.') + '</p>'
+            + '</div>')
+
+      + '<div class="gf-action-row">'
+      + '<button class="gf-continue-btn" id="gf-prime-ready">I\'m ready — let\'s go →</button>'
+      + '</div>'
+      + '</div>';
+
+    // Wire the card's own button and hide the global "Continue" FIRST, so they're
+    // always set up even when the intro is served from cache (which returns early).
+    document.getElementById('gf-prime-ready')?.addEventListener('click', () => this._advance());
+    this._nextBtn.style.display = 'none'; // the card has its own "I'm ready" button
+
+    if (hasAI) {
+      const ctx    = this._sourceContext(node);
+      const isBack = !!lastActivity;
+
+      // The first-time intro is static content (same every visit), so cache it
+      // per learner level to avoid re-calling the AI each time you open this node.
+      // Returning-visit intros are personalised to the last session, so they are
+      // always generated fresh and never cached.
+      const profile  = node.learnerProfile || 'college';
+      // First-visit intro caches permanently per level.
+      // Returning-visit intro caches for 24h so re-entering a topic repeatedly
+      // in a session reuses it instead of making a fresh AI call every time.
+      const DAY = 24 * 60 * 60 * 1000;
+      let cachedIntro = null;
+      if (!isBack && node.introCache?.[profile]) {
+        cachedIntro = node.introCache[profile];
+      } else if (isBack && node.introReturnCache?.[profile]) {
+        const entry = node.introReturnCache[profile];
+        if (entry && entry.text && (Date.now() - (entry.at || 0) < DAY)) {
+          cachedIntro = entry.text;
+        }
+      }
+
+      const renderIntro = (text) => {
+        const el = document.getElementById('gf-prime-ai-text');
+        if (el) {
+          el.innerHTML = text.split('\n').filter(l=>l.trim())
+            .map(l=>'<p style="margin:0 0 10px;font-family:var(--font-body);font-size:14px;line-height:1.7;color:var(--text-primary);">' + this._esc(l) + '</p>').join('');
+        }
+        this._bindSpeakBtn('gf-prime-speak', () =>
+          document.getElementById('gf-prime-ai-text')?.innerText || ''
+        );
+      };
+
+      if (cachedIntro) {
+        renderIntro(cachedIntro);
+        return;
+      }
+
+      const prompt = ctx + '\n\nYou are a warm, encouraging teacher.'
+        + (isBack
+            ? ' The student is returning to this topic. Their last session: "' + lastActivity + '".'
+              + (weakText ? ' They previously struggled with: ' + weakText.replace(/\n/g,'; ') + '.' : '')
+              + ' Acknowledge their return briefly, then give a focused intro that addresses those gaps.'
+            : ' Write a 2-paragraph introduction based ONLY on the source material above.')
+        + '\n- Paragraph 1: What this topic is really about and why it matters\n'
+        + '- Paragraph 2: What the student should watch out for — the 1-2 hardest things\n'
+        + 'Only reference the source. Conversational tone. Max 120 words.';
+      AIService._callWithFunction('chat', [{role:'user',content:prompt}], 300)
+        .then(text => {
+          if (!isBack) {
+            // First-visit intro — cache permanently per level
+            if (!node.introCache) node.introCache = {};
+            node.introCache[profile] = text;
+          } else {
+            // Returning-visit intro — cache with timestamp (24h freshness)
+            if (!node.introReturnCache) node.introReturnCache = {};
+            node.introReturnCache[profile] = { text, at: Date.now() };
+          }
+          try { nodeStore.save(node); } catch (e) { /* best-effort */ }
+          renderIntro(text);
+        })
+        .catch(() => {
+          const el = document.getElementById('gf-prime-ai-text');
+          if (el) el.innerHTML = '<p style="font-family:var(--font-body);font-size:14px;color:var(--text-primary);line-height:1.7;">' + this._esc(node.summary || 'Study this topic carefully.') + '</p>';
+          this._bindSpeakBtn('gf-prime-speak', () =>
+            document.getElementById('gf-prime-ai-text')?.innerText || ''
+          );
+        });
+    }
+  },
+
+  /* ── STEP 2: UNDERSTAND ─────────────────────────────── */
+  _renderUnderstand(node) {
+    // Re-query the live content element to avoid any stale reference
+    this._content = document.getElementById('step-content');
+    // Remember which step index this is, so onPass advances from the right place
+    const understandIndex = this._stepIndex;
+    UnderstandingCheck.show(node, () => {
+      // Move directly to the notes step (understand + 1), bypassing any guard issues
+      this._stepsCompleted.add(understandIndex);
+      this._stepIndex = understandIndex + 1;
+      this._nextBtn.style.display = 'block';
+      try { StreakTracker.recordActivity(); } catch(e) {}
+      this._render();
+    });
+    // Hide the built-in next button — understanding check has its own
+    this._nextBtn.style.display = 'none';
+  },
+
+  /* ── STEP 3: NOTES ──────────────────────────────────── */
+  _renderNotes(node) {
+    const hasQuestions = node.questions.length > 0;
+
+    // Build a clean read-aloud script from the node's blocks
+    const buildReadScript = () => {
+      const parts = [];
+      parts.push('Your notes for ' + node.title + '.');
+      if (node.blocks?.length) {
+        node.blocks.forEach(b => {
+          switch (b.type) {
+            case 'prose':
+            case 'callout':
+              if (b.title) parts.push(b.title + '.');
+              if (b.html) parts.push(b.html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim());
+              break;
+            case 'definition':
+              parts.push((b.title || 'Key Definitions') + '.');
+              (b.items || []).forEach(d => {
+                parts.push(d.term + ': ' + d.description + (d.examples ? '. Examples: ' + d.examples : '') + '.');
+              });
+              break;
+            case 'formula':
+              parts.push((b.title || 'Formulas') + '.');
+              (b.items || []).forEach(f => {
+                parts.push(f.expression + '. ' + (f.description || '') + (f.constraints ? '. Constraints: ' + f.constraints : '') + '.');
+              });
+              break;
+            case 'procedure':
+              parts.push((b.title || 'Procedure') + (b.appliesTo ? ', applies to ' + b.appliesTo : '') + '.');
+              (b.steps || []).forEach((s, i) => parts.push('Step ' + (i+1) + ': ' + s + '.'));
+              if (b.notes) parts.push('Note: ' + b.notes);
+              break;
+            case 'table':
+              parts.push((b.title || 'Table') + '.');
+              (b.rows || []).forEach(row => parts.push(row.join(', ') + '.'));
+              break;
+          }
+        });
+      } else {
+        // Legacy fallback
+        (node.definitions || []).forEach(d => parts.push(d.term + ': ' + d.description + '.'));
+        (node.formulas || []).forEach(f => parts.push(f.expression + '. ' + f.description + '.'));
+        if (node.summary) parts.push('Summary: ' + node.summary);
+      }
+      return parts.join(' ');
+    };
+
+    this._content.innerHTML =
+      '<div class="gf-notes-header">'
+      + '<div class="gf-step-badge">Step 3 — Read & Absorb</div>'
+      + '<h3 class="gf-title">Your notes on <em>' + this._esc(node.title) + '</em></h3>'
+      + (() => {
+          const focus = node.understandingCheck?.focusAreas;
+          if (focus?.length) {
+            return '<div class="gf-coach-tip" style="background:var(--accent-soft);border:1px solid var(--accent-dim);">📌 <strong>Based on your answers, focus on:</strong>'
+              + '<ul style="margin:6px 0 0;padding-left:18px;">'
+              + focus.map(f => '<li style="font-size:13px;line-height:1.55;margin-bottom:3px;">' + this._esc(f) + '</li>').join('')
+              + '</ul></div>';
+          }
+          return '<div class="gf-coach-tip">📌 <strong>Teacher tip:</strong> As you read, mentally tick off any gaps you noticed in the Understanding Check. Pay double attention to those sections.</div>';
+        })()
+      + '<div style="margin-top:12px;display:flex;gap:8px;flex-wrap:wrap;">'
+      + '<button class="btn-primary" id="gf-notes-lecture" style="flex:1;min-width:160px;font-size:13px;padding:9px 14px;display:flex;align-items:center;gap:7px;justify-content:center;" title="A narrated slideshow with activity break points — plus a voice-only option inside">🎓 Slide lecture</button>'
+      + '<button class="gf-speak-btn btn-secondary" id="gf-notes-speak" style="font-size:12px;padding:9px 14px;display:flex;align-items:center;gap:6px;justify-content:center;">🔊 Quick read</button>'
+      + '</div>'
+      + ((node.userNotes && node.userNotes.trim().length > 30)
+          ? '<button class="btn-secondary" id="gf-notes-structure" style="margin-top:10px;font-size:11px;padding:6px 12px;opacity:0.85;" title="Turn your typed notes into structured sections like an AI upload">✨ Structure my notes with AI</button>'
+          : '')
+      + '</div>'
+      + '<div id="gf-fit-check"></div>'
+      + (node.blocks?.length ? BlockEngine.renderNode(node) : NotesRenderer.renderFullNotes(node))
+      + (node.noteTemplate && node.noteTemplate !== 'standard' ? NoteTemplates.renderDisplay(node) : '')
+      + '<div class="gf-notes-footer">'
+      + '<div class="gf-section-complete-prompt">'
+      + '<p>Done reading? Before you continue, say aloud or write one sentence: <strong>what is the single most important thing on this page?</strong></p>'
+      + '<button class="gf-continue-btn" id="gf-notes-done">✓ I\'ve read it — continue →</button>'
+      + '</div>'
+      + '</div>';
+
+    ImageManager.bindEvents(this._content, node);
+    TextAnnotator.restoreHighlights(this._content, node);
+
+    // AI lecture — opens LectureMode, which generates a spoken lecture and handles
+    // mobile voice-loading reliably (the inline TTS below can stall on mobile).
+    document.getElementById('gf-notes-lecture')?.addEventListener('click', () => {
+      this._stopSpeech();
+      try { LectureMode.open(node); }
+      catch (e) { Toast.error('Could not start lecture: ' + e.message); }
+    });
+
+    this._bindSpeakBtn('gf-notes-speak', buildReadScript);
+    document.getElementById('gf-notes-structure')?.addEventListener('click', () => this._structureUserNotes(node));
+    document.getElementById('gf-notes-done')?.addEventListener('click', () => this._advance());
+    this._nextBtn.style.display = 'none';
+
+    // AI quietly checks whether any content (e.g. worked examples) would
+    // read better in another format, and asks before reshaping anything.
+    if (typeof StudyFitCheck !== 'undefined') {
+      StudyFitCheck.run(node, this._content, () => this._renderNotes(node));
+    }
+  },
+
+  /** Turn the learner's typed "My Notes" into structured blocks using the same
+   *  AI pipeline as the upload flow. Non-destructive: takes a backup first, only
+   *  commits if real structure was produced, and preserves the original text as
+   *  the node's source (rawOCR). */
+  async _structureUserNotes(node) {
+    if (!AIService.hasApiKey()) { Toast.error('Configure AI first in Settings.'); return; }
+    const raw = (node.userNotes || '').trim();
+    if (raw.length < 20) { Toast.info('Add some notes first.'); return; }
+    if (!confirm('Structure these notes into clean sections (definitions, steps, examples) like an AI upload?\n\nYour original text is preserved as the source, and a backup is taken first.')) return;
+
+    const btn = document.getElementById('gf-notes-structure');
+    if (btn) { btn.disabled = true; btn.textContent = '⟳ Structuring…'; }
+    try {
+      if (typeof BackupVault !== 'undefined') { try { await BackupVault.snapshot('pre-structure'); } catch {} }
+
+      const meta = { title: node.title, subject: node.subject, chapter: node.chapter };
+      const data = await AIService.processContent([], raw, meta, () => {});
+
+      const hasStructure = (data.definitions?.length || data.formulas?.length ||
+        data.procedures?.length || data.tables?.length ||
+        data.commonMistakes?.length || data.summary);
+      if (!hasStructure) throw new Error('Could not extract structure from these notes — they are unchanged.');
+
+      // Commit the structured content and rebuild the node's blocks.
+      node.definitions    = data.definitions    || [];
+      node.tables         = data.tables         || [];
+      node.formulas       = data.formulas       || [];
+      node.procedures     = data.procedures     || [];
+      node.commonMistakes = data.commonMistakes || [];
+      node.summary        = data.summary || node.summary || '';
+      if (Array.isArray(data.questions) && data.questions.length) {
+        node.questions = [...(node.questions || []), ...data.questions];
+      }
+      node.blocks  = node._migrateToBlocks();
+      node.rawOCR  = node.rawOCR || raw;   // keep the original text as source
+      node.userNotes = '';                  // now represented by structured blocks
+      node.updatedAt = Date.now();
+      nodeStore.save(node);
+
+      Toast.success('Notes structured. Your original text is kept as the source.');
+      this._renderNotes(node);
+    } catch (e) {
+      Toast.error('Could not structure: ' + e.message);
+      if (btn) { btn.disabled = false; btn.textContent = '✨ Structure my notes with AI'; }
+    }
+  },
+
+  /** Build a clean, readable source reference from the node's actual content —
+   *  definitions, formulas, tables, procedures, and raw OCR. Never shows AI prompts. */
+  _nodeSourceText(node) {
+    const parts = [];
+    if (node.summary) parts.push('SUMMARY\n' + node.summary);
+    if (node.definitions?.length) {
+      parts.push('DEFINITIONS\n' + node.definitions.slice(0, 12).map(d =>
+        (d.term || d.name || '') + ': ' + (d.description || d.def || '')).join('\n'));
+    }
+    if (node.formulas?.length) {
+      parts.push('FORMULAS\n' + node.formulas.slice(0, 8).map(f =>
+        (f.name || '') + (f.expression ? ' — ' + f.expression : '') + (f.description ? ': ' + f.description : '')).join('\n'));
+    }
+    if (node.procedures?.length) {
+      parts.push('PROCEDURES\n' + node.procedures.slice(0, 4).map((p, i) => {
+        const t = typeof p === 'string' ? p : (p && (p.title || p.name || JSON.stringify(p)));
+        return (i+1) + '. ' + t;
+      }).join('\n'));
+    }
+    if (node.tables?.length) {
+      parts.push('TABLES\n' + node.tables.slice(0, 2).map(t =>
+        (t.title || 'Table') + ': ' + (t.description || '')).join('\n'));
+    }
+    if (node.commonMistakes?.length) {
+      parts.push('COMMON MISTAKES\n' + node.commonMistakes.slice(0, 4).map(m =>
+        typeof m === 'string' ? m : (m.mistake || m.description || JSON.stringify(m))).join('\n'));
+    }
+    if (!parts.length && node.rawOCR) parts.push(node.rawOCR.slice(0, 1500));
+    if (!parts.length && node.userNotes) parts.push(node.userNotes.slice(0, 1500));
+    return parts.join('\n\n') || '(No source content found for this node.)';
+  },
+  _renderRecall(node) {
+    this._nextBtn.style.display = 'none';
+    const onPass = () => {
+      this._stepsCompleted.add(this._stepIndex);
+      this._advance();
+    };
+
+    // Mode picker — let the student choose how to test themselves
+    const container = document.getElementById('step-content');
+    if (!container) { BlankRecall.show(node, 'recall', onPass); return; }
+
+    container.innerHTML =
+      '<div class="gf-card" style="text-align:center;">'
+      + '<div class="gf-step-badge">Step 4 — Recall</div>'
+      + '<h3 class="gf-title">How do you want to test yourself?</h3>'
+      + '<p class="gf-subtitle" style="margin-bottom:24px;">Both methods work. The second is harder — and builds more memory.</p>'
+      + '<div style="display:flex;flex-direction:column;gap:12px;">'
+
+      + '<button id="mode-blank" class="btn-secondary" style="display:block;width:100%;white-space:normal;padding:16px 18px;text-align:left;">'
+      + '<div style="font-family:var(--font-ui);font-weight:700;font-size:15px;margin-bottom:4px;">✍ Blank Recall</div>'
+      + '<div style="font-size:13px;color:var(--text-muted);">Write everything you remember from scratch, then compare to your notes. Self-marked.</div>'
+      + '</button>'
+
+      + '<button id="mode-teach" class="btn-secondary" style="display:block;width:100%;white-space:normal;padding:16px 18px;text-align:left;border-color:var(--accent-dim);">'
+      + '<div style="font-family:var(--font-ui);font-weight:700;font-size:15px;margin-bottom:4px;color:var(--accent-light);">🎓 Teach It <span style="font-family:var(--font-mono);font-size:10px;font-weight:400;color:var(--accent);margin-left:6px;">90% retention</span></div>'
+      + '<div style="font-size:13px;color:var(--text-muted);">Explain the topic as if teaching a beginner. AI evaluates what you covered, what you missed, and what needs correction.</div>'
+      + '</button>'
+
+      + '<button id="mode-skip" style="background:none;border:none;color:var(--text-muted);font-size:13px;cursor:pointer;padding:8px;">Skip recall step →</button>'
+      + '</div></div>';
+
+    document.getElementById('mode-blank')?.addEventListener('click', () => BlankRecall.show(node, 'recall', onPass));
+    document.getElementById('mode-teach')?.addEventListener('click', () => BlankRecall.showTeachIt(node, onPass));
+    document.getElementById('mode-skip')?.addEventListener('click', () => onPass());
+  },
+
+  /* ── STEP 5: QUESTIONS ──────────────────────────────── */
+  _renderQuestions(node) {
+    const qs = node.questions;
+    this._nextBtn.style.display = 'block';
+
+    if (!qs.length) {
+      this._content.innerHTML =
+        '<div class="gf-card">'
+        + '<div class="gf-step-badge">Step 5 — Practice</div>'
+        + '<h3 class="gf-title">No questions yet</h3>'
+        + '<p class="gf-subtitle">This node doesn\'t have questions yet. You can:</p>'
+        + '<div style="display:flex;flex-direction:column;gap:10px;margin-top:16px;">'
+        + '<button class="btn-secondary" onclick="NodeDetailView.open(\'' + node.id + '\'); setTimeout(()=>document.querySelector(\'[data-section=questions]\')?.click?.(),400);">+ Add questions in Library →</button>'
+        + '</div>'
+        + '</div>';
+      return;
+    }
+
+    // Shuffle questions each session for variety — but persist the order and index
+    // so re-entering the step resumes exactly where the student left off.
+    const saveKey = 'kn_q_' + node.id;
+    let savedState = null;
+    try { savedState = JSON.parse(localStorage.getItem(saveKey) || 'null'); } catch {}
+
+    let shuffled, qIdx, correct, skipped;
+
+    // Restore: try to recover both position AND order; fall back to just position
+    if (savedState && typeof savedState.qIdx === 'number' && savedState.qIdx > 0) {
+      const hasValidOrder = savedState.order && Array.isArray(savedState.order)
+        && savedState.order.length === qs.length
+        && savedState.order.every(id => id != null);
+
+      if (hasValidOrder) {
+        const restored = savedState.order.map(id => qs.find(q => q.id === id)).filter(Boolean);
+        shuffled = (restored.length === qs.length) ? restored : [...qs].sort(() => Math.random()-0.5);
+      } else {
+        // No valid order saved — fresh shuffle but resume at the saved index
+        shuffled = [...qs].sort(() => Math.random()-0.5);
+      }
+      qIdx    = Math.min(savedState.qIdx, shuffled.length - 1);
+      correct = savedState.correct || 0;
+      skipped = savedState.skipped || 0;
+    } else {
+      shuffled = [...qs].sort(() => Math.random()-0.5);
+      qIdx = 0; correct = 0; skipped = 0;
+    }
+
+    const _save = () => {
+      const hasIds = shuffled.every(q => q && q.id);
+      localStorage.setItem(saveKey, JSON.stringify({
+        qIdx, correct, skipped,
+        order: hasIds ? shuffled.map(q => q.id) : null,
+      }));
+    };
+
+    const renderQ = (i) => {
+      _save();   // persist current index so re-entering resumes here
+      if (i >= shuffled.length) { localStorage.removeItem(saveKey); renderSummaryQ(); return; }
+      const q = shuffled[i];
+      const isRecall = q.type === 'recall';
+
+      this._content.innerHTML =
+        '<div class="gf-card gf-question-card">'
+        + '<div class="gf-step-badge">Question ' + (i+1) + ' of ' + shuffled.length + ' — ' + (isRecall?'Recall':'Application') + '</div>'
+
+        // Coach tip varies by question type
+        + '<div class="gf-coach-tip">' + (isRecall
+            ? '🧠 <strong>Recall:</strong> Try to answer from memory first. Don\'t look at your notes yet.'
+            : '🧩 <strong>Application:</strong> Work through this step by step. Think about which procedure or formula applies.')
+        + '</div>'
+
+        + '<div class="gf-q-text">' + (window.KNText ? KNText.html(q.question) : this._esc(q.question)) + '</div>'
+
+        // Source reference panel — always available for application questions,
+        // available on demand for recall. Lets students refer to the data the
+        // question is based on (e.g. financial statements, tables, examples).
+        + '<div id="gf-source-panel" style="margin-bottom:10px;">'
+        + '<button id="gf-source-btn" style="background:none;border:1px solid var(--border);border-radius:8px;color:var(--text-secondary);cursor:pointer;font-size:12px;padding:6px 12px;font-family:var(--font-ui);">'
+        + (isRecall ? '📋 Show source (only if stuck)' : '📋 View source data') + '</button>'
+        + '<div id="gf-source-body" style="display:none;margin-top:8px;background:var(--bg-raised);border:1px solid var(--border);border-radius:var(--radius-md);padding:14px 16px;max-height:220px;overflow-y:auto;">'
+        + '<div style="font-family:var(--font-mono);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:0.08em;color:var(--accent);margin-bottom:8px;">📋 Source: ' + this._esc(node.title) + '</div>'
+        + '<div style="font-family:var(--font-body);font-size:13px;color:var(--text-primary);line-height:1.7;white-space:pre-wrap;">' + this._esc(this._nodeSourceText(node)) + '</div>'
+        + '</div></div>'
+
+        + '<textarea id="gf-q-answer" class="config-input gf-answer-area" rows="4" placeholder="Write your answer here…" style="resize:vertical;touch-action:pan-y;" autocorrect="on" autocapitalize="sentences" spellcheck="true"></textarea>'
+
+        // AI hint (hidden by default)
+        + '<div id="gf-q-hint-area" style="display:none;margin-top:10px;background:var(--bg-raised);border:1px solid var(--border);border-left:3px solid var(--accent);border-radius:var(--radius-md);padding:12px 16px;">'
+        + '<div style="font-family:var(--font-mono);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:0.08em;color:var(--accent);margin-bottom:8px;">💡 Hint</div>'
+        + '<div id="gf-q-hint-text" style="font-family:var(--font-body);font-size:13px;color:var(--text-primary);line-height:1.65;"></div>'
+        + '</div>'
+
+        + '<div class="gf-q-actions">'
+        + (this._aiMode ? '<button class="rai-btn" id="gf-hint-btn">💡 Hint</button>' : '')
+        + '<button class="rai-btn" id="gf-skip-btn">Skip →</button>'
+        + '<button class="btn-primary" id="gf-submit-btn">Check Answer →</button>'
+        + '</div>'
+        + '</div>';
+
+      // Toggle source panel
+      document.getElementById('gf-source-btn')?.addEventListener('click', () => {
+        const body = document.getElementById('gf-source-body');
+        const btn  = document.getElementById('gf-source-btn');
+        if (!body) return;
+        const showing = body.style.display !== 'none';
+        body.style.display = showing ? 'none' : 'block';
+        btn.textContent = showing
+          ? (isRecall ? '📋 Show source (only if stuck)' : '📋 View source data')
+          : '📋 Hide source';
+      });
+
+      // Hint
+      if (this._aiMode) {
+        document.getElementById('gf-hint-btn')?.addEventListener('click', async () => {
+          const hintArea = document.getElementById('gf-q-hint-area');
+          const hintText = document.getElementById('gf-q-hint-text');
+          hintArea.style.display = 'block';
+          hintText.innerHTML = '<div class="aif-loading"><div class="aif-dot"></div><div class="aif-dot"></div><div class="aif-dot"></div></div>';
+          try {
+            const ctx = this._sourceContext(node);
+            const hint = await AIService._callWithFunction('chat', [{role:'user', content: ctx + '\n\nQuestion being asked: "' + q.question + '"\n\nGive a 1-2 sentence hint that nudges the student toward the answer WITHOUT revealing it. Reference only the source material above. If the answer is directly in the source, point them to the relevant section.'}], 150);
+            hintText.textContent = hint;
+          } catch(e) {
+            hintText.textContent = 'Think about the key definition or formula related to this question.';
+          }
+        });
+      }
+
+      // Skip
+      document.getElementById('gf-skip-btn')?.addEventListener('click', () => {
+        skipped++;
+        qIdx++;
+        renderQ(qIdx);
+      });
+
+      // Submit → AI grade or self-mark
+      document.getElementById('gf-submit-btn')?.addEventListener('click', async () => {
+        const studentAnswer = document.getElementById('gf-q-answer')?.value.trim();
+        if (!studentAnswer) { Toast.info('Write something first — even a guess.'); return; }
+
+        const submitBtn = document.getElementById('gf-submit-btn');
+        if (submitBtn) { submitBtn.disabled=true; submitBtn.textContent='Checking…'; }
+
+        let result;
+        // Free first pass: match against the stored acceptable answers on-device.
+        // Conservative — only short-circuits on a confident CORRECT match.
+        const quick = (typeof LocalGrader !== 'undefined')
+          ? LocalGrader.match(studentAnswer, LocalGrader.acceptedFor(q))
+          : { verdict: 'unknown' };
+        if (quick.verdict === 'correct') {
+          result = { score: 95, correct: true, local: true,
+            feedback: 'Instant check: your answer matches the model answer. No AI credits used. ⚡', tip: '' };
+        } else if (this._aiMode) {
+          try {
+            const ctx = this._sourceContext(node);
+            const gradePrompt = ctx + '\n\nQuestion: "' + q.question + '"\nModel answer: "' + q.answer + '"\nStudent answer: "' + studentAnswer + '"\n\nGrade based on CONCEPTUAL UNDERSTANDING, not exact wording or completeness. Rules:\n- If the student grasps the core idea correctly, score 80-100 even if their phrasing is informal or they left out minor details.\n- Only penalise for a fundamentally wrong concept or a critical missing element that changes the meaning.\n- Paraphrasing the model answer in the student\'s own words = full marks.\n- Partial understanding = 50-79 with encouragement on what they got right.\n- Missing the core concept entirely = below 50.\nBe warm and encouraging. Acknowledge what they got right before noting any gaps.\nOutput ONLY valid JSON: {"score":0,"correct":false,"feedback":"","tip":"","sourceQuote":""}';
+            const raw = await AIService._callWithFunction('grading', [{role:'user',content:gradePrompt}], 300);
+            result = AIService._parseJSON(raw);
+          } catch(e) {
+            // AI unreachable (offline / no credits) — degrade to self-marking
+            result = null;
+            Toast.info('AI unavailable — compare with the model answer and mark yourself.');
+          }
+        } else {
+          // No AI configured: self-mark against the model answer
+          result = null;
+        }
+
+        this._renderAnswerReveal(node, q, studentAnswer, result, shuffled, i, (selfMark) => {
+          if ((result && result.score >= 70) || selfMark === 'correct') correct++;
+
+          // Update SRS state so mastery reflects Guided Study performance
+          // Score ≥80 → Easy (4), ≥60 → Good (3), ≥40 → Hard (2), <40 → Again (1)
+          const rating = result
+            ? (result.score >= 80 ? 4 : result.score >= 60 ? 3 : result.score >= 40 ? 2 : 1)
+            : (selfMark === 'correct' ? 3 : selfMark === 'wrong' ? 1 : 3);
+          try {
+            node.recordRating(q.id, rating);
+            nodeStore.save(node);
+            LearnerMemory.recordStruggle(node, q, rating);
+          } catch(e) { console.warn('[GuidedView] recordRating failed:', e); }
+
+          qIdx++;
+          renderQ(qIdx);
+        });
+      });
+    };
+
+    const renderSummaryQ = () => {
+      const pct = shuffled.length > 0 ? Math.round((correct / shuffled.length) * 100) : 0;
+      const color = pct >= 80 ? 'var(--green)' : pct >= 50 ? 'var(--accent)' : 'var(--red)';
+      const msg   = pct >= 80
+        ? 'Excellent work! You clearly understand this topic.'
+        : pct >= 50
+          ? 'Good progress. Review the questions you struggled with before moving on.'
+          : 'This topic needs more practice. Consider re-reading the notes before your next session.';
+
+      this._content.innerHTML =
+        '<div class="gf-card">'
+        + '<div class="gf-step-badge">Practice Complete</div>'
+        + '<div style="text-align:center;padding:20px 0;">'
+        + '<div style="font-family:var(--font-mono);font-size:48px;font-weight:800;color:' + color + ';margin-bottom:8px;">' + pct + '%</div>'
+        + '<div style="font-family:var(--font-mono);font-size:12px;color:var(--text-muted);margin-bottom:16px;">' + correct + '/' + shuffled.length + ' correct · ' + skipped + ' skipped</div>'
+        + '<p style="font-family:var(--font-body);font-size:14px;color:var(--text-primary);line-height:1.65;">' + msg + '</p>'
+        + '</div>'
+        + '</div>';
+      this._nextBtn.style.display = 'block';
+    };
+
+    renderQ(qIdx);
+    this._nextBtn.style.display = 'none';
+  },
+
+  _renderAnswerReveal(node, q, studentAnswer, aiResult, shuffled, i, onNext) {
+    const isCorrect = aiResult ? aiResult.score >= 70 : null;
+    const scoreColor = aiResult
+      ? (aiResult.score >= 70 ? 'var(--green)' : aiResult.score >= 40 ? 'var(--accent)' : 'var(--red)')
+      : 'var(--text-muted)';
+
+    this._content.innerHTML =
+      '<div class="gf-card gf-question-card">'
+      + '<div class="gf-step-badge">Question ' + (i+1) + ' of ' + shuffled.length + ' — Answer Revealed</div>'
+
+      // Student answer
+      + '<div style="margin-bottom:14px;">'
+      + '<div style="font-family:var(--font-mono);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:0.08em;color:var(--text-muted);margin-bottom:6px;">Your answer</div>'
+      + '<div style="font-family:var(--font-body);font-size:14px;color:var(--text-primary);line-height:1.65;padding:12px 14px;background:var(--bg-raised);border:1px solid var(--border);border-radius:var(--radius-md);">' + this._esc(studentAnswer) + '</div>'
+      + '</div>'
+
+      // Model answer
+      + '<div style="margin-bottom:14px;">'
+      + '<div style="font-family:var(--font-mono);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:0.08em;color:var(--green);margin-bottom:6px;">✓ Model answer</div>'
+      + '<div style="font-family:var(--font-body);font-size:14px;color:var(--text-primary);line-height:1.65;padding:12px 14px;background:var(--green-dim);border:1px solid rgba(52,199,123,0.2);border-radius:var(--radius-md);">' + (window.KNText ? KNText.html(q.answer) : this._esc(q.answer)) + '</div>'
+      + '</div>'
+
+      // AI feedback
+      + (aiResult
+          ? '<div style="padding:12px 16px;background:var(--bg-raised);border:1px solid var(--border);border-left:3px solid ' + scoreColor + ';border-radius:var(--radius-md);margin-bottom:14px;">'
+            + '<div style="font-family:var(--font-mono);font-size:18px;font-weight:800;color:' + scoreColor + ';margin-bottom:6px;">' + aiResult.score + '/100</div>'
+            + '<p style="font-family:var(--font-body);font-size:13px;color:var(--text-primary);line-height:1.65;margin-bottom:' + (aiResult.tip?'8px':'0') + ';">' + this._esc(aiResult.feedback||'') + '</p>'
+            + (aiResult.tip ? '<p style="font-family:var(--font-mono);font-size:12px;color:var(--accent);margin-top:6px;">💡 ' + this._esc(aiResult.tip) + '</p>' : '')
+            + (aiResult.sourceQuote ? '<div style="margin-top:8px;padding:10px 12px;background:var(--bg-elevated,var(--bg));border:1px solid var(--border-soft,var(--border));border-left:3px solid var(--text-muted);border-radius:var(--radius-sm);font-family:var(--font-mono);font-size:11px;color:var(--text-muted);"><span style="font-weight:700;">📖 From your notes: </span>' + this._esc(aiResult.sourceQuote) + '</div>' : '')
+            + '</div>'
+          : '<div style="padding:12px 16px;background:var(--bg-raised);border:1px solid var(--border);border-radius:var(--radius-md);margin-bottom:14px;">'
+            + '<p style="font-family:var(--font-ui);font-size:13px;font-weight:600;color:var(--text-primary);margin-bottom:8px;">How did you do?</p>'
+            + '<div style="display:flex;gap:8px;">'
+            + '<button class="rai-btn" id="gf-self-right">✓ Got it</button>'
+            + '<button class="rai-btn" id="gf-self-wrong">✗ Missed it</button>'
+            + '</div>'
+            + '</div>')
+
+      + '<button class="gf-continue-btn" id="gf-next-q-btn">Next Question →</button>'
+      + '</div>';
+
+    document.getElementById('gf-next-q-btn')?.addEventListener('click', () => onNext());
+    document.getElementById('gf-self-right')?.addEventListener('click', () => onNext('correct'));
+    document.getElementById('gf-self-wrong')?.addEventListener('click', () => onNext('wrong'));
+  },
+
+  /* ── STEP 6: REFLECT ─────────────────────────────────── */
+  _renderReflect(node) {
+    this._nextBtn.style.display = 'block';
+    const isLastNode = this._nodeIndex === this._nodes.length - 1;
+    const sessionMins = Math.round((Date.now() - (this._sessionStart||Date.now())) / 60000);
+
+    this._content.innerHTML =
+      '<div class="gf-card gf-reflect">'
+      + '<div class="gf-step-badge">Step 6 — Reflect & Lock In</div>'
+      + '<h3 class="gf-title">Great work — let\'s cement this 🧠</h3>'
+
+      // Feynman moment
+      + '<div class="gf-reflect-section">'
+      + '<div class="gf-reflect-label">✏ The Feynman Test</div>'
+      + '<p class="gf-reflect-desc">Explain <strong>' + this._esc(node.title) + '</strong> in plain English, as if teaching a 15-year-old. No jargon allowed. This is the ultimate memory test.</p>'
+      + '<textarea id="gf-feynman-text" class="config-input" rows="4" style="resize:vertical;touch-action:pan-y;font-size:14px;line-height:1.65;margin-top:10px;" placeholder="In plain English, this topic is about… The way I\'d explain it is…"></textarea>'
+      + (this._aiMode ? '<button class="rai-btn" id="gf-feynman-check" style="margin-top:8px;">⬡ Get AI feedback on my explanation</button>' : '')
+      + '<div id="gf-feynman-feedback" style="display:none;margin-top:10px;"></div>'
+      + '</div>'
+
+      // What stuck / what didn't
+      + '<div class="gf-reflect-section">'
+      + '<div class="gf-reflect-label">🎯 Quick self-assessment</div>'
+      + '<div class="gf-confidence-grid">'
+      + ['I can define the key terms','I understand why it works this way','I can apply this to a new problem','I know the common mistakes to avoid']
+        .map((item, i) => '<label class="gf-confidence-row"><input type="checkbox" class="gf-confidence-check" style="accent-color:var(--accent);width:16px;height:16px;flex-shrink:0;"/><span>' + item + '</span></label>').join('')
+      + '</div>'
+      + '</div>'
+
+      // What's next
+      + '<div class="gf-reflect-section" style="background:var(--accent-soft);border:1px solid var(--accent-dim);border-radius:var(--radius-md);padding:16px 18px;">'
+      + '<div class="gf-reflect-label" style="color:var(--accent);">📅 What happens next</div>'
+      + '<p style="font-family:var(--font-body);font-size:13px;color:var(--text-secondary);line-height:1.65;margin-top:6px;">'
+      + 'Spaced repetition will schedule a review of this node. The longer you wait and still remember, the less frequently you\'ll need to review it. '
+      + 'Check the <strong>Review tab</strong> tomorrow for your first scheduled practice.'
+      + '</p>'
+      + (sessionMins > 0 ? '<p style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);margin-top:8px;">Session time: ' + sessionMins + ' min</p>' : '')
+      + '</div>'
+
+      + (isLastNode && this._stepsCompleted.size > 0
+          ? '<div style="margin-top:20px;padding:18px;background:var(--green-dim);border:1px solid rgba(52,199,123,0.2);border-radius:var(--radius-md);text-align:center;">'
+            + '<div style="font-size:28px;margin-bottom:8px;">🎉</div>'
+            + '<p style="font-family:var(--font-ui);font-size:15px;font-weight:700;color:var(--green);">All nodes complete!</p>'
+            + '<p style="font-family:var(--font-mono);font-size:12px;color:var(--text-muted);margin-top:4px;">Excellent session. Head to Review tomorrow to reinforce everything.</p>'
+            + '</div>'
+          : '')
+      + '</div>';
+
+    // Feynman AI feedback
+    if (this._aiMode) {
+      document.getElementById('gf-feynman-check')?.addEventListener('click', async () => {
+        const text = document.getElementById('gf-feynman-text')?.value?.trim();
+        if (!text) { Toast.info('Write your explanation first.'); return; }
+        const fb = document.getElementById('gf-feynman-feedback');
+        fb.style.display = 'block';
+        fb.innerHTML = '<div class="aif-loading"><div class="aif-dot"></div><div class="aif-dot"></div><div class="aif-dot"></div></div>';
+        try {
+          const ctx = this._sourceContext(node);
+          const prompt = ctx + '\n\nA student wrote this plain-English explanation of the topic:\n"' + text + '"\n\nBased ONLY on the source material above, evaluate their explanation: (1) what concepts they got right, (2) what is missing or inaccurate compared to the source, (3) one improvement suggestion. Where they are wrong, quote the correct information from the source. Be encouraging but honest. Max 100 words.';
+          const response = await AIService._callWithFunction('chat', [{role:'user',content:prompt}], 200);
+          fb.innerHTML = '<div style="background:var(--bg-raised);border:1px solid var(--border);border-left:3px solid var(--accent);border-radius:var(--radius-md);padding:12px 16px;">'
+            + '<div style="font-family:var(--font-mono);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:0.08em;color:var(--accent);margin-bottom:8px;">⬡ Feedback</div>'
+            + response.split('\n').filter(l=>l.trim()).map(l=>'<p style="font-family:var(--font-body);font-size:13px;line-height:1.65;color:var(--text-primary);margin:0 0 6px;">' + this._esc(l) + '</p>').join('')
+            + '</div>';
+        } catch(e) {
+          fb.innerHTML = '<p style="font-family:var(--font-mono);font-size:12px;color:var(--red);">' + this._esc(e.message) + '</p>';
+        }
+      });
+    }
+  },
+
+  /* ─── SESSION COMPLETE ───────────────────────────────── */
+  _showSessionComplete() {
+    const mins = this._sessionStart
+      ? Math.round((Date.now() - this._sessionStart) / 60000) : 0;
+    // Compute mastery deltas for studied nodes
+    const studied = this._nodes.slice(0, this._nodeIndex + 1);
+    const masteryLines = studied.map(n => `
+      <div class="gsc-topic" style="flex-direction:column;align-items:flex-start;gap:4px;">
+        <div style="display:flex;justify-content:space-between;width:100%;"><span>${this._esc(n.title)}</span><span class="gsc-mastery">${n.masteryScore}%</span></div>
+        ${n.masteryScore < 100 ? `<span style="font-family:var(--font-mono);font-size:10.5px;color:var(--text-muted);line-height:1.5;">${this._esc(n.masteryOutstandingText())}</span>` : ''}
+      </div>`
+    ).join('');
+    const due = nodeStore.getDueNodes().length;
+
+    this._content.innerHTML = `
+      <div class="guided-session-complete">
+        <div class="gsc-trophy">🎉</div>
+        <h2 class="gsc-title">Session Complete!</h2>
+        <div class="gsc-stats">
+          ${mins > 0 ? `<div class="gsc-stat"><span class="gsc-stat-val">${mins}</span><span class="gsc-stat-lbl">minutes</span></div>` : ''}
+          <div class="gsc-stat"><span class="gsc-stat-val">${studied.length}</span><span class="gsc-stat-lbl">topic${studied.length !== 1 ? 's' : ''}</span></div>
+          ${due > 0 ? `<div class="gsc-stat gsc-stat--due"><span class="gsc-stat-val">${due}</span><span class="gsc-stat-lbl">cards due</span></div>` : ''}
+        </div>
+        <div class="gsc-topics">${masteryLines}</div>
+        <p class="gsc-next-msg">
+          ${due > 0
+            ? 'You have <strong>' + due + ' cards due for review</strong> — now is a great time.'
+            : 'Your next review will be scheduled automatically. Come back tomorrow to reinforce this.'}
+        </p>
+        <div class="gsc-actions">
+          ${due > 0 ? `<button class="btn-primary" onclick="App.navigateTo('review')">↺ Start Review</button>` : ''}
+          <button class="btn-secondary" onclick="App.navigateTo('dashboard')">◉ View Progress</button>
+        </div>
+      </div>`;
+    this._prevBtn.style.display = 'none';
+    this._nextBtn.style.display = 'none';
+  },
+
+  /* ─── NAVIGATION ─────────────────────────────────────── */
+  _advance() {
+    this._stopSpeech();
+    this._stepsCompleted.add(this._stepIndex);
+    // Side effects must never block navigation
+    try { StreakTracker.recordActivity(); } catch(e) { console.warn('[GuidedView] streak:', e); }
+    try { if (this._stepIndex === 0) Onboarding.markStudied(); } catch(e) { console.warn('[GuidedView] onboarding:', e); }
+
+    if (this._stepIndex < this._STEPS.length - 1) {
+      this._stepIndex++;
+      this._nextBtn.style.display = 'block';
+      this._render();
+    } else if (this._nodeIndex < this._nodes.length - 1) {
+      this._nodeIndex++;
+      this._stepIndex      = 0;
+      this._stepsCompleted = new Set();
+      this._sessionStart   = Date.now();
+      this._render();
+    } else {
+      // Show rich session completion screen instead of a plain toast
+      this._inSession = false;
+      try { StreakTracker.recordActivity(); } catch(e) {}
+      try { localStorage.removeItem('kn_guided_progress'); } catch(e) {}
+      this._saveSessionSummary();
+      this._showSessionComplete();
+    }
+  },
+
+  async _saveSessionSummary() {
+    // Always write local memory for every node — even without AI.
+    for (const node of this._nodes) {
+      try { LearnerMemory.recordGuidedSession(node, { stepsCompleted: this._stepsCompleted.size }); }
+      catch(e) { console.warn('Session memory failed:', e); }
+    }
+    // Richer AI summaries: ONE batched call for the whole session instead of
+    // one call per node — fewer credits, same result.
+    if (!AIService.hasApiKey()) return;
+    const withQs = this._nodes.filter(n => (n.questions||[]).length);
+    if (!withQs.length) return;
+    try {
+      const mins = Math.round((Date.now()-(this._sessionStart||Date.now()))/60000);
+      const prompt = 'Summarise this study session per topic, for future reference. Max 30 words each: what was studied, plus any pattern you can infer.\n'
+        + 'Session duration: ' + mins + ' minutes\n'
+        + withQs.map((n,i) => (i+1) + '. Subject: ' + (n.subject||n.title) + ' — Topic: ' + n.title).join('\n')
+        + '\n\nOutput ONLY raw JSON, one summary per numbered topic IN ORDER: {"summaries":[""]}';
+      const raw = await AIService._callWithFunction('noteProcessing', [{role:'user',content:prompt}], Math.min(2000, 80 * withQs.length + 100));
+      const arr = (AIService._parseJSON(raw).summaries) || [];
+      withQs.forEach((node, i) => {
+        if (arr[i] && String(arr[i]).trim()) {
+          node.activitySummary = String(arr[i]).trim();
+          nodeStore.save(node);
+        }
+      });
+    } catch(e) {
+      console.warn('Session summary failed:', e);
+    }
+  },
+
+  _goToStep(idx) {
+    if (idx > this._stepIndex && !this._stepsCompleted.has(idx-1)) return;
+    this._stepIndex = idx;
+    this._nextBtn.style.display = 'block';
+    this._render();
+  },
+
+  _prevStep() {
+    if (this._stepIndex > 0) {
+      this._stepIndex--;
+      this._nextBtn.style.display = 'block';
+      this._render();
+      return;
+    }
+    if (this._nodeIndex > 0) {
+      this._nodeIndex--;
+      const steps = this._stepsFor(this._nodes[this._nodeIndex]);
+      this._stepIndex      = steps.length - 1;
+      this._stepsCompleted = new Set(steps.map((_, i) => i).slice(0, -1));
+      this._render();
+    }
+  },
+
+  /* ─── Source context builder — passed to every AI call ─── */
+  /** Build session memory string to inject into AI calls */
+  _sessionMemory(node) {
+    const log = (node.sessionLog||[]).slice(-3);
+    if (!log.length) return '';
+    return 'STUDENT SESSION HISTORY (use to personalise):\n'
+      + log.map(s => '- ' + s.date + ': ' + s.summary).join('\n') + '\n\n';
+  },
+
+  _sourceContext(node) {
+    return LearnerContext.forGuidedStudy(node);
+  },
+
+  _esc: s => String(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'),
+};

--- a/knowledgenode/www/js/ui/ImageManager.js
+++ b/knowledgenode/www/js/ui/ImageManager.js
@@ -1,0 +1,103 @@
+/**
+ * ImageManager.js
+ * Handles resizable images in node notes.
+ * Images are stored as { id, base64, caption, width } in node.userImages.
+ * Width is a percentage (20–100). User drags a resize handle.
+ */
+
+const ImageManager = {
+  _currentNode: null,
+
+  setNode(node) { this._currentNode = node; },
+
+  /** Render user images with resize handles */
+  renderImages(images) {
+    if (!images?.length) return '';
+    return `<div class="user-images-grid" id="user-images-grid">
+      ${images.map(img => this._imageBlock(img)).join('')}
+    </div>`;
+  },
+
+  _imageBlock(img) {
+    const w = img.width || 50;
+    return `
+      <div class="img-block" data-img-id="${img.id}" style="width:${w}%;min-width:120px;">
+        <div class="img-wrap">
+          <img src="data:image/jpeg;base64,${img.base64}" alt="${img.caption||'Image'}" loading="lazy"
+               style="width:100%;display:block;border-radius:var(--radius-sm);" />
+          <div class="img-resize-handle" title="Drag to resize"></div>
+          <button class="img-delete-btn" data-img-id="${img.id}" title="Remove image">✕</button>
+        </div>
+        <div class="img-caption-wrap">
+          <input type="text" class="img-caption-input" data-img-id="${img.id}"
+                 value="${this._esc(img.caption||'')}" placeholder="Add caption…"/>
+        </div>
+      </div>`;
+  },
+
+  /** Wire resize handles and caption/delete events after render */
+  bindEvents(container, node) {
+    this._currentNode = node;
+
+    // Delete buttons
+    container.querySelectorAll('.img-delete-btn').forEach(btn => {
+      btn.addEventListener('click', e => {
+        e.stopPropagation();
+        const id = btn.dataset.imgId;
+        node.userImages = node.userImages.filter(i => i.id !== id);
+        nodeStore.save(node);
+        btn.closest('.img-block').remove();
+        Toast.success('Image removed.');
+      });
+    });
+
+    // Caption autosave
+    container.querySelectorAll('.img-caption-input').forEach(input => {
+      input.addEventListener('change', () => {
+        const id  = input.dataset.imgId;
+        const img = node.userImages?.find(i => i.id === id);
+        if (img) { img.caption = input.value.trim(); nodeStore.save(node); }
+      });
+    });
+
+    // Resize handles
+    container.querySelectorAll('.img-resize-handle').forEach(handle => {
+      handle.addEventListener('mousedown', e => this._startResize(e, handle, node));
+      handle.addEventListener('touchstart', e => this._startResize(e, handle, node), { passive: false });
+    });
+  },
+
+  _startResize(e, handle, node) {
+    e.preventDefault();
+    const block     = handle.closest('.img-block');
+    const imgId     = block.dataset.imgId;
+    const container = block.parentElement;
+    const startX    = e.touches ? e.touches[0].clientX : e.clientX;
+    const startW    = block.offsetWidth;
+    const contW     = container.offsetWidth;
+
+    const onMove = ev => {
+      const x      = ev.touches ? ev.touches[0].clientX : ev.clientX;
+      const newPx  = Math.max(80, Math.min(contW, startW + (x - startX)));
+      const newPct = Math.round((newPx / contW) * 100);
+      block.style.width = newPct + '%';
+    };
+
+    const onUp = () => {
+      const pct = Math.round((block.offsetWidth / contW) * 100);
+      const img = node.userImages?.find(i => i.id === imgId);
+      if (img) { img.width = pct; nodeStore.save(node); }
+      document.removeEventListener('mousemove', onMove);
+      document.removeEventListener('mouseup',   onUp);
+      document.removeEventListener('touchmove', onMove);
+      document.removeEventListener('touchend',  onUp);
+    };
+
+    document.addEventListener('mousemove', onMove);
+    document.addEventListener('mouseup',   onUp);
+    document.addEventListener('touchmove', onMove, { passive: false });
+    document.addEventListener('touchend',  onUp);
+  },
+
+  _esc: s => String(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'),
+};

--- a/knowledgenode/www/js/ui/ImageResponseBlock.js
+++ b/knowledgenode/www/js/ui/ImageResponseBlock.js
@@ -1,0 +1,286 @@
+/**
+ * ImageResponseBlock.js
+ * Pairs a response area (text/procedure/table) with an image inside a node.
+ * Renders below each image that has a responseBlock attached.
+ */
+const ImageResponseBlock = {
+
+  /* Render an image with its response block below */
+  render(img, node, editable) {
+    const rb = img.responseBlock;
+    const hasRB = rb && (rb.type);
+
+    const imageHTML =
+      '<div class="img-block img-with-response" data-img-id="' + img.id + '" style="width:' + (img.width||80) + '%;min-width:180px;">'
+      + '<div class="img-wrap">'
+      + '<img src="data:image/jpeg;base64,' + img.base64 + '" alt="' + this._esc(img.caption||'Image') + '" loading="lazy" style="width:100%;display:block;border-radius:var(--radius-sm) var(--radius-sm) 0 0;"/>'
+      + (editable
+          ? '<div class="img-resize-handle">⟺</div>'
+          + '<button class="img-delete-btn" data-img-id="' + img.id + '">✕</button>'
+          : '')
+      + '</div>'
+      + (img.caption ? '<div class="img-caption">' + this._esc(img.caption) + '</div>' : '')
+
+      // Response block area
+      + (hasRB || editable
+          ? '<div class="img-response-block" data-img-id="' + img.id + '">'
+          + (!hasRB && editable
+              ? this._renderAddResponseBtn(img.id)
+              : this._renderResponseContent(img, node, editable))
+          + '</div>'
+          : '')
+      + '</div>';
+
+    return imageHTML;
+  },
+
+  _renderAddResponseBtn(imgId) {
+    return '<div class="irb-add-row">'
+      + '<span style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);">Add a response area below this image:</span>'
+      + '<div style="display:flex;gap:6px;flex-wrap:wrap;margin-top:8px;">'
+      + '<button class="irb-type-btn" data-img-id="' + imgId + '" data-type="text">✍ Answer text</button>'
+      + '<button class="irb-type-btn" data-img-id="' + imgId + '" data-type="procedure">📋 Working steps</button>'
+      + '<button class="irb-type-btn" data-img-id="' + imgId + '" data-type="table">📊 Computation table</button>'
+      + '</div>'
+      + '</div>';
+  },
+
+  _renderResponseContent(img, node, editable) {
+    const rb  = img.responseBlock;
+    if (!rb)  return this._renderAddResponseBtn(img.id);
+
+    const type = rb.type;
+    let contentHTML = '';
+
+    if (type === 'text') {
+      contentHTML = editable
+        ? '<textarea class="config-input irb-text-area" data-img-id="' + img.id + '" rows="4" style="width:100%;resize:vertical;touch-action:pan-y;font-size:14px;line-height:1.65;" placeholder="Write your answer here…">' + this._esc(rb.content||'') + '</textarea>'
+        : '<div style="font-family:var(--font-body);font-size:14px;color:var(--text-primary);line-height:1.65;padding:10px 0;white-space:pre-wrap;">' + (rb.content ? this._esc(rb.content) : '<span style="color:var(--text-muted);font-style:italic;">No answer yet.</span>') + '</div>';
+    }
+
+    if (type === 'procedure') {
+      const steps = rb.steps || [];
+      contentHTML = editable
+        ? '<div class="irb-proc-list" data-img-id="' + img.id + '">'
+          + steps.map((s,i) =>
+              '<div class="edit-row irb-step-row" style="gap:8px;">'
+              + '<span style="font-family:var(--font-mono);font-size:11px;color:var(--accent);min-width:20px;padding-top:10px;">' + (i+1) + '.</span>'
+              + '<input type="text" class="config-input irb-step-input" value="' + this._esc(s) + '" placeholder="Step…" data-img-id="' + img.id + '" style="flex:1;font-size:13px;padding:9px 12px;"/>'
+              + '<button class="edit-del-btn">✕</button>'
+              + '</div>'
+            ).join('')
+          + '</div>'
+          + '<button class="btn-secondary irb-add-step-btn" data-img-id="' + img.id + '" style="font-size:11px;padding:6px 12px;margin-top:6px;">+ Add Step</button>'
+        : '<div style="display:flex;flex-direction:column;gap:4px;padding:8px 0;">'
+          + (steps.length
+              ? steps.map((s,i)=>'<div class="procedure-step"><div class="procedure-num">'+(i+1)+'</div><div class="procedure-text">'+this._esc(s)+'</div></div>').join('')
+              : '<span style="color:var(--text-muted);font-family:var(--font-mono);font-size:12px;">No steps yet.</span>')
+          + '</div>';
+    }
+
+    if (type === 'table') {
+      const cols = rb.columns || ['Item','Amount','Notes'];
+      const rows = rb.rows    || [['','','']];
+      contentHTML = editable
+        ? '<div style="overflow-x:auto;">'
+          + '<table style="width:100%;border-collapse:collapse;">'
+          + '<thead><tr>' + cols.map((c,ci)=>'<th style="padding:6px 8px;background:var(--bg-raised);border:1px solid var(--border);font-family:var(--font-ui);font-size:11px;font-weight:700;text-transform:uppercase;"><input type="text" class="irb-col-input" value="'+this._esc(c)+'" data-img-id="'+img.id+'" data-col-idx="'+ci+'" style="border:none;background:transparent;font-family:inherit;font-size:inherit;font-weight:inherit;text-transform:inherit;width:80px;color:var(--text-muted);"/></th>').join('') + '</tr></thead>'
+          + '<tbody class="irb-table-body" data-img-id="' + img.id + '">'
+          + rows.map((row,ri)=>'<tr>' + cols.map((_,ci)=>'<td style="padding:4px;border:1px solid var(--border-soft);"><input type="text" class="config-input irb-cell-input" value="'+this._esc(row[ci]||'')+'" data-img-id="'+img.id+'" data-row-idx="'+ri+'" data-col-idx="'+ci+'" style="width:100%;min-width:60px;font-size:13px;padding:7px 8px;border:none;"/></td>').join('') + '<td style="padding:4px;border:1px solid var(--border-soft);"><button class="edit-del-btn irb-row-del" data-img-id="'+img.id+'" data-row-idx="'+ri+'">✕</button></td></tr>').join('')
+          + '</tbody></table></div>'
+          + '<button class="btn-secondary irb-add-tbl-row-btn" data-img-id="' + img.id + '" style="font-size:11px;padding:6px 12px;margin-top:6px;">+ Add Row</button>'
+        : '<div style="overflow-x:auto;"><table class="node-table"><thead><tr>'
+          + cols.map(c=>'<th>'+this._esc(c)+'</th>').join('')
+          + '</tr></thead><tbody>'
+          + rows.map(row=>'<tr>'+cols.map((_,ci)=>'<td>'+this._esc(row[ci]||'')+'</td>').join('')+'</tr>').join('')
+          + '</tbody></table></div>';
+    }
+
+    const modelAns = rb.modelAnswer
+      ? '<details class="irb-model-answer"><summary>Show model answer</summary><div class="irb-model-text">' + this._esc(rb.modelAnswer) + '</div></details>'
+      : (editable
+          ? '<div style="margin-top:10px;"><input type="text" class="config-input irb-model-input" placeholder="Model answer (optional — shown after student answers)…" value="' + this._esc(rb.modelAnswer||'') + '" data-img-id="' + img.id + '" style="font-size:12px;padding:8px 12px;"/></div>'
+          : '');
+
+    const header = '<div class="irb-header">'
+      + '<span class="irb-label">' + { text:'✍ Answer', procedure:'📋 Working Steps', table:'📊 Computation' }[type] + '</span>'
+      + (editable ? '<button class="irb-remove-btn" data-img-id="' + img.id + '">Remove</button>' : '')
+      + '</div>';
+
+    // AI grading — only in read mode, only when the student has actually answered.
+    // Grades the typed answer against BOTH the image and the model answer via vision.
+    const gradeUI = (!editable && this._hasStudentAnswer(rb))
+      ? '<div class="irb-grade-wrap" style="margin-top:10px;">'
+        + '<button class="btn-secondary irb-grade-btn" data-img-id="' + img.id + '" style="font-size:12px;padding:8px 14px;">🤖 Check my answer with AI</button>'
+        + '<div class="irb-grade-feedback" data-img-id="' + img.id + '" style="display:none;margin-top:10px;"></div>'
+        + '</div>'
+      : '';
+
+    return header + contentHTML + modelAns + gradeUI;
+  },
+
+  /** True if the student has entered any answer content for this response block. */
+  _hasStudentAnswer(rb) {
+    if (!rb) return false;
+    if (rb.type === 'text')      return !!(rb.content && rb.content.trim());
+    if (rb.type === 'procedure') return (rb.steps || []).some(s => s && s.trim());
+    if (rb.type === 'table')     return (rb.rows || []).some(row => (row||[]).some(c => c && c.trim()));
+    return false;
+  },
+
+  /** Flatten a response block's student answer into plain text for grading. */
+  _answerToText(rb) {
+    if (!rb) return '';
+    if (rb.type === 'text')      return rb.content || '';
+    if (rb.type === 'procedure') return (rb.steps || []).map((s,i) => (i+1) + '. ' + s).join('\n');
+    if (rb.type === 'table') {
+      const cols = rb.columns || [];
+      const head = cols.join(' | ');
+      const body = (rb.rows || []).map(r => (r||[]).join(' | ')).join('\n');
+      return head + '\n' + body;
+    }
+    return '';
+  },
+
+  /* Bind all response block events inside a container */
+  bindEvents(container, node) {
+    // Add response block type
+    container.addEventListener('click', e => {
+      if (e.target.classList.contains('irb-type-btn')) {
+        const imgId = e.target.dataset.imgId;
+        const type  = e.target.dataset.type;
+        const img   = node.userImages?.find(i => i.id === imgId);
+        if (!img) return;
+        img.responseBlock = { type, content:'', steps:[], columns:['Item','Amount','Notes'], rows:[['','','']], modelAnswer:'' };
+        nodeStore.save(node);
+        NodeDetailView._renderSection();
+      }
+      if (e.target.classList.contains('irb-remove-btn')) {
+        const imgId = e.target.dataset.imgId;
+        const img   = node.userImages?.find(i => i.id === imgId);
+        if (img) { img.responseBlock = null; nodeStore.save(node); NodeDetailView._renderSection(); }
+      }
+      if (e.target.classList.contains('irb-add-step-btn')) {
+        const imgId = e.target.dataset.imgId;
+        const list  = container.querySelector('.irb-proc-list[data-img-id="' + imgId + '"]');
+        if (!list) return;
+        const idx = list.querySelectorAll('.irb-step-row').length;
+        const div = document.createElement('div');
+        div.className = 'edit-row irb-step-row';
+        div.style.gap = '8px';
+        div.innerHTML = '<span style="font-family:var(--font-mono);font-size:11px;color:var(--accent);min-width:20px;padding-top:10px;">' + (idx+1) + '.</span><input type="text" class="config-input irb-step-input" placeholder="Step…" data-img-id="' + imgId + '" style="flex:1;font-size:13px;padding:9px 12px;"/><button class="edit-del-btn">✕</button>';
+        list.appendChild(div);
+        div.querySelector('input').focus();
+      }
+      if (e.target.classList.contains('irb-add-tbl-row-btn')) {
+        const imgId  = e.target.dataset.imgId;
+        const tbody  = container.querySelector('.irb-table-body[data-img-id="' + imgId + '"]');
+        const cols   = container.querySelectorAll('.irb-col-input[data-img-id="' + imgId + '"]').length || 3;
+        const ri     = tbody?.querySelectorAll('tr').length || 0;
+        if (!tbody) return;
+        const tr = document.createElement('tr');
+        tr.innerHTML = Array.from({length:cols}).map((_,ci)=>'<td style="padding:4px;border:1px solid var(--border-soft);"><input type="text" class="config-input irb-cell-input" data-img-id="'+imgId+'" data-row-idx="'+ri+'" data-col-idx="'+ci+'" style="width:100%;min-width:60px;font-size:13px;padding:7px 8px;border:none;"/></td>').join('')+'<td style="padding:4px;border:1px solid var(--border-soft);"><button class="edit-del-btn irb-row-del" data-img-id="'+imgId+'" data-row-idx="'+ri+'">✕</button></td>';
+        tbody.appendChild(tr);
+        tr.querySelector('input').focus();
+      }
+      if (e.target.classList.contains('irb-row-del')) {
+        e.target.closest('tr')?.remove();
+      }
+      if (e.target.classList.contains('edit-del-btn') && e.target.closest('.irb-step-row')) {
+        e.target.closest('.irb-step-row')?.remove();
+      }
+      if (e.target.classList.contains('irb-grade-btn')) {
+        this._gradeAnswer(e.target, node);
+      }
+    });
+  },
+
+  /** Grade a student's image-response answer against the image + model answer. */
+  async _gradeAnswer(btn, node) {
+    const imgId = btn.dataset.imgId;
+    const img   = node.userImages?.find(i => i.id === imgId);
+    if (!img || !img.responseBlock) return;
+    const rb     = img.responseBlock;
+    const answer = this._answerToText(rb).trim();
+    if (!answer) { Toast.info('Write your answer first.'); return; }
+
+    const fb = btn.parentElement.querySelector('.irb-grade-feedback[data-img-id="' + imgId + '"]');
+
+    if (!AIService.hasApiKey()) {
+      if (fb) {
+        fb.style.display = 'block';
+        fb.innerHTML = '<div style="font-family:var(--font-mono);font-size:12px;color:var(--text-muted);">Configure AI in Settings to grade your answer.</div>';
+      }
+      return;
+    }
+
+    const original = btn.textContent;
+    btn.disabled = true; btn.textContent = 'Grading…';
+    try {
+      const useVision = AIService.supportsVision();
+      const result = await AIService.gradeImageAnswer(
+        useVision ? img.base64 : null,
+        answer,
+        rb.modelAnswer || '',
+        node.subject || 'general'
+      );
+      const score = Number.isFinite(result?.score) ? result.score : 0;
+      const color = score >= 70 ? 'var(--green)' : score >= 50 ? 'var(--accent)' : 'var(--red)';
+      const missed = (result?.keyPointsMissed || []).filter(Boolean);
+      if (fb) {
+        fb.style.display = 'block';
+        fb.innerHTML =
+          '<div style="background:var(--bg-raised);border:1px solid var(--border);border-left:3px solid ' + color + ';border-radius:var(--radius-md);padding:14px 18px;">'
+          + '<div style="font-family:var(--font-mono);font-size:18px;font-weight:700;color:' + color + ';margin-bottom:6px;">' + score + '/100</div>'
+          + '<p style="font-family:var(--font-body);font-size:13px;color:var(--text-primary);line-height:1.65;">' + this._esc(result?.feedback || '') + '</p>'
+          + (missed.length
+              ? '<div style="margin-top:10px;"><div style="font-family:var(--font-ui);font-size:11px;font-weight:700;text-transform:uppercase;color:var(--text-muted);margin-bottom:4px;">Key points missed</div>'
+                + '<ul style="margin:0;padding-left:18px;font-family:var(--font-body);font-size:13px;color:var(--text-primary);line-height:1.6;">'
+                + missed.map(p => '<li>' + this._esc(p) + '</li>').join('') + '</ul></div>'
+              : '')
+          + '</div>';
+      }
+    } catch (err) {
+      if (fb) {
+        fb.style.display = 'block';
+        fb.innerHTML = '<div style="font-family:var(--font-mono);font-size:12px;color:var(--red);">Grading failed: ' + this._esc(err.message) + '</div>';
+      } else {
+        Toast.error('Grading failed: ' + err.message);
+      }
+    } finally {
+      btn.disabled = false; btn.textContent = original;
+    }
+  },
+
+  /* Save all response block data from DOM back to node */
+  saveAll(container, node) {
+    (node.userImages||[]).forEach(img => {
+      const rb = img.responseBlock;
+      if (!rb) return;
+      if (rb.type === 'text') {
+        const ta = container.querySelector('.irb-text-area[data-img-id="' + img.id + '"]');
+        if (ta) rb.content = ta.value;
+      }
+      if (rb.type === 'procedure') {
+        const inputs = container.querySelectorAll('.irb-step-input[data-img-id="' + img.id + '"]');
+        rb.steps = Array.from(inputs).map(i=>i.value.trim()).filter(Boolean);
+      }
+      if (rb.type === 'table') {
+        const colInputs  = container.querySelectorAll('.irb-col-input[data-img-id="' + img.id + '"]');
+        const cols       = Array.from(colInputs).map(c=>c.value.trim()||'Column');
+        rb.columns       = cols;
+        const tbody      = container.querySelector('.irb-table-body[data-img-id="' + img.id + '"]');
+        const rows       = [];
+        tbody?.querySelectorAll('tr').forEach(tr => {
+          const row = cols.map((_,ci) => tr.querySelector('[data-col-idx="'+ci+'"]')?.value.trim()||'');
+          if (row.some(c=>c)) rows.push(row);
+        });
+        rb.rows = rows;
+      }
+      const modelInput = container.querySelector('.irb-model-input[data-img-id="' + img.id + '"]');
+      if (modelInput) rb.modelAnswer = modelInput.value.trim();
+    });
+  },
+
+  _esc: s => String(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'),
+};

--- a/knowledgenode/www/js/ui/KNLoader.js
+++ b/knowledgenode/www/js/ui/KNLoader.js
@@ -39,8 +39,30 @@ const KNText = {
     for (const c of chain) { out += t.slice(last, c.idx) + '\n'; last = c.idx + 1; }
     return out + t.slice(last);
   },
+  // "A Employees who earn…" reads as one run-on line, so give a confident
+  // option run a consistent "A)" label and the letter stops colliding with the
+  // option text. Only rewrites an in-order A,B,C… run of at least three, and
+  // only where the option text starts with a capital, digit or quote, so
+  // ordinary prose is never relabelled.
+  _OPT: /^(\s*)\(?([A-Za-z])\)?(?:\s*[—–\-:.)]\s*|\s+(?=["“(]?[A-Z0-9]))\s*(\S.*)$/,
+  label(text) {
+    const lines = String(text == null ? '' : text).split('\n');
+    const hits = []; let want = 'A';
+    lines.forEach((l, i) => {
+      const m = l.match(this._OPT);
+      if (m && m[2].toUpperCase() === want) {
+        hits.push(i); want = String.fromCharCode(want.charCodeAt(0) + 1);
+      }
+    });
+    if (hits.length < 3) return text;
+    hits.forEach(i => {
+      const m = lines[i].match(this._OPT);
+      lines[i] = m[1] + m[2].toUpperCase() + ') ' + m[3];
+    });
+    return lines.join('\n');
+  },
   esc(s) { return String(s == null ? '' : s).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c])); },
-  html(s) { return this.esc(this.split(s)).replace(/\n/g, '<br>'); },
+  html(s) { return this.esc(this.label(this.split(s))).replace(/\n/g, '<br>'); },
 };
 if (typeof window !== 'undefined') window.KNText = KNText;
 

--- a/knowledgenode/www/js/ui/KNLoader.js
+++ b/knowledgenode/www/js/ui/KNLoader.js
@@ -1,0 +1,265 @@
+/**
+ * KNLoader.js — shared premium loading visuals for the whole app.
+ *
+ * Provides one on-brand hexagon loader (tracing comet + breathing core + glow)
+ * so every upload/processing flow looks consistent. Styles and the shared SVG
+ * gradient are injected once, on load.
+ *
+ *   KNLoader.hex(size)        → returns hexagon loader markup (string)
+ *   KNLoader.mount(el, size)  → renders the loader into an element (id or node)
+ *   KNLoader.ensureStyles()   → injects keyframes + gradient def (idempotent)
+ */
+/**
+ * KNText — shared question/answer text formatting for every practice surface.
+ *
+ * Imported revision questions keep verbatim line breaks (MCQ options on their
+ * own lines, multi-line worked solutions), but innerHTML collapses "\n" to a
+ * space — so options ran together into one unreadable paragraph. All question
+ * and model-answer rendering goes through these helpers instead:
+ *
+ *   KNText.split(s) → plain text; if an MCQ's options were flattened onto one
+ *                     line (OCR sometimes does this), puts each option back on
+ *                     its own line. Requires an in-order A,B,C… chain of at
+ *                     least 3 markers so normal prose is never touched.
+ *   KNText.html(s)  → escaped HTML with line breaks preserved (\n → <br>).
+ */
+const KNText = {
+  split(text) {
+    const t = String(text == null ? '' : text);
+    if (/\n/.test(t)) return t;                 // real line breaks — keep as-is
+    const re = /\s([A-F])[.):]?\s+(?=["“(]?[A-Z0-9])/g;
+    let m; const found = [];
+    while ((m = re.exec(t))) found.push({ letter: m[1], idx: m.index });
+    const chain = []; let want = 'A';
+    for (const f of found) {
+      if (f.letter === want) { chain.push(f); want = String.fromCharCode(want.charCodeAt(0) + 1); }
+    }
+    if (chain.length < 3) return t;             // not confidently an MCQ — leave alone
+    let out = '', last = 0;
+    for (const c of chain) { out += t.slice(last, c.idx) + '\n'; last = c.idx + 1; }
+    return out + t.slice(last);
+  },
+  esc(s) { return String(s == null ? '' : s).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c])); },
+  html(s) { return this.esc(this.split(s)).replace(/\n/g, '<br>'); },
+};
+if (typeof window !== 'undefined') window.KNText = KNText;
+
+const KNLoader = {
+  _OUTER: '50,4 89.8,27 89.8,73 50,96 10.2,73 10.2,27',
+  _INNER: '50,22 74.2,36 74.2,64 50,78 25.8,64 25.8,36',
+
+  ensureStyles() {
+    if (!document.getElementById('kn-loader-styles')) {
+      const s = document.createElement('style');
+      s.id = 'kn-loader-styles';
+      s.textContent = `
+        @keyframes kn-hex-trace { to { stroke-dashoffset:-100; } }
+        @keyframes kn-hex-pulse { 0%,100% { transform:scale(.78); opacity:.45; } 50% { transform:scale(1); opacity:1; } }
+        @keyframes kn-glow { 0%,100% { filter:drop-shadow(0 0 3px rgba(240,165,0,.30)); } 50% { filter:drop-shadow(0 0 16px rgba(240,165,0,.72)); } }
+        @keyframes kn-aurora { 0% { transform:translate(-12%,-8%) scale(1); } 50% { transform:translate(12%,10%) scale(1.25); } 100% { transform:translate(-12%,-8%) scale(1); } }
+        @keyframes kn-fade-rise { from { opacity:0; transform:translateY(8px); } to { opacity:1; transform:translateY(0); } }
+        .kn-hex-wrap { display:inline-flex; align-items:center; justify-content:center; animation:kn-glow 2.2s ease-in-out infinite; }
+        .kn-hex-track { fill:none; stroke:rgba(240,165,0,.14); stroke-width:5; }
+        .kn-hex-trace { fill:none; stroke:url(#knhexgrad); stroke-width:5; stroke-linecap:round; stroke-dasharray:24 76; animation:kn-hex-trace 1.5s linear infinite; }
+        .kn-hex-core  { fill:rgba(240,165,0,.16); transform-box:fill-box; transform-origin:center; animation:kn-hex-pulse 2.2s ease-in-out infinite; }
+      `;
+      document.head.appendChild(s);
+    }
+
+    // Shared gradient definition referenced by every hex via url(#knhexgrad)
+    if (!document.getElementById('kn-loader-defs')) {
+      const host = document.createElement('div');
+      host.id = 'kn-loader-defs';
+      host.style.cssText = 'position:absolute;width:0;height:0;overflow:hidden;';
+      host.innerHTML =
+        '<svg width="0" height="0" aria-hidden="true"><defs>'
+        + '<linearGradient id="knhexgrad" x1="0" y1="0" x2="1" y2="1">'
+        + '<stop offset="0%" stop-color="#ffd266"/><stop offset="100%" stop-color="#f0a500"/>'
+        + '</linearGradient></defs></svg>';
+      (document.body || document.documentElement).appendChild(host);
+    }
+  },
+
+  hex(size = 64) {
+    this.ensureStyles();
+    return `
+      <span class="kn-hex-wrap" style="width:${size}px;height:${size}px;flex-shrink:0;">
+        <svg viewBox="0 0 100 100" width="${size}" height="${size}" style="overflow:visible;">
+          <polygon class="kn-hex-track" points="${this._OUTER}"/>
+          <polygon class="kn-hex-core"  points="${this._INNER}"/>
+          <polygon class="kn-hex-trace" points="${this._OUTER}" pathLength="100"/>
+        </svg>
+      </span>`;
+  },
+
+  mount(elOrId, size = 56) {
+    const el = typeof elOrId === 'string' ? document.getElementById(elOrId) : elOrId;
+    if (el) el.innerHTML = this.hex(size);
+  },
+};
+
+// Inject styles as soon as possible so static markup (e.g. #processing-status) animates.
+if (typeof document !== 'undefined') {
+  if (document.readyState !== 'loading') KNLoader.ensureStyles();
+  else document.addEventListener('DOMContentLoaded', () => KNLoader.ensureStyles());
+}
+
+/* ───────────────────────────────────────────────────────────────────────────
+ * KNFiles — save & print that actually work inside the Android WebView.
+ * Uses the native KnowledgeNodeFiles bridge when present, else browser fallback.
+ * ──────────────────────────────────────────────────────────────────────────*/
+const KNFiles = {
+  nativeAvailable() {
+    try { return !!(window.KnowledgeNodeFiles && window.KnowledgeNodeFiles.saveToDownloads); }
+    catch (e) { return false; }
+  },
+
+  _isWebView() {
+    return !!window.Capacitor || /\bwv\b/.test(navigator.userAgent || '');
+  },
+
+  async save(filename, mime, data) {
+    const type   = mime || 'application/octet-stream';
+    const isText = /json|text|xml|html|csv|javascript/i.test(type) || typeof data === 'string';
+    const blob   = (data instanceof Blob) ? data : new Blob([data], { type });
+
+    // 1) Native bridge (Android) — the only thing that truly "downloads" in the app
+    if (this.nativeAvailable()) {
+      try {
+        if (window.Toast) Toast.info('Saving ' + filename + '…');
+        const b64 = await this._toBase64(blob);
+        window.KnowledgeNodeFiles.saveToDownloads(filename, type, b64);
+        return 'native'; // a knfiles:saved / knfiles:error event confirms the outcome
+      } catch (e) { /* fall through */ }
+    }
+
+    // 2) Real browser (not a WebView) — <a download> works here
+    if (!this._isWebView()) {
+      try {
+        const url = URL.createObjectURL(blob);
+        const a = Object.assign(document.createElement('a'), { href: url, download: filename, style: 'display:none' });
+        document.body.appendChild(a); a.click();
+        setTimeout(() => { URL.revokeObjectURL(url); a.remove(); }, 1000);
+        return 'browser';
+      } catch (e) { /* fall through */ }
+    }
+
+    // 3) WebView WITHOUT the native bridge — never fail silently.
+    //    For text (e.g. backup JSON) guarantee recovery via clipboard + a copyable panel.
+    if (isText) {
+      const text = (typeof data === 'string') ? data : await blob.text();
+      let copied = false;
+      try { await navigator.clipboard.writeText(text); copied = true; } catch (e) {}
+      this._showTextFallback(filename, text, copied);
+      return 'fallback';
+    }
+
+    if (window.Toast) Toast.error('Couldn’t save ' + filename + '. The file bridge isn’t in this build — rebuild with the native files bridge.');
+    return 'failed';
+  },
+
+  print(html, jobName) {
+    if (window.KnowledgeNodeFiles && typeof window.KnowledgeNodeFiles.printHtml === 'function') {
+      window.KnowledgeNodeFiles.printHtml(html, jobName || 'KnowledgeNode');
+      return 'native';
+    }
+    const win = window.open('', '_blank');
+    if (!win) { try { if (window.Toast) Toast.error('Pop-up blocked — allow pop-ups and retry.'); } catch {} return 'blocked'; }
+    win.document.write(html); win.document.close();
+    return 'browser';
+  },
+
+  _toBase64(blob) {
+    return new Promise((resolve, reject) => {
+      const r = new FileReader();
+      r.onload = () => resolve(String(r.result).split(',')[1] || '');
+      r.onerror = reject;
+      r.readAsDataURL(blob);
+    });
+  },
+
+  // Full-screen copyable panel so the user can always extract text data (backup JSON)
+  _showTextFallback(filename, text, copied) {
+    document.getElementById('kn-textfallback')?.remove();
+    const el = document.createElement('div');
+    el.id = 'kn-textfallback';
+    el.setAttribute('data-kn-overlay', '');
+    el.setAttribute('data-kn-close', '#kn-tf-close');
+    el.style.cssText = 'position:fixed;inset:0;z-index:9500;background:var(--bg-base,#07080b);display:flex;flex-direction:column;padding:16px;gap:12px;';
+    el.innerHTML = `
+      <div style="font-family:var(--font-ui),sans-serif;font-weight:800;font-size:16px;color:#fff;">${filename}</div>
+      <div style="font-family:var(--font-mono),monospace;font-size:12px;color:${copied ? 'var(--green,#34c77b)' : 'var(--accent,#f0a500)'};">
+        ${copied ? '✓ Copied to clipboard — paste into a notes/text app and save as “' + filename + '”.' : 'Select all, copy, then paste into a text app and save as “' + filename + '”.'}
+      </div>
+      <textarea readonly style="flex:1;width:100%;resize:none;background:#0f1116;color:#cfd3dc;border:1px solid var(--border,#262a33);border-radius:10px;padding:12px;font-family:var(--font-mono),monospace;font-size:11px;line-height:1.5;">${text.replace(/</g,'&lt;')}</textarea>
+      <div style="display:flex;gap:10px;">
+        <button id="kn-tf-copy" style="flex:1;padding:13px;border:none;border-radius:10px;background:var(--accent,#f0a500);color:#060709;font-weight:700;font-size:15px;">Copy again</button>
+        <button id="kn-tf-close" style="padding:13px 20px;border:1px solid var(--border,#262a33);border-radius:10px;background:transparent;color:#fff;font-size:15px;">Close</button>
+      </div>`;
+    document.body.appendChild(el);
+    const ta = el.querySelector('textarea');
+    el.querySelector('#kn-tf-copy').onclick = async () => {
+      ta.select();
+      try { await navigator.clipboard.writeText(text); } catch (e) { document.execCommand('copy'); }
+      if (window.Toast) Toast.info('Copied.');
+    };
+    el.querySelector('#kn-tf-close').onclick = () => el.remove();
+  },
+};
+
+if (typeof window !== 'undefined') {
+  window.KNFiles = KNFiles;
+  // Toast the outcome of native saves
+  window.addEventListener('knfiles:saved', e => { try { if (window.Toast) Toast.info('Saved to Downloads: ' + e.detail); } catch {} });
+  window.addEventListener('knfiles:error', e => { try { if (window.Toast) Toast.error('Save failed (' + e.detail + ')'); } catch {} });
+}
+
+/* ───────────────────────────────────────────────────────────────────────────
+ * KNNav / KNBack — let the device back button navigate the app.
+ * Modules register an overlay close-handler when they open something modal;
+ * the hardware back button pops the most recent one. With nothing registered,
+ * we step back a view (node-detail → library, sub-views → library) before
+ * letting Android background the app.
+ * ──────────────────────────────────────────────────────────────────────────*/
+const KNNav = {
+  _id: 0,
+  _stack: [],
+  register(closeFn) { const id = ++this._id; this._stack.push({ id, closeFn }); return id; },
+  unregister(id) { this._stack = this._stack.filter(o => o.id !== id); },
+
+  back() {
+    // 1) Close the most recently opened registered overlay
+    if (this._stack.length) {
+      const top = this._stack.pop();
+      try { top.closeFn(); } catch (e) {}
+      return true;
+    }
+    // 2) Close any tagged overlay that registered declaratively
+    const overlays = document.querySelectorAll('[data-kn-overlay]');
+    if (overlays.length) {
+      const top = overlays[overlays.length - 1];
+      const closeSel = top.getAttribute('data-kn-close');
+      const closeBtn = closeSel ? top.querySelector(closeSel) : null;
+      if (closeBtn) closeBtn.click(); else top.remove();
+      return true;
+    }
+    // 3) Step back through real navigation history — works for every page
+    //    (top-level views, a specific node, a specific competency report),
+    //    not just a fixed "always go to library" shortcut.
+    if (window.App && typeof App.goBack === 'function' && App.goBack()) return true;
+    // 4) Fallback for the rare case the stack is empty (e.g. the very first
+    //    navigation right after a cold boot straight into a sub-view).
+    if (window.App && App._currentView) {
+      const v = App._currentView;
+      const homes = ['upload', 'library', 'guided'];
+      if (homes.indexOf(v) === -1) { App.navigateTo('library'); return true; }
+    }
+    // 5) Nothing to do in-app
+    return false;
+  },
+};
+
+if (typeof window !== 'undefined') {
+  window.KNNav = KNNav;
+  window.KNBack = () => { try { return !!KNNav.back(); } catch (e) { return false; } };
+}

--- a/knowledgenode/www/js/ui/LearnPanel.js
+++ b/knowledgenode/www/js/ui/LearnPanel.js
@@ -1,0 +1,138 @@
+/**
+ * LearnPanel.js — Combined Learn button: Lecture + Tutor + Study Session
+ */
+const LearnPanel = {
+
+  open(node) {
+    document.getElementById('learn-panel-root')?.remove();
+    const examples   = node.workedExamples || [];
+    const hasEx      = examples.length > 0;
+
+    const root = document.createElement('div');
+    root.id = 'learn-panel-root';
+    root.setAttribute('data-kn-overlay', '');
+    root.setAttribute('data-kn-close', '#lp-close-x');
+    root.style.cssText = 'position:fixed;inset:0;z-index:9998;background:rgba(0,0,0,.55);display:flex;align-items:flex-end;';
+
+    // Build HTML with plain string concat — no template literals
+    let html = '<div id="learn-panel-sheet" style="position:relative;width:100%;background:var(--bg-raised);border-radius:20px 20px 0 0;padding:20px 18px 36px;max-height:82vh;overflow-y:auto;">';
+    html += '<button id="lp-close-x" class="sheet-close-x" aria-label="Close">✕</button>';
+    html += '<div style="width:40px;height:4px;background:var(--border);border-radius:2px;margin:0 auto 20px;"></div>';
+    html += '<div style="font-family:var(--font-ui);font-size:19px;font-weight:800;color:var(--text-primary);margin-bottom:4px;">🎓 Learn</div>';
+    html += '<div style="font-family:var(--font-body);font-size:13px;color:var(--text-muted);margin-bottom:22px;">' + this._esc(node.title) + '</div>';
+
+    // Lecture button
+    html += '<button id="lp-lecture" style="display:flex;align-items:center;gap:14px;padding:16px 18px;background:var(--bg-base);border:1px solid var(--border);border-radius:14px;cursor:pointer;text-align:left;width:100%;margin-bottom:10px;">';
+    html += '<span style="font-size:28px;flex-shrink:0;">📖</span>';
+    html += '<div><div style="font-family:var(--font-ui);font-size:15px;font-weight:700;color:var(--text-primary);margin-bottom:2px;">AI Lecture</div>';
+    html += '<div style="font-family:var(--font-body);font-size:13px;color:var(--text-muted);">Listen to your notes read aloud</div></div>';
+    html += '<span style="margin-left:auto;color:var(--text-muted);font-size:20px;">›</span></button>';
+
+    // Tutor button
+    var tutorBg     = 'var(--bg-base)';
+    var tutorBorder = hasEx ? 'var(--accent-dim)' : 'var(--border)';
+    var tutorOpacity = '1';
+    var tutorDesc   = hasEx
+      ? (examples.length + ' worked example' + (examples.length > 1 ? 's' : '') + ' ready')
+      : 'Tutor from your source notes';
+    html += '<button id="lp-tutor" style="display:flex;align-items:center;gap:14px;padding:16px 18px;background:' + tutorBg + ';border:1px solid ' + tutorBorder + ';border-radius:14px;cursor:pointer;text-align:left;width:100%;margin-bottom:10px;opacity:' + tutorOpacity + ';">';
+    html += '<span style="font-size:28px;flex-shrink:0;">⬡</span>';
+    html += '<div><div style="font-family:var(--font-ui);font-size:15px;font-weight:700;color:var(--text-primary);margin-bottom:2px;">Tutor Me</div>';
+    html += '<div style="font-family:var(--font-body);font-size:13px;color:var(--text-muted);">' + this._esc(tutorDesc) + '</div></div>';
+    html += '<span style="margin-left:auto;color:var(--text-muted);font-size:20px;">›</span></button>';
+
+    // Study session button
+    html += '<button id="lp-study" style="display:flex;align-items:center;gap:14px;padding:16px 18px;background:var(--bg-base);border:1px solid var(--border);border-radius:14px;cursor:pointer;text-align:left;width:100%;margin-bottom:0;">';
+    html += '<span style="font-size:28px;flex-shrink:0;">▶</span>';
+    html += '<div><div style="font-family:var(--font-ui);font-size:15px;font-weight:700;color:var(--text-primary);margin-bottom:2px;">Study Session</div>';
+    html += '<div style="font-family:var(--font-body);font-size:13px;color:var(--text-muted);">6-step guided: orient, check, study, recall, practice, reflect</div></div>';
+    html += '<span style="margin-left:auto;color:var(--text-muted);font-size:20px;">›</span></button>';
+
+    html += '</div>';
+    root.innerHTML = html;
+    document.body.appendChild(root);
+
+    // Close on backdrop
+    root.addEventListener('click', function(e) { if (e.target === root) LearnPanel._close(); });
+    // Close on X
+    document.getElementById('lp-close-x').addEventListener('click', function() { LearnPanel._close(); });
+
+    // Lecture
+    document.getElementById('lp-lecture').addEventListener('click', function() {
+      LearnPanel._close();
+      try { LectureMode.open(node); } catch(e) { Toast.error('Lecture error: ' + e.message); }
+    });
+
+    // Tutor — works with examples OR direct from source material
+    document.getElementById('lp-tutor').addEventListener('click', function() {
+      LearnPanel._close();
+      if (examples.length === 1) {
+        try { SocraticTutor.open(node, examples[0]); } catch(e) { Toast.error('Tutor error: ' + e.message); }
+      } else if (examples.length > 1) {
+        LearnPanel._showPicker(node, examples);
+      } else {
+        // No worked examples — synthesise one from source material
+        const defs = (node.definitions||[]).slice(0,3).map(d => d.term + ': ' + d.description).join('\n');
+        const procs = (node.procedures||[]).slice(0,1).flatMap(p => p.steps||[]).join(' ');
+        const sourceEx = {
+          id:       'source_' + node.id,
+          title:    node.title,
+          question: 'Based on your notes for "' + node.title + '", explain the core concepts and how they apply.',
+          solution: defs || node.summary || 'Use the key definitions and procedures from your notes.',
+          steps:    (node.procedures||[]).slice(0,1).flatMap(p => p.steps||[]).slice(0,5),
+          _fromSource: true,
+        };
+        try { SocraticTutor.open(node, sourceEx); } catch(e) { Toast.error('Tutor error: ' + e.message); }
+      }
+    });
+
+    // Study session
+    document.getElementById('lp-study').addEventListener('click', function() {
+      LearnPanel._close();
+      var btn = document.querySelector('.mobile-nav-btn[data-view="guided"]')
+             || document.querySelector('.nav-item[data-view="guided"]');
+      if (btn) btn.click();
+    });
+  },
+
+  _showPicker(node, examples) {
+    document.getElementById('learn-panel-root')?.remove();
+    const root = document.createElement('div');
+    root.id = 'learn-panel-root';
+    root.setAttribute('data-kn-overlay', '');
+    root.setAttribute('data-kn-close', '#lp-close-x');
+    root.style.cssText = 'position:fixed;inset:0;z-index:9998;background:rgba(0,0,0,.55);display:flex;align-items:flex-end;';
+
+    let html = '<div style="position:relative;width:100%;background:var(--bg-raised);border-radius:20px 20px 0 0;padding:20px 18px 36px;max-height:82vh;overflow-y:auto;">';
+    html += '<button id="lp-close-x" class="sheet-close-x" aria-label="Close">✕</button>';
+    html += '<div style="width:40px;height:4px;background:var(--border);border-radius:2px;margin:0 auto 16px;"></div>';
+    html += '<button id="lp-back" style="background:transparent;border:none;color:var(--text-muted);cursor:pointer;font-family:var(--font-ui);font-size:13px;padding:0;margin-bottom:14px;">← Back</button>';
+    html += '<div style="font-family:var(--font-ui);font-size:17px;font-weight:800;color:var(--text-primary);margin-bottom:16px;">Choose Example</div>';
+
+    examples.forEach(function(ex, i) {
+      html += '<button class="lp-ex-pick" data-ex-id="' + LearnPanel._esc(ex.id) + '" style="display:flex;align-items:center;gap:12px;padding:14px 16px;background:var(--bg-base);border:1px solid var(--border);border-radius:12px;cursor:pointer;text-align:left;width:100%;margin-bottom:10px;">';
+      html += '<span style="font-family:var(--font-mono);font-size:10px;font-weight:700;color:var(--accent);background:var(--accent-soft);padding:2px 8px;border-radius:10px;flex-shrink:0;">Ex ' + (i+1) + '</span>';
+      html += '<div style="flex:1;min-width:0;"><div style="font-family:var(--font-ui);font-size:14px;font-weight:700;color:var(--text-primary);">' + LearnPanel._esc(ex.title) + '</div>';
+      var preview = (ex.question || '').slice(0, 55) + (ex.question && ex.question.length > 55 ? '…' : '');
+      html += '<div style="font-family:var(--font-body);font-size:12px;color:var(--text-muted);">' + LearnPanel._esc(preview) + '</div></div>';
+      html += '<span style="color:var(--text-muted);font-size:18px;flex-shrink:0;">›</span></button>';
+    });
+
+    html += '</div>';
+    root.innerHTML = html;
+    document.body.appendChild(root);
+
+    root.addEventListener('click', function(e) { if (e.target === root) LearnPanel._close(); });
+    document.getElementById('lp-close-x').addEventListener('click', function() { LearnPanel._close(); });
+    document.getElementById('lp-back').addEventListener('click', function() { LearnPanel._close(); LearnPanel.open(node); });
+    root.querySelectorAll('.lp-ex-pick').forEach(function(btn) {
+      btn.addEventListener('click', function() {
+        var ex = examples.find(function(e) { return e.id === btn.dataset.exId; });
+        if (ex) { LearnPanel._close(); SocraticTutor.open(node, ex); }
+      });
+    });
+  },
+
+  _close() { document.getElementById('learn-panel-root')?.remove(); },
+  _esc:  function(s) { return String(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); },
+};

--- a/knowledgenode/www/js/ui/LectureMode.js
+++ b/knowledgenode/www/js/ui/LectureMode.js
@@ -1,0 +1,1139 @@
+/**
+ * LectureMode.js — Voice lecture with hardened cross-browser speech synthesis
+ */
+const LectureMode = {
+  _node: null, _script: '', _questions: [], _currentQ: 0,
+  _utterance: null, _isPlaying: false,
+  _voiceMode: 'browser', _recognition: null, _quizAnswers: [],
+  _slides: null, _slideIndex: 0, _autoNarrate: false, _slideSpeaking: false, _presentMode: false,
+
+  // Lazy-init synth — some browsers throw if accessed before user gesture
+  get _synth() {
+    return window.speechSynthesis || null;
+  },
+
+  /** True when running as a native Android app (Capacitor) with our TTS bridge. */
+  _isCapacitor() {
+    return typeof window.KnowledgeNodeTTS !== 'undefined';
+  },
+
+  /** Speak via native TTS and call onDone when finished. Manages its own listener. */
+  _capSpeak(text, rate, onDone) {
+    if (this._capDoneListener) {
+      window.removeEventListener('kntts:done', this._capDoneListener);
+    }
+    this._capDoneListener = () => {
+      this._capDoneListener = null;
+      if (onDone) onDone();
+    };
+    window.addEventListener('kntts:done', this._capDoneListener, { once: true });
+    window.KnowledgeNodeTTS.speak(text, rate, 0.95);
+  },
+
+  /** Stop native TTS and cancel pending done callback. */
+  _capStop() {
+    if (this._capDoneListener) {
+      window.removeEventListener('kntts:done', this._capDoneListener);
+      this._capDoneListener = null;
+    }
+    if (typeof window.KnowledgeNodeTTS !== 'undefined') window.KnowledgeNodeTTS.stop();
+  },
+
+  _speechSupported() {
+    // Native TTS is always available on Capacitor Android.
+    if (this._isCapacitor()) return true;
+    return !!(window.speechSynthesis && window.SpeechSynthesisUtterance);
+  },
+
+  open(node) {
+    this._node = node; this._script = ''; this._questions = [];
+    this._currentQ = 0; this._quizAnswers = []; this._isPlaying = false;
+    this._slides = null; this._slideIndex = 0; this._slideSpeaking = false;
+    this._halt(); // stop any playback WITHOUT clearing saved position
+    Modal.open(this._renderUI(), () => this._halt());
+    // Bind events AFTER modal renders, then auto-load a cached lecture if one
+    // exists for this node's current learner level (saves an AI call).
+    setTimeout(() => {
+      this._bindAllEvents();
+      const cached = this._node.lectureCache?.[this._profileKey()];
+      if (cached) this._displayLecture(cached, true);
+      // Pre-load a cached slide deck into the (default) Slides tab — display only,
+      // no narration, so there's no surprise audio on open.
+      const cachedSlides = this._node.lectureSlidesCache?.[this._profileKey()];
+      if (cachedSlides && cachedSlides.length) this._displaySlides(cachedSlides, true);
+    }, 0);
+  },
+
+  /** Stop playback but preserve the saved resume position. */
+  _clearPauseTimer() {
+    if (this._pauseTimer) { clearTimeout(this._pauseTimer); this._pauseTimer = null; }
+  },
+
+  _halt() {
+    this._clearPauseTimer();
+    this._slideSpeaking = false;
+    this._presentMode = false;
+    document.getElementById('lm-present')?.remove();
+    if (!this._speechSupported()) return;
+    this._isPlaying = false;
+    if (this._isCapacitor()) { this._capStop(); } else { this._synth.cancel(); }
+    this._updatePlayBtn();
+    this._updateSlidePlayBtn();
+    if (typeof SpeechPill !== 'undefined') SpeechPill.hide();
+  },
+
+  _renderUI() {
+    return `
+      <div id="lecture-modal">
+        <h2 style="font-family:var(--font-ui);font-size:19px;font-weight:800;margin-bottom:4px;">🎓 Lecture Mode</h2>
+        <p style="font-family:var(--font-mono);font-size:12px;color:var(--text-muted);margin-bottom:18px;">${this._esc(this._node.title)}</p>
+
+        <div style="display:flex;gap:8px;margin-bottom:18px;border-bottom:1px solid var(--border);padding-bottom:16px;">
+          <button class="lecture-tab active" id="tab-slides" data-mode="slides">🎓 Lecture</button>
+          <button class="lecture-tab" id="tab-lecture" data-mode="lecture">🔊 Voice only</button>
+          <button class="lecture-tab" id="tab-quiz" data-mode="quiz">❓ Practice</button>
+        </div>
+
+        <div style="display:flex;align-items:center;gap:10px;margin-bottom:18px;background:var(--bg-raised);border:1px solid var(--border);border-radius:var(--radius-md);padding:12px 14px;">
+          <span style="font-family:var(--font-ui);font-size:11px;font-weight:600;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.08em;">Voice</span>
+          <span style="font-family:var(--font-ui);font-size:12px;color:var(--text-secondary);">🔊 Your device's built-in voice</span>
+        </div>
+
+        <!-- Slides Panel -->
+        <div id="slides-panel">
+          <div id="slides-stage" style="min-height:340px;margin-bottom:14px;">
+            <div style="background:var(--bg-raised);border:1px solid var(--border);border-radius:14px;padding:48px 24px;text-align:center;">
+              <div style="font-size:34px;margin-bottom:12px;">🎓</div>
+              <div style="font-family:var(--font-ui);font-size:15px;font-weight:700;color:var(--text-primary);margin-bottom:6px;">Slide Lecture</div>
+              <p style="font-family:var(--font-body);font-size:13px;color:var(--text-secondary);line-height:1.6;max-width:340px;margin:0 auto 18px;">A narrated slideshow — each slide a single idea, read aloud, with activity break points where you answer before moving on. Tap Play and it presents itself like a class.</p>
+              <button class="btn-primary" id="gen-slides-btn" style="justify-content:center;">⬡ Generate lecture</button>
+            </div>
+          </div>
+          <div id="slides-controls" style="display:none;flex-wrap:wrap;gap:8px;align-items:center;">
+            <button class="btn-secondary" id="slide-prev-btn" title="Previous slide">← Prev</button>
+            <button class="btn-primary" id="slide-play-btn" title="Play the narrated lecture">▶ Play</button>
+            <button class="btn-secondary" id="slide-next-btn" title="Next slide">Next →</button>
+            <button class="btn-secondary" id="slide-present-btn" title="Full-screen presentation">⛶ Present</button>
+            <select id="slide-speed" class="config-select" style="width:auto;padding:8px 12px;font-size:12px;">
+              <option value="0.8">Slow</option>
+              <option value="1" selected>Normal</option>
+              <option value="1.3">Fast</option>
+            </select>
+            <button class="btn-secondary" id="slide-pptx-btn" title="Download as an editable PowerPoint file">⬇ PowerPoint</button>
+            <button class="btn-secondary" id="slide-regen-btn" style="margin-left:auto;" title="Generate a fresh lecture">⬡ Regenerate</button>
+          </div>
+        </div>
+
+        <!-- Lecture Panel -->
+        <div id="lecture-panel" style="display:none;">
+          <div id="lecture-script-area" style="background:var(--bg-raised);border:1px solid var(--border);border-radius:var(--radius-md);padding:18px;min-height:140px;max-height:280px;overflow-y:auto;font-family:var(--font-body);font-size:14px;line-height:1.7;color:var(--text-secondary);margin-bottom:14px;scroll-behavior:smooth;">
+            <span style="color:var(--text-muted);font-family:var(--font-mono);font-size:12px;">Click "Generate" to create your script…</span>
+          </div>
+          <div style="display:flex;gap:8px;flex-wrap:wrap;align-items:center;">
+            <button class="btn-primary" id="gen-lecture-btn">⬡ Generate</button>
+            <button class="btn-secondary" id="skip-back-btn" disabled title="Back 10 seconds">⏪ 10s</button>
+            <button class="btn-secondary" id="play-btn" disabled>▶ Play</button>
+            <button class="btn-secondary" id="skip-fwd-btn" disabled title="Forward 10 seconds">10s ⏩</button>
+            <button class="btn-secondary" id="stop-btn" disabled>■ Stop</button>
+            <select id="lecture-speed" class="config-select" style="width:auto;padding:8px 12px;font-size:12px;">
+              <option value="0.8">Slow</option>
+              <option value="1" selected>Normal</option>
+              <option value="1.3">Fast</option>
+            </select>
+          </div>
+        </div>
+
+        <!-- Quiz Panel -->
+        <div id="quiz-panel" style="display:none;">
+          <div style="padding:24px;text-align:center;background:var(--bg-raised);border:1px solid var(--border);border-radius:var(--radius-md);">
+            <div style="font-size:32px;margin-bottom:12px;">❓</div>
+            <div style="font-family:var(--font-ui);font-size:15px;font-weight:700;color:var(--text-primary);margin-bottom:8px;">Practice Questions</div>
+            <p style="font-family:var(--font-body);font-size:13px;color:var(--text-secondary);line-height:1.65;margin-bottom:18px;">
+              Your practice questions live in the <strong>Review tab</strong> — powered by spaced repetition so you're tested at the right time.
+            </p>
+            <button class="btn-primary" id="lm-go-review" style="width:100%;justify-content:center;">Go to Review →</button>
+          </div>
+        </div>
+      </div>`;
+  },
+
+  _bindAllEvents() {
+    // Tab switching
+    document.getElementById('tab-slides')?.addEventListener('click',  () => this._switchTab('slides'));
+    document.getElementById('tab-lecture')?.addEventListener('click', () => this._switchTab('lecture'));
+    document.getElementById('tab-quiz')?.addEventListener('click',    () => this._switchTab('quiz'));
+
+    // Slide controls
+    document.getElementById('gen-slides-btn')?.addEventListener('click', () => { this._forceSlideRegen = false; this._generateSlides(); });
+    document.getElementById('slide-regen-btn')?.addEventListener('click', () => { this._forceSlideRegen = true; this._generateSlides(); });
+    document.getElementById('slide-prev-btn')?.addEventListener('click', () => this._gotoSlide(this._slideIndex - 1));
+    document.getElementById('slide-next-btn')?.addEventListener('click', () => this._gotoSlide(this._slideIndex + 1));
+    document.getElementById('slide-play-btn')?.addEventListener('click', () => this._togglePresentation());
+    document.getElementById('slide-present-btn')?.addEventListener('click', () => this._enterPresent());
+    document.getElementById('slide-pptx-btn')?.addEventListener('click', () => this._exportPptx());
+
+    // Lecture controls
+    document.getElementById('gen-lecture-btn')?.addEventListener('click', () => {
+      // If a lecture is already showing/cached, an explicit click means "regenerate".
+      this._forceRegen = !!(this._node.lectureCache?.[this._profileKey()]);
+      this._generateLecture();
+    });
+    document.getElementById('play-btn')?.addEventListener('click',         () => this._togglePlay());
+    document.getElementById('stop-btn')?.addEventListener('click',         () => this._stop());
+    document.getElementById('skip-back-btn')?.addEventListener('click',    () => this._skip(-1));
+    document.getElementById('skip-fwd-btn')?.addEventListener('click',     () => this._skip(1));
+
+    // Quiz controls
+    document.getElementById('lm-go-review')?.addEventListener('click', () => { Modal.close(); App.navigateTo('review'); });
+  },
+
+  _switchTab(mode) {
+    document.getElementById('tab-slides')?.classList.toggle('active',  mode==='slides');
+    document.getElementById('tab-lecture')?.classList.toggle('active', mode==='lecture');
+    document.getElementById('tab-quiz')?.classList.toggle('active',    mode==='quiz');
+    const sp = document.getElementById('slides-panel');  if (sp) sp.style.display = mode==='slides'  ? 'block' : 'none';
+    const lp = document.getElementById('lecture-panel'); if (lp) lp.style.display = mode==='lecture' ? 'block' : 'none';
+    const qp = document.getElementById('quiz-panel');    if (qp) qp.style.display = mode==='quiz'    ? 'block' : 'none';
+    // Leaving a tab stops any audio from that tab.
+    this._stop();
+    this._stopSlideNarration();
+  },
+
+  _profileKey() {
+    return this._node?.learnerProfile || AIService._activeProfile || 'college';
+  },
+
+  async _generateLecture() {
+    const btn  = document.getElementById('gen-lecture-btn');
+    const area = document.getElementById('lecture-script-area');
+    const profile = this._profileKey();
+
+    // Reuse a saved lecture for this level unless the user is explicitly
+    // regenerating (the button reads "Regenerate" once one is cached).
+    const cached = this._node.lectureCache?.[profile];
+    if (cached && !this._forceRegen) { this._displayLecture(cached, true); return; }
+    this._forceRegen = false;
+
+    btn.disabled = true; btn.textContent = '⬡ Generating…';
+    area.innerHTML = '<span style="color:var(--accent);font-family:var(--font-mono);font-size:12px;">AI is writing your lecture…</span>';
+    try {
+      let script;
+      if (AIService.hasApiKey()) {
+        script = await AIService.generateLecture(this._node);
+      } else {
+        await this._delay(1200); script = this._mockLecture();
+      }
+      // Save to the node so reopening (or switching back to this level) is free.
+      if (!this._node.lectureCache) this._node.lectureCache = {};
+      this._node.lectureCache[profile] = script;
+      try { nodeStore.save(this._node); } catch (e) { /* persistence is best-effort */ }
+      this._displayLecture(script, false);
+    } catch(e) {
+      area.innerHTML = `<span style="color:var(--red);font-family:var(--font-mono);font-size:12px;">Error: ${this._esc(e.message)}</span>`;
+      btn.disabled = false; btn.textContent = '⬡ Generate';
+    }
+  },
+
+  /** Render a lecture script into the panel and enable controls. */
+  _displayLecture(script, fromCache) {
+    this._script = script;
+    this._questions = this._node.questions || [];
+    const area = document.getElementById('lecture-script-area');
+    const btn  = document.getElementById('gen-lecture-btn');
+
+    // Preserve paragraph breaks (\n\n) for natural narration pauses; only
+    // collapse runs of spaces/tabs and single newlines within a paragraph.
+    const fullText = script
+      .replace(/\[PAUSE\]/g, '. ')           // old pause cues → sentence stop
+      .replace(/[#*_`>]/g, ' ')              // strip markdown symbols
+      .replace(/\r/g, '')
+      .replace(/\n{2,}/g, '\n\n')            // normalise paragraph breaks
+      .replace(/[ \t]+/g, ' ')               // collapse spaces/tabs only
+      .replace(/ *\n *(?!\n)/g, ' ')         // join single newlines into spaces
+      .trim();
+    this._chunks = this._chunkText(fullText, 200);
+    // Resume from saved position if we have one for this node
+    const savedPos = this._loadPosition();
+    this._chunkIndex = (savedPos > 0 && savedPos < this._chunks.length) ? savedPos : 0;
+
+    const savedBadge = fromCache
+      ? '<div style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);margin-bottom:8px;">💾 Saved lecture for <b>' + this._esc(this._profileKey()) + '</b> level — tap Regenerate for a fresh one.</div>'
+      : '';
+    if (area) area.innerHTML = savedBadge
+      + '<div id="lecture-text" style="white-space:normal;font-size:15px;line-height:1.8;">'
+      + this._chunks.map((c, i) => `<span class="lm-chunk" id="lm_chunk_${i}" data-i="${i}">${this._esc(c.text)} </span>`).join('')
+      + '</div>';
+
+    ['play-btn','stop-btn','skip-back-btn','skip-fwd-btn'].forEach(id => {
+      const el = document.getElementById(id); if (el) el.disabled = false;
+    });
+    if (btn) { btn.disabled = false; btn.textContent = '⬡ Regenerate'; }
+
+    // If resuming, highlight where we left off (the Resume button label is enough — no toast)
+    if (this._chunkIndex > 0) {
+      this._highlightChunk(this._chunkIndex);
+      const playBtn = document.getElementById('play-btn');
+      if (playBtn) playBtn.textContent = '▶ Resume';
+    }
+  },
+
+  // ─── Slide Lecture ────────────────────────────────────
+
+  async _generateSlides() {
+    const stage = document.getElementById('slides-stage');
+    const profile = this._profileKey();
+    const cached = this._node.lectureSlidesCache?.[profile];
+    if (cached && cached.length && !this._forceSlideRegen) { this._displaySlides(cached, true); return; }
+    this._forceSlideRegen = false;
+    this._stopSlideNarration();
+
+    if (stage) stage.innerHTML = '<div style="background:var(--bg-raised);border:1px solid var(--border);border-radius:14px;padding:48px 24px;text-align:center;"><div style="font-family:var(--font-mono);font-size:12px;color:var(--accent);">⬡ Building your slides…</div></div>';
+    try {
+      let slides;
+      if (AIService.hasApiKey()) {
+        slides = await AIService.generateLectureSlides(this._node);
+      } else {
+        await this._delay(900); slides = this._mockSlides();
+      }
+      if (!this._node.lectureSlidesCache) this._node.lectureSlidesCache = {};
+      this._node.lectureSlidesCache[profile] = slides;
+      try { nodeStore.save(this._node); } catch(e) { /* best-effort */ }
+      this._displaySlides(slides, false);
+    } catch(e) {
+      if (stage) stage.innerHTML = '<div style="background:var(--bg-raised);border:1px solid var(--border);border-radius:14px;padding:40px 24px;text-align:center;"><div style="color:var(--red);font-family:var(--font-mono);font-size:12px;margin-bottom:14px;">Error: ' + this._esc(e.message) + '</div><button class="btn-secondary" id="slides-retry">Try again</button></div>';
+      document.getElementById('slides-retry')?.addEventListener('click', () => this._generateSlides());
+    }
+  },
+
+  _displaySlides(slides, fromCache) {
+    if (!Array.isArray(slides) || !slides.length) return;
+    this._slides = slides;
+    this._slideIndex = 0;
+    const controls = document.getElementById('slides-controls');
+    if (controls) controls.style.display = 'flex';
+    this._renderSlide();
+  },
+
+  _renderSlide() {
+    const stage = document.getElementById('slides-stage');
+    if (!stage || !this._slides || !this._slides.length) return;
+    const i = this._slides[this._slideIndex] ? this._slideIndex : 0;
+    const s = this._slides[i];
+    const total = this._slides.length;
+    const pct = Math.round(((i + 1) / total) * 100);
+    const kicker = this._esc(((this._node.subject || 'Lecture') + (this._node.chapter ? ' · ' + this._node.chapter : '')).toUpperCase());
+    const topic = this._esc(this._node.title || '');
+    const footer =
+      '<div class="lm-deck-footer">'
+      + '<span class="lm-deck-topic">' + topic + '</span>'
+      + '<span class="lm-deck-num">' + (i + 1) + ' / ' + total + '</span>'
+      + '</div>';
+    const progress = '<div class="lm-deck-progress"><div class="lm-deck-progress-fill" style="width:' + pct + '%;"></div></div>';
+
+    if (s.kind === 'activity') {
+      const typeLabel = { recall: 'Recall', apply: 'Apply', reflect: 'Reflect' }[s.activityType] || 'Activity';
+      stage.innerHTML =
+        '<div class="lm-deck lm-deck-activity" key="' + i + '">'
+        + progress
+        + '<div class="lm-deck-body">'
+        +   '<div class="lm-activity-badge">✏️ Your turn · ' + typeLabel + '</div>'
+        +   '<h3 class="lm-deck-title">' + this._esc(s.title) + '</h3>'
+        +   '<p class="lm-activity-prompt">' + this._esc(s.prompt) + '</p>'
+        +   '<textarea id="lm-activity-input" class="lm-activity-input" rows="3" placeholder="Type your answer…"></textarea>'
+        +   '<div class="lm-activity-actions">'
+        +     '<button class="btn-primary" id="lm-activity-check">Check my answer</button>'
+        +     (s.answer ? '<button class="btn-secondary" id="lm-activity-reveal">Reveal answer</button>' : '')
+        +   '</div>'
+        +   '<div id="lm-activity-feedback" class="lm-activity-feedback" style="display:none;"></div>'
+        + '</div>'
+        + footer
+        + '</div>';
+      document.getElementById('lm-activity-check')?.addEventListener('click', () => this._checkActivity(s));
+      document.getElementById('lm-activity-reveal')?.addEventListener('click', () => this._revealActivity(s));
+    } else {
+      const isTitle = (i === 0) && (!s.bullets || s.bullets.length === 0);
+      const bullets = (s.bullets || []).map((b, n) =>
+        '<li style="animation-delay:' + (0.12 + n * 0.08).toFixed(2) + 's">' + this._esc(b) + '</li>').join('');
+      stage.innerHTML =
+        '<div class="lm-deck lm-deck-teach' + (isTitle ? ' lm-deck-titleslide' : '') + '" key="' + i + '">'
+        + progress
+        + '<div class="lm-deck-body">'
+        +   '<div class="lm-deck-kicker">' + kicker + '</div>'
+        +   '<h3 class="lm-deck-title">' + this._esc(s.title) + '</h3>'
+        +   (bullets ? '<ul class="lm-deck-bullets">' + bullets + '</ul>' : '')
+        + '</div>'
+        + (s.explanation ? '<div class="lm-deck-notes"><span class="lm-deck-notes-label">Narration</span><span class="lm-deck-notes-text">' + this._esc(s.explanation) + '</span></div>' : '')
+        + footer
+        + '</div>';
+    }
+
+    const prev = document.getElementById('slide-prev-btn'); if (prev) prev.disabled = i === 0;
+    const next = document.getElementById('slide-next-btn'); if (next) next.disabled = i >= total - 1;
+    // Restart narration for the new slide if auto-narrate is on; otherwise just
+    // reset the play button. (No audio without an explicit toggle/gesture.)
+    this._stopSlideNarration();
+    if (this._autoNarrate) this._narrateCurrentSlide();
+    else this._updateSlidePlayBtn();
+  },
+
+  async _checkActivity(slide) {
+    const input = document.getElementById('lm-activity-input');
+    const fb = document.getElementById('lm-activity-feedback');
+    const answer = (input?.value || '').trim();
+    if (!answer) { Toast.info('Type an answer first, or tap Reveal answer.'); return; }
+    if (fb) { fb.style.display = 'block'; fb.innerHTML = '<span style="font-family:var(--font-mono);font-size:12px;color:var(--accent);">Checking…</span>'; }
+    let result;
+    try {
+      result = AIService.hasApiKey()
+        ? await AIService.checkAnswer(slide.prompt, slide.answer || '', answer, this._node.subject, this._node)
+        : this._mockGrade(answer, slide.answer || '');
+    } catch { result = this._mockGrade(answer, slide.answer || ''); }
+    const color = result.score >= 70 ? 'var(--green)' : result.score >= 40 ? 'var(--accent)' : 'var(--red)';
+    if (fb) fb.innerHTML =
+      '<div style="border-left:3px solid ' + color + ';padding:10px 14px;background:var(--bg-base);border-radius:var(--radius-sm);">'
+      + '<div style="font-family:var(--font-ui);font-size:14px;font-weight:700;color:' + color + ';margin-bottom:6px;">' + result.score + '/100</div>'
+      + '<p style="font-family:var(--font-body);font-size:13px;color:var(--text-primary);margin:0 0 8px;">' + this._esc(result.feedback) + '</p>'
+      + (slide.answer ? '<div style="padding-top:8px;border-top:1px solid var(--border-soft);font-family:var(--font-body);font-size:12px;color:var(--text-secondary);"><b>Model answer:</b> ' + this._esc(slide.answer) + '</div>' : '')
+      + '<div style="margin-top:10px;"><button class="btn-primary" id="lm-activity-continue">Continue →</button></div>'
+      + '</div>';
+    document.getElementById('lm-activity-continue')?.addEventListener('click', () => this._gotoSlide(this._slideIndex + 1));
+  },
+
+  _revealActivity(slide) {
+    const fb = document.getElementById('lm-activity-feedback');
+    if (fb) {
+      fb.style.display = 'block';
+      fb.innerHTML =
+        '<div style="border-left:3px solid var(--accent);padding:10px 14px;background:var(--bg-base);border-radius:var(--radius-sm);">'
+        + '<div style="font-family:var(--font-mono);font-size:10px;text-transform:uppercase;letter-spacing:0.08em;color:var(--text-muted);margin-bottom:6px;">Model answer</div>'
+        + '<p style="font-family:var(--font-body);font-size:13px;color:var(--text-primary);margin:0 0 10px;">' + this._esc(slide.answer) + '</p>'
+        + '<button class="btn-primary" id="lm-activity-continue">Continue →</button>'
+        + '</div>';
+      document.getElementById('lm-activity-continue')?.addEventListener('click', () => this._gotoSlide(this._slideIndex + 1));
+    }
+  },
+
+  _gotoSlide(idx) {
+    if (!this._slides) return;
+    const clamped = Math.max(0, Math.min(this._slides.length - 1, idx));
+    if (clamped === this._slideIndex) return;
+    this._slideIndex = clamped;
+    if (this._presentMode) this._renderPresent();
+    else this._renderSlide();
+  },
+
+  /** What the "lecturer" says aloud. For a teaching slide: the explanation,
+   *  prefixed by the title. For an activity: a cue plus the prompt. */
+  _slideNarrationText(s) {
+    if (s.kind === 'activity') {
+      return 'Let\'s pause for a quick activity. ' + (s.prompt || s.title || '');
+    }
+    const body = s.explanation || (s.bullets || []).join('. ');
+    return (s.title ? s.title + '. ' : '') + body;
+  },
+
+  _narrateCurrentSlide() {
+    if (!this._speechSupported()) { Toast.error('Read-aloud needs Chrome or Edge.'); return; }
+    const s = this._slides && this._slides[this._slideIndex];
+    if (!s) return;
+    const chunks = this._chunkText(this._slideNarrationText(s), 200);
+    const speed = parseFloat(document.getElementById('slide-speed')?.value || 1);
+    if (this._isCapacitor()) { this._capStop(); } else { this._synth.cancel(); }
+    if (!this._isCapacitor()) {
+      const voices = this._synth.getVoices();
+      this._voice = voices.length
+        ? (voices.find(v => v.lang.startsWith('en') && /Google|Natural|Online|Samsung/.test(v.name))
+          || voices.find(v => v.lang.startsWith('en')) || voices[0])
+        : null;
+    }
+    this._slideSpeaking = true;
+    this._updateSlidePlayBtn();
+    let k = 0;
+    const speakNext = () => {
+      if (!this._slideSpeaking) return;
+      if (k >= chunks.length) {
+        this._slideSpeaking = false;
+        this._updateSlidePlayBtn();
+        const cur = this._slides[this._slideIndex];
+        if (this._autoNarrate && cur && cur.kind !== 'activity' && this._slideIndex < this._slides.length - 1) {
+          this._pauseTimer = setTimeout(() => this._gotoSlide(this._slideIndex + 1), 700);
+        }
+        return;
+      }
+      const chunk = chunks[k];
+      if (this._isCapacitor()) {
+        this._capSpeak(chunk.text, speed * 0.9, () => {
+          const justRead = chunk; k++;
+          if (this._slideSpeaking) this._pauseTimer = setTimeout(speakNext, this._pauseFor(justRead.pause));
+        });
+        return;
+      }
+      const u = new SpeechSynthesisUtterance(chunks[k].text);
+      u.rate = speed * 0.9; u.pitch = 0.95; u.lang = 'en-US';
+      if (this._voice) u.voice = this._voice;
+      u.onend = () => {
+        const justRead = chunks[k]; k++;
+        if (this._slideSpeaking) this._pauseTimer = setTimeout(speakNext, this._pauseFor(justRead.pause));
+      };
+      u.onerror = (e) => {
+        if (e.error === 'interrupted' || e.error === 'canceled') return;
+        k++;
+        if (this._slideSpeaking && k < chunks.length) speakNext();
+        else { this._slideSpeaking = false; this._updateSlidePlayBtn(); }
+      };
+      this._utterance = u;
+      try { this._synth.speak(u); }
+      catch(err) { this._slideSpeaking = false; this._updateSlidePlayBtn(); }
+    };
+    speakNext();
+  },
+
+  /** Play/pause the whole narrated lecture: narrate the current slide and
+   *  auto-advance through teaching slides, pausing at activity break points. */
+  _togglePresentation() {
+    if (this._slideSpeaking) {
+      this._autoNarrate = false;
+      this._stopSlideNarration();
+    } else {
+      if (!this._speechSupported()) { Toast.error('Read-aloud needs Chrome or Edge. You can still tap through the slides.'); return; }
+      this._autoNarrate = true;
+      this._narrateCurrentSlide();
+    }
+  },
+
+  _stopSlideNarration() {
+    this._slideSpeaking = false;
+    this._clearPauseTimer();
+    if (this._isCapacitor()) { this._capStop(); }
+    else if (this._speechSupported()) { this._synth.cancel(); }
+    this._updateSlidePlayBtn();
+  },
+
+  _updateSlidePlayBtn() {
+    const txt = this._slideSpeaking ? '⏸ Pause' : '▶ Play';
+    const b = document.getElementById('slide-play-btn'); if (b) b.textContent = txt;
+    const p = document.getElementById('lm-present-play'); if (p) p.textContent = txt;
+  },
+
+  // ─── Full-screen presentation ─────────────────────────
+  _enterPresent() {
+    if (!this._slides || !this._slides.length) { Toast.info('Generate the lecture first.'); return; }
+    if (document.getElementById('lm-present')) return;
+    this._presentMode = true;
+
+    // Lock body scroll using a CSS class — safer than position:fixed on mobile
+    // (position:fixed causes page-jump and can hide the overlay on some browsers).
+    const mcSave = document.getElementById('main-content');
+    this._scrollY = mcSave ? mcSave.scrollTop : window.scrollY;
+    document.body.classList.add('lm-presenting');
+    document.body.style.top = '-' + this._scrollY + 'px';
+
+    const el = document.createElement('div');
+    el.id = 'lm-present';
+    el.className = 'lm-present';
+    el.innerHTML =
+      '<div class="lm-present-top">'
+      +   '<span class="lm-present-kicker" id="lm-present-kicker"></span>'
+      +   '<div style="display:flex;gap:8px;">'
+      +     '<button class="lm-present-iconbtn" id="lm-present-notes" title="Speaker notes">📝</button>'
+      +     '<button class="lm-present-iconbtn" id="lm-present-exit" title="Exit full screen">✕</button>'
+      +   '</div>'
+      + '</div>'
+      + '<div id="lm-present-stage" class="lm-present-stage"></div>'
+      + '<div id="lm-present-notes-sheet" class="lm-present-notes-sheet" style="display:none;"></div>'
+      + '<div class="lm-present-bar">'
+      +   '<button class="btn-secondary" id="lm-present-prev">← Prev</button>'
+      +   '<button class="btn-primary" id="lm-present-play">▶ Play</button>'
+      +   '<button class="btn-secondary" id="lm-present-next">Next →</button>'
+      + '</div>';
+    document.body.appendChild(el);
+
+    // Block touchmove on the overlay so rubber-band scroll can't bleed through
+    // to whatever is underneath. The notes sheet, slide stage, and activity
+    // input are exempt — they need to scroll internally.
+    el.addEventListener('touchmove', (e) => {
+      if (!e.target.closest('#lm-present-notes-sheet, #lm-present-stage, #lm-activity-input')) {
+        e.preventDefault();
+      }
+    }, { passive: false });
+
+    document.getElementById('lm-present-exit').addEventListener('click', () => this._exitPresent());
+    document.getElementById('lm-present-prev').addEventListener('click', () => this._gotoSlide(this._slideIndex - 1));
+    document.getElementById('lm-present-next').addEventListener('click', () => this._gotoSlide(this._slideIndex + 1));
+    document.getElementById('lm-present-play').addEventListener('click', () => this._togglePresentation());
+    document.getElementById('lm-present-notes').addEventListener('click', () => this._togglePresentNotes());
+    this._renderPresent();
+  },
+
+  _exitPresent() {
+    this._presentMode = false;
+    this._autoNarrate = false;
+    this._stopSlideNarration();
+    document.getElementById('lm-present')?.remove();
+    // Restore body scroll and position
+    document.body.classList.remove('lm-presenting');
+    document.body.style.top = '';
+    const mcRestore = document.getElementById('main-content');
+    if (mcRestore) mcRestore.scrollTop = this._scrollY || 0;
+    window.scrollTo(0, this._scrollY || 0);
+    this._renderSlide(); // keep the inline stage in sync with where they left off
+  },
+
+  _renderPresent() {
+    const stage = document.getElementById('lm-present-stage');
+    if (!stage) return;
+    const i = this._slides[this._slideIndex] ? this._slideIndex : 0;
+    const s = this._slides[i];
+    const total = this._slides.length;
+    const kicker = this._esc(((this._node.subject || 'Lecture') + (this._node.chapter ? ' · ' + this._node.chapter : '')).toUpperCase());
+    const kEl = document.getElementById('lm-present-kicker'); if (kEl) kEl.textContent = (i + 1) + ' / ' + total;
+
+    if (s.kind === 'activity') {
+      const typeLabel = { recall:'Recall', apply:'Apply', reflect:'Reflect' }[s.activityType] || 'Activity';
+      stage.innerHTML =
+        '<div class="lm-present-slide lm-present-activity">'
+        + '<div class="lm-activity-badge">✏️ Your turn · ' + typeLabel + '</div>'
+        + '<h2 class="lm-present-title">' + this._esc(s.title) + '</h2>'
+        + '<p class="lm-activity-prompt">' + this._esc(s.prompt) + '</p>'
+        + '<textarea id="lm-activity-input" class="lm-activity-input" rows="3" placeholder="Type your answer…"></textarea>'
+        + '<div class="lm-activity-actions">'
+        +   '<button class="btn-primary" id="lm-activity-check">Check my answer</button>'
+        +   (s.answer ? '<button class="btn-secondary" id="lm-activity-reveal">Reveal answer</button>' : '')
+        + '</div>'
+        + '<div id="lm-activity-feedback" class="lm-activity-feedback" style="display:none;"></div>'
+        + '</div>';
+      document.getElementById('lm-activity-check')?.addEventListener('click', () => this._checkActivity(s));
+      document.getElementById('lm-activity-reveal')?.addEventListener('click', () => this._revealActivity(s));
+    } else {
+      const bullets = (s.bullets || []).map((b, n) =>
+        '<li style="animation-delay:' + (0.1 + n * 0.07).toFixed(2) + 's">' + this._esc(b) + '</li>').join('');
+      // Show a short preview of the narration inline (≤4 bullets only).
+      // Full narration is always available via the 📝 notes button.
+      const MAX_NARRATION = 220;
+      const showInlineNarration = s.explanation && (s.bullets || []).length <= 4;
+      const narrationPreview = showInlineNarration
+        ? (() => {
+            const exp = s.explanation;
+            if (exp.length <= MAX_NARRATION) return exp;
+            // Try to end on a sentence boundary within the limit
+            const cut = exp.slice(0, MAX_NARRATION);
+            const lastDot = Math.max(cut.lastIndexOf('. '), cut.lastIndexOf('! '), cut.lastIndexOf('? '));
+            return lastDot > MAX_NARRATION * 0.5
+              ? exp.slice(0, lastDot + 1)
+              : cut.replace(/\s+\S*$/, '') + '…';
+          })()
+        : null;
+      stage.innerHTML =
+        '<div class="lm-present-slide">'
+        + '<div class="lm-present-kicker2">' + kicker + '</div>'
+        + '<h2 class="lm-present-title">' + this._esc(s.title) + '</h2>'
+        + (bullets ? '<ul class="lm-present-bullets">' + bullets + '</ul>' : '')
+        + (narrationPreview
+            ? '<div class="lm-present-narration">' + this._esc(narrationPreview) + '</div>'
+            : '')
+        + '</div>';
+    }
+    const sheet = document.getElementById('lm-present-notes-sheet');
+    if (sheet && sheet.style.display !== 'none') {
+      sheet.innerHTML = '<span class="lm-deck-notes-label">Narration</span>' + this._esc(s.explanation || s.prompt || '');
+    }
+    const prev = document.getElementById('lm-present-prev'); if (prev) prev.disabled = i === 0;
+    const next = document.getElementById('lm-present-next'); if (next) next.disabled = i >= total - 1;
+    this._stopSlideNarration();
+    if (this._autoNarrate) this._narrateCurrentSlide();
+    else this._updateSlidePlayBtn();
+  },
+
+  _togglePresentNotes() {
+    const sheet = document.getElementById('lm-present-notes-sheet');
+    if (!sheet) return;
+    const show = sheet.style.display === 'none';
+    sheet.style.display = show ? 'block' : 'none';
+    if (show) {
+      const s = this._slides[this._slideIndex];
+      sheet.innerHTML = '<span class="lm-deck-notes-label">Narration</span>' + this._esc(s.explanation || s.prompt || '');
+    }
+  },
+
+  // ─── Export to a real, editable PowerPoint (.pptx) ────
+  /** Pure mapping from slides → a plain deck model (unit-testable). */
+  _pptxModel() {
+    const n = this._node;
+    const safe = (n.title || 'lecture').replace(/[^a-z0-9 _-]/gi, '').trim() || 'lecture';
+    return {
+      fileName: safe,
+      title: n.title || 'Lecture',
+      subtitle: ((n.subject || '') + (n.chapter ? ' · ' + n.chapter : '')).trim(),
+      slides: (this._slides || []).map(s => s.kind === 'activity'
+        ? { kind: 'activity', title: s.title || 'Your turn', bullets: [s.prompt || ''].filter(Boolean), notes: s.answer || '' }
+        : { kind: 'teach', title: s.title || '', bullets: (s.bullets || []).slice(), notes: s.explanation || '' }),
+    };
+  },
+
+  async _exportPptx() {
+    if (!this._slides || !this._slides.length) { Toast.info('Generate the lecture first.'); return; }
+    if (typeof PptxGenJS === 'undefined') { Toast.error('PowerPoint export is still loading — try again in a moment.'); return; }
+    const btn = document.getElementById('slide-pptx-btn');
+    const old = btn ? btn.textContent : '';
+    if (btn) { btn.disabled = true; btn.textContent = '⬇ Building…'; }
+    try {
+      const model = this._pptxModel();
+      const pptx = new PptxGenJS();
+      pptx.layout = 'LAYOUT_16x9';
+      pptx.author = 'KnowledgeNode';
+      pptx.title  = model.title;
+      const ACCENT = '5B8DEF', DARK = '0E1116', LIGHT = 'E8ECF2', MUTED = '9AA4B2';
+      // Title slide
+      const t = pptx.addSlide(); t.background = { color: DARK };
+      t.addShape(pptx.ShapeType.rect, { x: 0, y: 0, w: 10, h: 0.25, fill: { color: ACCENT } });
+      t.addText(model.title, { x: 0.6, y: 2.0, w: 8.8, h: 1.4, fontSize: 40, bold: true, color: LIGHT, align: 'center' });
+      if (model.subtitle) t.addText(model.subtitle, { x: 0.6, y: 3.5, w: 8.8, h: 0.6, fontSize: 18, color: ACCENT, align: 'center' });
+      // Content slides
+      model.slides.forEach((s, idx) => {
+        const sl = pptx.addSlide(); sl.background = { color: DARK };
+        sl.addShape(pptx.ShapeType.rect, { x: 0, y: 0, w: 10, h: 0.18, fill: { color: ACCENT } });
+        sl.addText(s.title, { x: 0.6, y: 0.45, w: 8.8, h: 0.9, fontSize: 26, bold: true, color: s.kind === 'activity' ? ACCENT : LIGHT });
+        if (s.bullets && s.bullets.length) {
+          sl.addText(
+            s.bullets.map(b => ({ text: b, options: { bullet: { code: '25B8' }, color: LIGHT, fontSize: 18, paraSpaceAfter: 12 } })),
+            { x: 0.8, y: 1.6, w: 8.4, h: 3.4, valign: 'top' }
+          );
+        }
+        sl.addText((idx + 1) + ' / ' + model.slides.length, { x: 8.3, y: 5.05, w: 1.3, h: 0.3, fontSize: 10, color: MUTED, align: 'right' });
+        if (s.notes) sl.addNotes(s.notes);
+      });
+      await pptx.writeFile({ fileName: model.fileName + '.pptx' });
+      Toast.success('PowerPoint saved to your device.');
+    } catch (e) {
+      Toast.error('Could not create the PowerPoint: ' + (e && e.message || e));
+    } finally {
+      if (btn) { btn.disabled = false; btn.textContent = old; }
+    }
+  },
+
+  /** Offline/no-key fallback deck built from the node's structured content,
+   *  with an activity break point so the structure matches the real deck. */
+  _mockSlides() {
+    const n = this._node;
+    const slides = [];
+    slides.push({ kind: 'teach', title: n.title || 'Overview', bullets: [ (n.subject || 'This topic') + (n.chapter ? ' · ' + n.chapter : '') ].filter(Boolean), explanation: 'This deck covers ' + (n.title || 'this topic') + '. ' + (n.summary || '') });
+    const defs = (n.definitions || []).slice(0, 6);
+    defs.forEach(d => slides.push({ kind: 'teach', title: d.term || 'Definition', bullets: [d.description || ''].filter(Boolean), explanation: (d.term ? d.term + ': ' : '') + (d.description || '') }));
+    // Break point: a recall activity on the first definition, if we have one.
+    if (defs.length && defs[0].term) {
+      slides.push({ kind: 'activity', title: 'Quick check', prompt: 'In your own words, what does "' + defs[0].term + '" mean?', answer: defs[0].description || '', activityType: 'recall' });
+    }
+    if ((n.formulas || []).length) slides.push({ kind: 'teach', title: 'Key formulas', bullets: n.formulas.map(f => (f.expression || '') + (f.description ? ' — ' + f.description : '')).filter(Boolean), explanation: 'These are the formulas to remember for this topic.' });
+    if (n.summary) slides.push({ kind: 'teach', title: 'Summary', bullets: [n.summary], explanation: n.summary });
+    let deck = slides.filter(s => s.kind === 'activity' ? !!s.prompt : (s.bullets.length || s.explanation));
+    // Always include at least one activity break, even when the node has no
+    // structured definitions to build one from.
+    if (!deck.some(s => s.kind === 'activity')) {
+      const act = { kind: 'activity', title: 'Your turn', prompt: 'In a sentence or two, explain the main idea of ' + (n.title || 'this topic') + ' in your own words.', answer: n.summary || '', activityType: 'reflect' };
+      // Insert before the final summary slide if there is one, else append.
+      const lastIsSummary = deck.length && /summary/i.test(deck[deck.length - 1].title || '');
+      if (lastIsSummary) deck.splice(deck.length - 1, 0, act); else deck.push(act);
+    }
+    return deck;
+  },
+
+  _togglePlay() { this._isPlaying ? this._pause() : this._play(); },
+
+  _play() {
+    if (!this._chunks || !this._chunks.length) return;
+    if (!this._speechSupported()) {
+      Toast.error('Your browser does not support text-to-speech. Try Chrome or Edge.');
+      return;
+    }
+    const speed = parseFloat(document.getElementById('lecture-speed')?.value || 1);
+    if (this._isCapacitor()) {
+      this._capStop();
+    } else {
+      this._synth.cancel();
+    }
+    if (this._chunkIndex === 0) {
+      const saved = this._loadPosition();
+      if (saved > 0 && saved < this._chunks.length) this._chunkIndex = saved;
+    }
+    if (this._chunkIndex >= this._chunks.length) this._chunkIndex = 0;
+    if (!this._isCapacitor()) {
+      const voices = this._synth.getVoices();
+      this._voice = voices.length
+        ? (voices.find(v => v.lang.startsWith('en') && /Google|Natural|Online|Samsung/.test(v.name))
+          || voices.find(v => v.lang.startsWith('en')) || voices[0])
+        : null;
+    }
+    this._isPlaying = true; this._updatePlayBtn();
+    this._speakNextChunk(speed);
+  },
+
+  /** Split text into natural narration units: one sentence per chunk, with
+   *  paragraph breaks marked. This gives a real pause at every period and a
+   *  longer pause between paragraphs — like an audiobook narrator. */
+  _chunkText(text, maxLen) {
+    // Preserve paragraph breaks as explicit markers
+    const paragraphs = text.split(/\n\s*\n/).map(p => p.trim()).filter(Boolean);
+    const chunks = [];
+
+    paragraphs.forEach((para, pIdx) => {
+      // Split into sentences — keep the terminal punctuation
+      const sentences = para.match(/[^.!?]+[.!?]+(\s|$)|[^.!?]+$/g) || [para];
+      sentences.forEach(sentence => {
+        const s = sentence.trim();
+        if (!s) return;
+        // For very long sentences, split on commas/semicolons so the narrator
+        // takes a breath mid-sentence rather than racing through.
+        if (s.length > 180) {
+          const clauses = s.match(/[^,;:]+[,;:]+(\s|$)|[^,;:]+$/g) || [s];
+          let buf = '';
+          clauses.forEach(cl => {
+            const c = cl.trim();
+            if ((buf + ' ' + c).length > 180 && buf) {
+              chunks.push({ text: buf.trim(), pause: 'clause' });
+              buf = '';
+            }
+            buf += (buf ? ' ' : '') + c;
+          });
+          if (buf.trim()) chunks.push({ text: buf.trim(), pause: 'sentence' });
+        } else {
+          chunks.push({ text: s, pause: 'sentence' });
+        }
+      });
+      // Mark the last chunk of a paragraph for a longer pause
+      if (chunks.length && pIdx < paragraphs.length - 1) {
+        chunks[chunks.length - 1].pause = 'paragraph';
+      }
+    });
+
+    // Fallback: if nothing parsed, return the whole text as one chunk
+    if (!chunks.length) chunks.push({ text: text.trim(), pause: 'sentence' });
+
+    // Safety net: hard-wrap any chunk longer than maxLen on word boundaries.
+    // A long unpunctuated passage could otherwise become one giant utterance
+    // that some mobile TTS engines truncate or drop entirely.
+    const cap = maxLen || 200;
+    const wrapped = [];
+    chunks.forEach(chunk => {
+      if (chunk.text.length <= cap) { wrapped.push(chunk); return; }
+      const words = chunk.text.split(/\s+/);
+      let buf = '';
+      words.forEach(w => {
+        if (buf && (buf + ' ' + w).length > cap) {
+          wrapped.push({ text: buf, pause: 'clause' });
+          buf = '';
+        }
+        buf += (buf ? ' ' : '') + w;
+      });
+      if (buf) wrapped.push({ text: buf, pause: chunk.pause });
+    });
+    return wrapped;
+  },
+
+  /** Pause length in milliseconds after a chunk, by break type. */
+  _pauseFor(type) {
+    switch (type) {
+      case 'clause':    return 180;  // brief breath mid-sentence
+      case 'sentence':  return 420;  // clear stop at a period
+      case 'paragraph': return 850;  // longer rest between paragraphs
+      default:          return 350;
+    }
+  },
+
+  _speakNextChunk(speed) {
+    if (!this._isPlaying) return;
+    if (this._chunkIndex >= this._chunks.length) {
+      this._isPlaying = false; this._updatePlayBtn();
+      this._highlightChunk(-1);
+      if (typeof SpeechPill !== 'undefined') SpeechPill.hide();
+      return;
+    }
+    this._highlightChunk(this._chunkIndex);
+    const chunk = this._chunks[this._chunkIndex];
+    if (this._isCapacitor()) {
+      this._capSpeak(chunk.text, speed * 0.9, () => {
+        this._chunkIndex++;
+        this._savePosition();
+        const pauseMs = this._pauseFor(chunk.pause);
+        if (this._isPlaying) this._pauseTimer = setTimeout(() => this._speakNextChunk(speed), pauseMs);
+      });
+      return;
+    }
+    const u = new SpeechSynthesisUtterance(chunk.text);
+    // Narration settings: slightly slower and lower for an audiobook feel
+    u.rate  = speed * 0.9;
+    u.pitch = 0.95;
+    u.lang  = 'en-US';
+    if (this._voice) u.voice = this._voice;
+    u.onend = () => {
+      this._chunkIndex++;
+      this._savePosition();
+      // Insert a natural silent pause before the next chunk
+      const pauseMs = this._pauseFor(chunk.pause);
+      if (this._isPlaying) {
+        this._pauseTimer = setTimeout(() => this._speakNextChunk(speed), pauseMs);
+      }
+    };
+    u.onerror = (e) => {
+      if (e.error === 'interrupted' || e.error === 'canceled') return;
+      // Skip a failed chunk rather than aborting the whole lecture.
+      console.warn('[LectureMode] chunk speech error:', e.error);
+      this._chunkIndex++;
+      if (this._chunkIndex < this._chunks.length) { this._speakNextChunk(speed); }
+      else {
+        this._isPlaying = false; this._updatePlayBtn();
+        Toast.error('Read-aloud isn\'t available in this browser — the lecture text is shown below.');
+      }
+    };
+    this._utterance = u;
+    try { this._synth.speak(u); }
+    catch (err) {
+      this._isPlaying = false; this._updatePlayBtn();
+      Toast.error('Could not start read-aloud here. The lecture text is shown below.');
+    }
+  },
+
+  /** Highlight the chunk currently being read and scroll it into view. Pass -1 to clear. */
+  _highlightChunk(i) {
+    document.querySelectorAll('.lm-chunk.active').forEach(el => el.classList.remove('active'));
+    if (i < 0) return;
+    const el = document.getElementById('lm_chunk_' + i);
+    if (!el) return;
+    el.classList.add('active');
+    // Keep the active line comfortably in view inside the scroll box.
+    const box = document.getElementById('lecture-script-area');
+    if (box) {
+      const boxRect = box.getBoundingClientRect();
+      const elRect  = el.getBoundingClientRect();
+      if (elRect.top < boxRect.top + 24 || elRect.bottom > boxRect.bottom - 24) {
+        box.scrollTop += (elRect.top - boxRect.top) - box.clientHeight / 3;
+      }
+    }
+  },
+
+  /** Skip roughly ±10 seconds. At ~14 chars/sec speech, 10s ≈ 2 chunks of 200 chars. */
+  _skip(direction) {
+    if (!this._chunks || !this._chunks.length) return;
+    const wasPlaying = this._isPlaying;
+    this._clearPauseTimer();
+    if (this._isCapacitor()) { this._capStop(); } else { this._synth.cancel(); }
+    this._chunkIndex = Math.max(0, Math.min(this._chunks.length - 1, this._chunkIndex + direction * 2));
+    this._highlightChunk(this._chunkIndex);
+    if (wasPlaying) {
+      const speed = parseFloat(document.getElementById('lecture-speed')?.value || 1);
+      this._isPlaying = true; this._updatePlayBtn();
+      this._speakNextChunk(speed);
+    }
+  },
+
+  _savePosition() {
+    if (!this._node) return;
+    try {
+      const key = 'kn_lecture_pos';
+      const all = JSON.parse(localStorage.getItem(key) || '{}');
+      const posKey = this._node.id + ':' + this._profileKey();
+      // At the end, clear the saved position so next open starts fresh
+      if (this._chunkIndex >= (this._chunks?.length || 0)) {
+        delete all[posKey];
+      } else {
+        all[posKey] = this._chunkIndex;
+      }
+      localStorage.setItem(key, JSON.stringify(all));
+    } catch(e) { /* best-effort */ }
+  },
+
+  _loadPosition() {
+    try {
+      const all = JSON.parse(localStorage.getItem('kn_lecture_pos') || '{}');
+      const posKey = this._node.id + ':' + this._profileKey();
+      const v = all[posKey];
+      return (typeof v === 'number' && v > 0) ? v : 0;
+    } catch(e) { return 0; }
+  },
+
+  _pause() {
+    if (!this._speechSupported()) return;
+    this._clearPauseTimer();
+    // With chunked playback, cancel and stay on the current chunk so Play resumes
+    // from here (synth.pause/resume is unreliable on mobile).
+    this._isPlaying = false;
+    if (this._isCapacitor()) { this._capStop(); } else { this._synth.cancel(); }
+    this._savePosition();
+    this._updatePlayBtn();
+    // Leave the current chunk highlighted so the reader sees where they paused.
+  },
+  _stop() {
+    if (!this._speechSupported()) return;
+    this._clearPauseTimer();
+    this._isPlaying = false;
+    this._chunkIndex = 0;
+    if (this._isCapacitor()) { this._capStop(); } else { this._synth.cancel(); }
+    // Starting over — clear saved position
+    try {
+      const all = JSON.parse(localStorage.getItem('kn_lecture_pos') || '{}');
+      delete all[this._node.id + ':' + this._profileKey()];
+      localStorage.setItem('kn_lecture_pos', JSON.stringify(all));
+    } catch(e) {}
+    this._updatePlayBtn();
+    this._highlightChunk(-1);
+    if (typeof SpeechPill !== 'undefined') SpeechPill.hide();
+  },
+  _updatePlayBtn() { const b = document.getElementById('play-btn'); if (b) b.textContent = this._isPlaying ? '⏸ Pause' : '▶ Play'; },
+
+  // ─── Voice Input — Fixed proper binding ──────────────
+
+  _startVoiceInput() {
+    const btn = document.getElementById('voice-answer-btn');
+    if (!btn) return;
+
+    if (!('webkitSpeechRecognition' in window) && !('SpeechRecognition' in window)) {
+      Toast.error('Voice recognition requires Chrome or Edge.');
+      return;
+    }
+    const SR = window.SpeechRecognition || window.webkitSpeechRecognition;
+    const rec = new SR();
+    rec.continuous = false; rec.interimResults = true; rec.lang = 'en-US';
+
+    btn.textContent = '🔴 Listening…'; btn.style.color = 'var(--red)';
+    btn.disabled = true;
+
+    rec.onresult = e => {
+      const transcript = Array.from(e.results).map(r=>r[0].transcript).join('');
+      const ta = document.getElementById('quiz-text-answer');
+      if (ta) ta.value = transcript;
+    };
+    rec.onerror = err => {
+      Toast.error('Voice error: ' + err.error + '. Try speaking clearly into the mic.');
+      btn.textContent = '🎤 Voice Answer'; btn.style.color = ''; btn.disabled = false;
+    };
+    rec.onend = () => {
+      btn.textContent = '🎤 Voice Answer'; btn.style.color = ''; btn.disabled = false;
+    };
+
+    try { rec.start(); }
+    catch(e) { Toast.error('Could not start microphone: ' + e.message); btn.textContent = '🎤 Voice Answer'; btn.style.color = ''; btn.disabled = false; }
+  },
+
+  // ─── Quiz ─────────────────────────────────────────────
+
+  _startQuiz() {
+    if (!this._questions.length) {
+      Toast.info('No questions — generate a lecture first or add questions to this node.');
+      return;
+    }
+    this._currentQ = 0; this._quizAnswers = [];
+    document.getElementById('start-quiz-btn').style.display = 'none';
+    document.getElementById('quiz-progress').style.display  = 'block';
+    this._renderQuestion();
+  },
+
+  _renderQuestion() {
+    const q = this._questions[this._currentQ];
+    if (!q) { this._showQuizComplete(); return; }
+    const area = document.getElementById('quiz-question-area');
+    if (area) area.innerHTML = `
+      <div style="font-family:var(--font-mono);font-size:10px;text-transform:uppercase;letter-spacing:0.1em;color:var(--text-muted);margin-bottom:8px;">
+        Question ${this._currentQ+1} of ${this._questions.length} · ${q.type}
+      </div>
+      <div style="font-family:var(--font-ui);font-size:16px;font-weight:600;color:var(--text-primary);line-height:1.4;">${this._esc(q.question)}</div>`;
+
+    const ta = document.getElementById('quiz-text-answer');
+    if (ta) ta.value = '';
+    const ansArea = document.getElementById('quiz-answer-area');
+    if (ansArea) ansArea.style.display = 'block';
+    const feedback = document.getElementById('quiz-feedback');
+    if (feedback) feedback.style.display = 'none';
+    const nextBtn = document.getElementById('next-q-btn');
+    if (nextBtn) nextBtn.style.display = 'none';
+    const pct = (this._currentQ / this._questions.length) * 100;
+    const pFill = document.getElementById('quiz-progress-fill');
+    if (pFill) pFill.style.width = pct + '%';
+    const pLabel = document.getElementById('quiz-progress-label');
+    if (pLabel) pLabel.textContent = `${this._currentQ} / ${this._questions.length}`;
+
+    if (this._isCapacitor()) {
+      this._capSpeak(`Question ${this._currentQ+1}. ${q.question}`, 0.95, () => {});
+    } else if (this._speechSupported()) {
+      const u = new SpeechSynthesisUtterance(`Question ${this._currentQ+1}. ${q.question}`);
+      u.rate = 0.95; this._synth.cancel(); this._synth.speak(u);
+    }
+  },
+
+  async _submitAnswer() {
+    const q      = this._questions[this._currentQ];
+    const answer = document.getElementById('quiz-text-answer')?.value?.trim() || '';
+
+    const ansArea = document.getElementById('quiz-answer-area');
+    if (ansArea) ansArea.style.display = 'none';
+    const feedback = document.getElementById('quiz-feedback');
+    if (feedback) { feedback.style.display = 'block'; feedback.innerHTML = '<span style="font-family:var(--font-mono);font-size:12px;color:var(--accent);">Checking…</span>'; }
+
+    let result;
+    try {
+      result = AIService.hasApiKey()
+        ? await AIService.checkAnswer(q.question, q.answer, answer, this._node.subject)
+        : this._mockGrade(answer, q.answer);
+    } catch { result = this._mockGrade(answer, q.answer); }
+
+    this._quizAnswers.push({ question:q, studentAnswer:answer, result });
+
+    const color = result.score>=70?'var(--green)':result.score>=40?'var(--accent)':'var(--red)';
+    if (feedback) feedback.innerHTML = `
+      <div style="background:var(--bg-raised);border:1px solid var(--border);border-left:3px solid ${color};border-radius:var(--radius-md);padding:14px 18px;">
+        <div style="font-family:var(--font-ui);font-size:15px;font-weight:700;color:${color};margin-bottom:7px;">${result.score}/100</div>
+        <p style="font-family:var(--font-body);font-size:13px;color:var(--text-primary);margin-bottom:8px;">${this._esc(result.feedback)}</p>
+        <div style="padding-top:10px;border-top:1px solid var(--border-soft);font-family:var(--font-body);font-size:12px;color:var(--text-secondary);font-style:italic;">
+          Model: ${this._esc(q.answer.slice(0,100))}${q.answer.length>100?'…':''}
+        </div>
+      </div>`;
+
+    if (this._isCapacitor()) {
+      this._capSpeak(result.feedback, 0.95, () => {});
+    } else if (this._speechSupported()) {
+      const u = new SpeechSynthesisUtterance(result.feedback);
+      u.rate = 0.95; this._synth.cancel(); this._synth.speak(u);
+    }
+
+    const nextBtn = document.getElementById('next-q-btn');
+    if (nextBtn) { nextBtn.style.display = 'inline-flex'; nextBtn.textContent = this._currentQ < this._questions.length-1 ? 'Next →' : 'See Results'; }
+  },
+
+  _nextQuestion() { this._currentQ++; this._renderQuestion(); },
+
+  _showQuizComplete() {
+    const total = this._quizAnswers.length;
+    const avg   = total ? Math.round(this._quizAnswers.reduce((s,a)=>s+a.result.score,0)/total) : 0;
+    const area  = document.getElementById('quiz-question-area');
+    if (area) area.innerHTML = `
+      <div style="font-size:36px;margin-bottom:12px;">🎓</div>
+      <div style="font-family:var(--font-ui);font-size:18px;font-weight:800;margin-bottom:6px;">Quiz Complete!</div>
+      <div style="font-family:var(--font-mono);font-size:13px;color:var(--accent);">Average: ${avg}/100</div>`;
+    const ansArea = document.getElementById('quiz-answer-area');
+    const feedback = document.getElementById('quiz-feedback');
+    const nextBtn  = document.getElementById('next-q-btn');
+    const startBtn = document.getElementById('start-quiz-btn');
+    if (ansArea)  ansArea.style.display  = 'none';
+    if (feedback) feedback.style.display = 'none';
+    if (nextBtn)  nextBtn.style.display  = 'none';
+    if (startBtn) { startBtn.style.display = 'inline-flex'; startBtn.textContent = '↺ Restart Quiz'; }
+    const pFill = document.getElementById('quiz-progress-fill');
+    if (pFill) pFill.style.width = '100%';
+    const pLabel = document.getElementById('quiz-progress-label');
+    if (pLabel) pLabel.textContent = `${total} / ${total}`;
+  },
+
+  _mockGrade(student, correct) {
+    if (!student) return { score:0, feedback:'No answer given.', keyPointsMissed:[] };
+    const stu = student.toLowerCase().split(/\W+/).filter(Boolean);
+    const mod = correct.toLowerCase().split(/\W+/).filter(w=>w.length>3);
+    const hits = mod.filter(w=>stu.includes(w)).length;
+    const score = Math.min(100, Math.round((hits/Math.max(mod.length,1))*120));
+    return { score, feedback: score>=70?'Good answer!':score>=40?'Partially correct — review the model answer.':'Needs more detail.', keyPointsMissed:[] };
+  },
+
+  _mockLecture() {
+    return `Welcome. Today we cover ${this._node.title} — a core topic in ${this._node.subject||'your subject'}.\n\n[PAUSE]\n\n${this._node.definitions?.map((d,i)=>`${i===0?'First':'Next'}, let's define ${d.term}. ${d.description}`).join('\n\n')}\n\n[PAUSE]\n\nFormulas to know:\n${this._node.formulas?.map(f=>`${f.expression} — ${f.description}`).join('\n')}\n\n[PAUSE]\n\nSummary: ${this._node.summary}\n\n[PAUSE]\n\nNow let me test your understanding…`;
+  },
+
+  _esc: s => String(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'),
+  _delay: ms => new Promise(r=>setTimeout(r,ms)),
+};

--- a/knowledgenode/www/js/ui/LibraryView.js
+++ b/knowledgenode/www/js/ui/LibraryView.js
@@ -1,0 +1,189 @@
+/**
+ * LibraryView.js v2 — Library with subject filter, search, add-more, delete
+ */
+
+const LibraryView = {
+  _nodes: [], _filtered: [],
+
+  init() {
+    this._grid      = document.getElementById('library-grid');
+    this._empty     = document.getElementById('library-empty');
+    this._search    = document.getElementById('library-search');
+    this._filter    = document.getElementById('library-filter');
+    this._exportBtn = document.getElementById('export-all-btn');
+
+    // Inject sort selector next to subject filter if not already present
+    if (!document.getElementById('library-sort')) {
+      const sel = document.createElement('select');
+      sel.id = 'library-sort';
+      sel.className = 'config-input';
+      sel.style.cssText = 'font-size:12px;padding:7px 10px;height:auto;min-width:130px;';
+      sel.innerHTML = `
+        <option value="handbook">📖 Handbook order</option>
+        <option value="alpha">A → Z (Name)</option>
+        <option value="recent">Newest first</option>
+        <option value="mastery">Mastery ↓</option>
+        <option value="due">Due first</option>
+      `;
+      // Insert after the subject filter
+      this._filter?.parentNode?.insertBefore(sel, this._filter.nextSibling);
+      this._sortSelect = sel;
+
+      // Share-a-subject pack button (shares whatever the filter shows)
+      if (!document.getElementById('library-share')) {
+        const sh = document.createElement('button');
+        sh.id = 'library-share';
+        sh.className = 'btn-secondary';
+        sh.style.cssText = 'font-size:12px;padding:7px 12px;';
+        sh.textContent = '⤴ Share';
+        sh.title = 'Save the selected subject as a pack file you can send to a friend';
+        sh.addEventListener('click', () => {
+          if (typeof SharePack !== 'undefined') SharePack.share(this._filter?.value || 'all');
+        });
+        sel.parentNode?.insertBefore(sh, sel.nextSibling);
+      }
+    } else {
+      this._sortSelect = document.getElementById('library-sort');
+    }
+
+    this._search.addEventListener('input',  () => this._applyFilter());
+    this._filter.addEventListener('change', () => this._applyFilter());
+    this._sortSelect?.addEventListener('change', () => this._applyFilter());
+    this._exportBtn.addEventListener('click', () => this._exportAll());
+  },
+
+  refresh() {
+    const nodes = nodeStore.getAll().filter(n => n.processingStatus === 'ready');
+    // Only re-render when data actually changed — avoids full grid rebuilds
+    // on every background save (review ratings, ReactiveReshaper, etc.)
+    // Use updatedAt instead of dueQuestions() — avoids O(n×q) SRS scan just to check dirty
+    const fp = nodes.map(n => n.id + ':' + n.masteryScore + ':' + (n.updatedAt || 0)).join('|');
+    if (fp === this._lastFingerprint && this._nodes.length === nodes.length) return;
+    this._lastFingerprint = fp;
+    this._nodes = nodes;
+    this._updateSubjectFilter();
+    this._applyFilter();
+  },
+
+  _updateSubjectFilter() {
+    const subjects = nodeStore.getSubjects();
+    const current  = this._filter.value;
+    this._filter.innerHTML = '<option value="all">All Subjects</option>' +
+      subjects.map(s=>`<option value="${s}" ${s===current?'selected':''}>${s}</option>`).join('');
+  },
+
+  _applyFilter() {
+    const q    = this._search.value.toLowerCase().trim();
+    const s    = this._filter.value;
+    const sort = this._sortSelect?.value || 'handbook';
+
+    this._filtered = this._nodes.filter(n => {
+      const ms = s === 'all' || n.subject === s;
+      const mq = !q || [n.title,n.subject,n.chapter,n.summary].some(t => t?.toLowerCase().includes(q));
+      return ms && mq;
+    });
+
+    // Sort — numeric-aware so M1.2 comes before M1.10
+    this._filtered.sort((a, b) => {
+      if (sort === 'handbook') {
+        // Strict textbook order: by page number first. Nodes with a page always
+        // come before nodes without one. Ties (or no page) fall back to the
+        // numeric-aware title order (M1.1, M1.2, M2.1…) so flow never shuffles.
+        const pa = a.sourcePage, pb = b.sourcePage;
+        if (pa != null && pb != null && pa !== pb) return pa - pb;
+        if (pa != null && pb == null) return -1;
+        if (pa == null && pb != null) return 1;
+        return a.title.localeCompare(b.title, undefined, { numeric: true, sensitivity: 'base' });
+      }
+      if (sort === 'alpha')   return a.title.localeCompare(b.title, undefined, { numeric: true, sensitivity: 'base' });
+      if (sort === 'mastery') return (b.masteryScore || 0) - (a.masteryScore || 0);
+      if (sort === 'due')     return b.dueQuestions().length - a.dueQuestions().length;
+      if (sort === 'recent')  return (b.createdAt || 0) - (a.createdAt || 0);
+      return 0;
+    });
+
+    this._render();
+  },
+
+  _render() {
+    if (!this._filtered.length) {
+      this._grid.innerHTML = '';
+      this._empty.classList.remove('hidden');
+      return;
+    }
+    this._empty.classList.add('hidden');
+    this._grid.innerHTML = this._filtered.map(n => this._nodeCard(n)).join('');
+
+    this._grid.querySelectorAll('.node-card-body').forEach(el => {
+      el.addEventListener('click', () => NodeDetailView.open(el.dataset.id));
+    });
+    this._grid.querySelectorAll('.card-add-btn').forEach(el => {
+      el.addEventListener('click', e => { e.stopPropagation(); UploadView.openForNode(el.dataset.id); });
+    });
+    this._grid.querySelectorAll('.card-del-btn').forEach(el => {
+      el.addEventListener('click', e => { e.stopPropagation(); this._confirmDelete(el.dataset.id); });
+    });
+  },
+
+  _nodeCard(node) {
+    const due      = node.dueQuestions().length;
+    const newCount = node.newQuestions?.().length || 0;
+    const date     = new Date(node.createdAt).toLocaleDateString('en-GB',{day:'numeric',month:'short',year:'2-digit'});
+
+    // Badge logic: only show DUE if has been reviewed. Show NEW if never studied.
+    const badge = due > 0
+      ? `<div class="node-due-badge">${due} due</div>`
+      : newCount > 0 && node.reviewCount === 0
+        ? `<div class="node-due-badge" style="background:var(--bg-raised);border:1px solid var(--border);color:var(--text-muted);">${newCount} new</div>`
+        : '';
+    return `
+      <div class="node-card" style="display:flex;flex-direction:column;">
+        ${badge}
+        <div class="node-card-body" data-id="${node.id}" style="flex:1;cursor:pointer;">
+          <div class="node-card-subject">${node.subject||'No subject'}</div>
+          <div class="node-card-title">${this._esc(node.title)}</div>
+          <div class="node-card-meta">${this._esc(node.chapter||'')}${node.chapter ? ' · ' : ''}${this._esc(date)}</div>
+          ${node.sourceBookmark ? `<div class="node-card-bookmark" style="font-family:var(--font-mono);font-size:10px;color:var(--accent);margin-top:4px;display:flex;align-items:center;gap:4px;"><span>📖</span><span style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">${this._esc(node.sourceBookmark)}</span></div>` : ''}
+          <div class="node-card-stats">
+            <div class="mastery-bar-wrap">
+              <div class="mastery-bar-label"><span>Mastery</span><span>${node.masteryScore}%</span></div>
+              <div class="mastery-bar-track"><div class="mastery-bar-fill" style="width:${node.masteryScore}%"></div></div>
+            </div>
+          </div>
+        </div>
+        <div style="display:flex;gap:6px;padding-top:12px;margin-top:12px;border-top:1px solid var(--border-soft);">
+          <button class="card-add-btn btn-secondary" data-id="${node.id}" style="flex:1;font-size:11px;padding:7px 10px;">+ Add More</button>
+          <button class="card-del-btn" data-id="${node.id}" style="padding:7px 12px;background:transparent;border:1px solid var(--border);border-radius:var(--radius-md);color:var(--text-muted);font-size:12px;cursor:pointer;transition:all 0.2s;" onmouseover="this.style.borderColor='var(--red)';this.style.color='var(--red)'" onmouseout="this.style.borderColor='var(--border)';this.style.color='var(--text-muted)'">🗑</button>
+        </div>
+      </div>`;
+  },
+
+  _confirmDelete(nodeId) {
+    const node = nodeStore.get(nodeId);
+    if (!node) return;
+    Modal.open(`
+      <h2 style="font-family:var(--font-ui);font-size:18px;font-weight:800;margin-bottom:12px;">Delete Node?</h2>
+      <p style="font-family:var(--font-body);font-size:14px;color:var(--text-secondary);margin-bottom:24px;">
+        This will permanently delete "<strong>${this._esc(node.title)}</strong>" including all notes, questions, and review history. This cannot be undone.
+      </p>
+      <div style="display:flex;gap:10px;">
+        <button class="btn-primary" style="background:var(--red);box-shadow:none;" onclick="LibraryView._deleteNode('${nodeId}')">Delete Permanently</button>
+        <button class="btn-secondary" onclick="Modal.close()">Cancel</button>
+      </div>
+    `);
+  },
+
+  _deleteNode(nodeId) {
+    nodeStore.delete(nodeId);
+    Modal.close();
+    Toast.success('Node deleted.');
+    this.refresh();
+  },
+
+  _exportAll() {
+    const nodes = nodeStore.getAll().filter(n => n.processingStatus === 'ready');
+    PrintExport.showAllExportMenu(nodes);
+  },
+
+  _esc(s='') { return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); },
+};

--- a/knowledgenode/www/js/ui/Modal.js
+++ b/knowledgenode/www/js/ui/Modal.js
@@ -1,0 +1,30 @@
+/**
+ * Modal.js — Properly wired modal with optional onClose cleanup hook
+ */
+const Modal = {
+  _onClose: null,
+  _knBackId: null,
+  open(html, onClose) {
+    const overlay = document.getElementById('modal-overlay');
+    const content = document.getElementById('modal-content');
+    content.innerHTML = html;
+    overlay.classList.remove('hidden');
+    this._onClose = (typeof onClose === 'function') ? onClose : null;
+    // Phone back button closes the modal (one registration even if content is replaced)
+    if (!this._knBackId && typeof KNNav !== 'undefined')
+      this._knBackId = KNNav.register(() => this.close());
+  },
+  close() {
+    const overlay = document.getElementById('modal-overlay');
+    const content = document.getElementById('modal-content');
+    overlay.classList.add('hidden');
+    content.innerHTML = '';
+    const cb = this._onClose;
+    this._onClose = null;
+    if (this._knBackId && typeof KNNav !== 'undefined') {
+      KNNav.unregister(this._knBackId);
+      this._knBackId = null;
+    }
+    if (cb) { try { cb(); } catch (e) { /* ignore cleanup errors */ } }
+  },
+};

--- a/knowledgenode/www/js/ui/NodeDetailView.js
+++ b/knowledgenode/www/js/ui/NodeDetailView.js
@@ -1,0 +1,2785 @@
+/**
+ * NodeDetailView.js — Main note canvas (4 tabs: Notes, Questions, Examples, Mastery)
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * METHOD INDEX — search for these markers (▶) to jump to each section
+ * ═══════════════════════════════════════════════════════════════════════════
+ *
+ *   ▶ ENTRY              line ~14    open(), refresh(), _renderSection()
+ *   ▶ NOTES TAB          line ~57    _renderNotes()
+ *   ▶ PROFILE BAR        line ~307   _renderProfileBar(), _bindProfileBar()
+ *   ▶ ADD BLOCK          line ~396   _renderAddBlock(), _bindAddBlock()
+ *   ▶ OUTCOMES PANEL     line ~520   _renderOutcomes(), scan, add
+ *   ▶ TEMPLATE PICKER    line ~904   _openTemplatePanel()
+ *   ▶ EDIT MODE          line ~1021  _toggleEditMode(), _renderEditForm(),
+ *                                    _bindEditEvents(), _saveEdits()
+ *   ▶ ADD IMAGE          line ~1354  _addUserImage() — 3-option modal
+ *   ▶ AI FLOATER         line ~1584  _showAIFloater()
+ *   ▶ QUESTIONS TAB      line ~1740  _renderQuestions(), _renderQList()
+ *   ▶ EXAMPLES TAB       line ~1890  _renderExamples(), _scanExampleFromImage(),
+ *                                    _openAddExampleModal()
+ *   ▶ MASTERY TAB        line ~2214  _renderMastery()
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * STATE
+ *   _currentNode    — the open node
+ *   _currentSection — 'notes' | 'questions' | 'examples' | 'mastery'
+ *   _editMode       — true when Edit mode is active for the notes tab
+ *   _body           — cached reference to #detail-body
+ * ═══════════════════════════════════════════════════════════════════════════
+ */
+const NodeDetailView = {
+  _currentNode:    null,
+  _currentSection: 'notes',
+  _editMode:       false,
+
+  init() { this._body = document.getElementById('detail-body'); },
+  _escStr: s => String(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'),
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // ▶ ENTRY
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  open(nodeId, section = 'notes') {
+    if (typeof App !== 'undefined') App._maybePush({ type: 'node', id: nodeId, section });
+    // Clean up any previous document click handler
+    if (this._docClickHandler) { document.removeEventListener('click', this._docClickHandler); this._docClickHandler = null; }
+    const node = nodeStore.get(nodeId);
+    if (!node) { Toast.error('Node not found.'); return; }
+    this._currentNode    = node;
+    this._currentSection = ['notes','examples','questions','mastery'].includes(section) ? section : 'notes';
+    this._editMode       = false;
+    // Set global AI profile from this node's setting
+    AIService.setProfile(node.learnerProfile || 'college');
+    // Track recency
+    LearnerMemory.recordNoteOpened(node);
+    // Persist so refresh returns to this exact node
+    localStorage.setItem('kn_last_node', node.id);
+    // Always sync tab buttons to match _currentSection
+    document.querySelectorAll('.detail-tab-btn').forEach(b =>
+      b.classList.toggle('active', b.dataset.section === this._currentSection)
+    );
+    document.querySelectorAll('.detail-nav-btn, .detail-tab-btn').forEach(b =>
+      b.classList.toggle('active', b.dataset.section === this._currentSection));
+    SelectToAction.setNode(node);
+    ImageManager.setNode(node);
+    App.showView('node-detail');
+    this._renderSection();
+    this._showAIFloater();
+  },
+
+  _renderSection() {
+    const node = this._currentNode;
+    if (!node) return;
+    // Guard: ensure section is valid, default to notes
+    const valid = ['notes','examples','questions','mastery'];
+    if (!valid.includes(this._currentSection)) this._currentSection = 'notes';
+    // Sync tab active state to match current section
+    document.querySelectorAll('.detail-tab-btn').forEach(b =>
+      b.classList.toggle('active', b.dataset.section === this._currentSection)
+    );
+    switch (this._currentSection) {
+      case 'notes':     this._renderNotes(node);     break;
+      case 'examples':  this._renderExamples(node);  break;
+      case 'questions': this._renderQuestions(node); break;
+      case 'mastery':   this._renderMastery(node);   break;
+    }
+  },
+
+  /* ─── NOTES VIEW ──────────────────────────────────── */
+  // ═══════════════════════════════════════════════════════════════════════════
+  // ▶ NOTES TAB
+  // ═══════════════════════════════════════════════════════════════════════════
+  _renderNotes(node) {
+    const tmpl         = node.noteTemplate || 'standard';
+    const templateDisp = tmpl !== 'standard' ? NoteTemplates.renderDisplay(node) : null;
+    const stdDisplay   = NotesRenderer.renderFullNotes(node);
+    const outcomes     = node.moduleOutcomes || [];
+    const outcomeCount = outcomes.length;
+
+    this._body.innerHTML =
+      // ── Header ───────────────────────────────────────────────
+      '<div style="margin-bottom:20px;">'
+
+      // Title
+      + '<h2 style="font-family:var(--font-ui);font-size:22px;font-weight:800;margin:0 0 4px;letter-spacing:-0.02em;line-height:1.25;word-break:break-word;">' + this._esc(node.title) + '</h2>'
+
+      // Subject · Chapter breadcrumb
+      + '<p style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);margin:0 0 14px;">'
+      + [node.subject].filter(Boolean).join(' · ')
+      + (tmpl !== 'standard' ? ' · <span style="color:var(--accent);">' + (NoteTemplates.TEMPLATES[tmpl]?.icon || '') + ' ' + (NoteTemplates.TEMPLATES[tmpl]?.name || '') + '</span>' : '')
+      + '</p>'
+
+      // Action buttons row — labelled, consistent size
+      + '<div style="display:flex;gap:8px;flex-wrap:wrap;">'
+      + '<button class="btn-secondary" id="template-btn" style="font-size:12px;padding:8px 14px;display:flex;align-items:center;gap:5px;"><span>📐</span><span>Template</span></button>'
+      + '<button class="btn-secondary" id="edit-toggle-btn" style="font-size:12px;padding:8px 14px;display:flex;align-items:center;gap:5px;"><span>✏️</span><span>Edit</span></button>'
+      + '<button class="btn-secondary" id="add-image-btn" style="font-size:12px;padding:8px 14px;display:flex;align-items:center;gap:5px;"><span>🖼️</span><span>Add image</span></button>'
+      + '</div>'
+
+      // ── Textbook bookmark — where you left off in the physical handbook ──
+      + '<div id="bookmark-bar" style="margin-top:12px;background:var(--bg-raised);border:1px solid var(--border-soft);border-left:3px solid var(--accent);border-radius:8px;padding:10px 12px;">'
+      + '<div style="display:flex;align-items:center;gap:8px;">'
+      + '<span style="font-size:15px;">📖</span>'
+      + '<div style="flex:1;min-width:0;">'
+      + '<div style="font-family:var(--font-mono);font-size:9px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;color:var(--accent);margin-bottom:2px;">Handbook bookmark' + (node.sourcePage ? ' · p.' + node.sourcePage : '') + '</div>'
+      + (node.sourceBookmark
+          ? '<div id="bookmark-display" style="font-family:var(--font-body);font-size:13px;color:var(--text-primary);line-height:1.4;word-break:break-word;">' + this._esc(node.sourceBookmark) + '</div>'
+          : '<div id="bookmark-display" style="font-family:var(--font-body);font-size:13px;color:var(--text-muted);font-style:italic;">Tap edit to note where you left off (page, section…)</div>')
+      + '</div>'
+      + '<button class="btn-secondary" id="bookmark-edit-btn" style="font-size:11px;padding:5px 10px;flex-shrink:0;">' + (node.sourceBookmark || node.sourcePage ? '✏️' : '+ Add') + '</button>'
+      + '</div>'
+      + '<div id="bookmark-editor" style="display:none;margin-top:10px;">'
+      + '<label style="font-family:var(--font-mono);font-size:9px;text-transform:uppercase;letter-spacing:.06em;color:var(--text-muted);display:block;margin-bottom:4px;">Handbook page (for ordering)</label>'
+      + '<input type="number" id="bookmark-page-input" class="config-input" placeholder="e.g. 81" value="' + (node.sourcePage || '') + '" style="font-size:13px;margin-bottom:10px;" min="1"/>'
+      + '<label style="font-family:var(--font-mono);font-size:9px;text-transform:uppercase;letter-spacing:.06em;color:var(--text-muted);display:block;margin-bottom:4px;">Where you left off (free text)</label>'
+      + '<input type="text" id="bookmark-input" class="config-input" placeholder="e.g. Halfway through Year-End Procedures" value="' + this._esc(node.sourceBookmark) + '" style="font-size:13px;"/>'
+      + '<div style="display:flex;gap:8px;margin-top:8px;">'
+      + '<button class="btn-primary" id="bookmark-save-btn" style="font-size:12px;padding:7px 14px;">Save</button>'
+      + '<button class="btn-secondary" id="bookmark-cancel-btn" style="font-size:12px;padding:7px 14px;">Cancel</button>'
+      + '</div>'
+      + '</div>'
+      + '</div>'
+      + '</div>'
+
+      // ── Table of Contents ─────────────────────────────────────
+      + '<div class="outcomes-panel" id="outcomes-panel">'
+      + '<div class="outcomes-summary" id="outcomes-toggle" style="cursor:pointer;">'
+      + '<div style="display:flex;align-items:center;gap:8px;">'
+      + '<span style="font-family:var(--font-mono);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--accent);">📑 Table of Contents</span>'
+      + (outcomeCount > 0 ? '<span class="outcomes-count" style="font-family:var(--font-mono);font-size:10px;background:var(--accent-soft);color:var(--accent);padding:2px 8px;border-radius:20px;">' + outcomeCount + ' section' + (outcomeCount!==1?'s':'') + '</span>' : '<span class="outcomes-count"></span>')
+      + '</div>'
+      + '<div style="display:flex;gap:6px;align-items:center;">'
+      + (AIService.hasApiKey() ? '<button class="btn-secondary" id="outcomes-from-image-btn" style="font-size:11px;padding:5px 10px;" title="Scan image to extract table of contents">📷 Scan</button>' : '')
+      + (outcomes.some(o => o.text && (o.text.includes('"') || o.text.startsWith('{'))) ? '<button class="btn-secondary" id="outcomes-cleanup-btn" style="font-size:11px;padding:5px 10px;background:var(--red-dim);color:var(--red,#e54);">🔧 Fix</button>' : '')
+      + '<span id="outcomes-chevron" style="font-family:var(--font-mono);font-size:12px;color:var(--text-muted);">▶</span>'
+      + '</div>'
+      + '</div>'
+      + '<div class="outcomes-body" id="outcomes-body" style="display:none;">' + this._renderOutcomes(node) + '</div>'
+      + '</div>'
+
+      // ── Adapt to / Profile bar + Notes content ────────────────
+      + '<div id="notes-display">'
+      + this._renderProfileBar(node)
+      + (tmpl !== 'standard' && templateDisp
+          ? templateDisp
+          : (node.blocks?.length
+              ? '<div id="kn-canvas" class="' + (node.learnerProfile === 'primary' ? 'kn-kid' : '') + '">' + BlockEngine.renderNode(node) + '</div>'
+                + this._renderAddBlock()
+              : stdDisplay))
+      + '</div>';
+
+    ImageManager.bindEvents(this._body, node);
+    ImageResponseBlock.bindEvents(this._body, node);
+    TextAnnotator.restoreHighlights(this._body, node);
+    this._bindProfileBar(node);
+    this._bindAddBlock(node);
+    if (typeof AICorrections !== 'undefined') AICorrections.bindCorrectionButtons(this._body, node);
+
+    document.getElementById('template-btn').addEventListener('click',    () => this._openTemplatePanel());
+    document.getElementById('outcomes-toggle')?.addEventListener('click', e => {
+      if (e.target.closest('button')) return;
+      const body = document.getElementById('outcomes-body');
+      const chev = document.getElementById('outcomes-chevron');
+      const collapsed = body.style.display === 'none';
+      body.style.display = collapsed ? 'block' : 'none';
+      if (chev) chev.textContent = collapsed ? '▼' : '▶';
+    });
+    document.getElementById('edit-toggle-btn').addEventListener('click', () => this._toggleEditMode());
+    document.getElementById('add-image-btn').addEventListener('click',   () => this._addUserImage());
+
+    // Textbook bookmark
+    const bmEdit   = document.getElementById('bookmark-edit-btn');
+    const bmEditor = document.getElementById('bookmark-editor');
+    bmEdit?.addEventListener('click', () => {
+      bmEditor.style.display = bmEditor.style.display === 'none' ? 'block' : 'none';
+      if (bmEditor.style.display === 'block') document.getElementById('bookmark-input')?.focus();
+    });
+    document.getElementById('bookmark-cancel-btn')?.addEventListener('click', () => {
+      bmEditor.style.display = 'none';
+      document.getElementById('bookmark-input').value = node.sourceBookmark || '';
+    });
+    document.getElementById('bookmark-save-btn')?.addEventListener('click', () => {
+      const val = document.getElementById('bookmark-input').value.trim();
+      const pageRaw = document.getElementById('bookmark-page-input')?.value.trim();
+      const pageNum = pageRaw ? parseInt(pageRaw, 10) : null;
+      node.sourceBookmark = val;
+      node.sourcePage = (pageNum && pageNum > 0) ? pageNum : null;
+      node.updatedAt = Date.now();
+      nodeStore.save(node);
+      const disp = document.getElementById('bookmark-display');
+      if (disp) {
+        if (val) { disp.textContent = val; disp.style.color = 'var(--text-primary)'; disp.style.fontStyle = 'normal'; }
+        else { disp.textContent = 'Tap edit to note where you left off (page, section…)'; disp.style.color = 'var(--text-muted)'; disp.style.fontStyle = 'italic'; }
+      }
+      if (bmEdit) bmEdit.textContent = (val || node.sourcePage) ? '✏️' : '+ Add';
+      bmEditor.style.display = 'none';
+      Toast.success(val || node.sourcePage ? 'Bookmark saved 📖' : 'Bookmark cleared');
+    });
+
+    // Use document-level delegation so outcomes panel (outside _body) also works
+    this._docClickHandler = e => {
+      if (!this._currentNode) return;
+      if (e.target.id === 'add-outcome-btn')              this._addOutcome();
+      if (e.target.id === 'outcomes-from-image-btn')     { e.stopPropagation(); this._scanOutcomesFromImage(); return; }
+      if (e.target.id === 'outcomes-cleanup-btn') {
+        e.stopPropagation();
+        // Remove all entries that look like raw JSON fragments
+        const node = this._currentNode;
+        const before = (node.moduleOutcomes||[]).length;
+        node.moduleOutcomes = (node.moduleOutcomes||[]).filter(o => {
+          const t = (o.text||'').trim();
+          // Keep only clean text entries — reject anything with JSON syntax
+          return t.length > 0
+            && !t.startsWith('"')
+            && !t.startsWith('{')
+            && !t.startsWith('[')
+            && !t.includes('": "')
+            && !t.includes('": [');
+        });
+        nodeStore.save(node);
+        this._refreshOutcomesBody(node);
+        Toast.success('Removed ' + (before - node.moduleOutcomes.length) + ' corrupt entries. Tap Scan to re-add.');
+        return;
+      }
+
+      // Per-module scan
+      const scanBtn = e.target.closest('.outcome-scan-btn');
+      if (scanBtn?.dataset.outcomeId) {
+        e.stopPropagation();
+        const o = (this._currentNode.moduleOutcomes||[]).find(x => x.id === scanBtn.dataset.outcomeId);
+        if (o) this._scanOutcomeForModule(o);
+        return;
+      }
+      if (e.target.id === 'outcomes-structure-btn')       { e.stopPropagation(); this._structureNotesFromToC(); return; }
+
+      // Navigate to linked node
+      const gotoBtn = e.target.closest('.outcome-goto-btn');
+      if (gotoBtn?.dataset.nodeId) { NodeDetailView.open(gotoBtn.dataset.nodeId); return; }
+
+      // Collapse/expand outcome row — tap chevron OR row title/badge
+      const collapseBtn = e.target.closest('.outcome-collapse-btn');
+      const rowHeader   = e.target.closest('.toc-row__header');
+      const rowId = collapseBtn?.dataset.rowId || (rowHeader && !e.target.closest('.toc-row__check') && !e.target.closest('.toc-row__icon') && rowHeader.closest('.toc-row')?.dataset.rowId);
+      if (rowId) {
+        const expandable = document.querySelector('.toc-expandable[data-expand-id="' + rowId + '"]');
+        const chevron    = document.querySelector('.outcome-collapse-btn[data-row-id="' + rowId + '"]');
+        if (expandable) {
+          const computedDisplay = window.getComputedStyle(expandable).display;
+          const isOpen = computedDisplay !== 'none' && expandable.style.display !== 'none';
+          expandable.style.display = isOpen ? 'none' : 'flex';
+          if (chevron) { chevron.textContent = isOpen ? '▶' : '▼'; chevron.title = isOpen ? 'Expand' : 'Collapse'; }
+        }
+        if (collapseBtn) return;
+      }
+
+      // Scroll to section within current node
+      const scrollBtn = e.target.closest('.outcome-scroll-btn');
+      if (scrollBtn?.dataset.anchor) {
+        const detailBody = document.getElementById('detail-body');
+        const target = document.getElementById(scrollBtn.dataset.anchor);
+        if (target && detailBody) {
+          const offset = target.offsetTop - detailBody.offsetTop - 16;
+          detailBody.scrollTo({ top: offset, behavior: 'smooth' });
+        } else if (target) {
+          target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+        return;
+      }
+
+
+
+      // Create new node for this outcome — with duplicate guard
+      const createBtn = e.target.closest('.outcome-create-btn');
+      if (createBtn?.dataset.outcomeId) {
+        const node = this._currentNode;
+        const o = (node.moduleOutcomes||[]).find(x => x.id === createBtn.dataset.outcomeId);
+        if (o) {
+          const moduleLabel = 'Module ' + (o.moduleNum || '') + ' — ' + o.text.slice(0, 60);
+          // Check if a node already exists with this exact chapter/title to prevent duplicates
+          const existing = nodeStore.getAll().find(n =>
+            n.id !== node.id && (
+              n.chapter === moduleLabel ||
+              n.title === o.text.slice(0, 80) ||
+              (n.chapter||'').toLowerCase() === (o.text||'').toLowerCase().slice(0,60)
+            )
+          );
+          if (existing) {
+            Toast.info('Node already exists — opening it.');
+            setTimeout(() => NodeDetailView.open(existing.id), 200);
+            return;
+          }
+          // Copy all module outcomes from the parent node into the new node
+          // so every node in the subject shares the same module map
+          // Copy outcomes — preserve moduleNum and text but reset achieved state
+          // Keep linkedNodeId so "Go to" buttons work immediately on the new node
+          const copiedOutcomes = (node.moduleOutcomes || []).map(x => ({
+            id: 'oc_' + Math.random().toString(36).slice(2,8),
+            text: x.text,
+            moduleNum: x.moduleNum,
+            linkedNodeId: x.linkedNodeId || null,
+            achieved: false,
+          }));
+          const newNode = new KnowledgeNode({
+            subject: node.subject,
+            chapter: moduleLabel,
+            title: o.text.slice(0, 80),
+            processingStatus: 'ready',
+            moduleOutcomes: copiedOutcomes,
+            definitions: [], tables: [], formulas: [], procedures: [], commonMistakes: [], summary: '', questions: [],
+          });
+          nodeStore.save(newNode);
+          // Update the new node's own outcome for this module to point to itself
+          const selfOutcome = newNode.moduleOutcomes?.find(x =>
+            x.text.toLowerCase().trim() === o.text.toLowerCase().trim()
+          );
+          if (selfOutcome) { selfOutcome.linkedNodeId = newNode.id; nodeStore.save(newNode); }
+          // Store link on the parent outcome
+          o.linkedNodeId = newNode.id;
+          nodeStore.save(node);
+          // Also update the same outcome on all other nodes in the same subject
+          // so the link is shared across the whole subject
+          nodeStore.getAll()
+            .filter(n => n.id !== node.id && n.id !== newNode.id && n.subject && node.subject &&
+              n.subject.toLowerCase().trim() === node.subject.toLowerCase().trim() &&
+              Array.isArray(n.moduleOutcomes)
+            )
+            .forEach(n => {
+              const match = n.moduleOutcomes.find(x =>
+                x.text.toLowerCase().trim() === o.text.toLowerCase().trim()
+              );
+              if (match) { match.linkedNodeId = newNode.id; nodeStore.save(n); }
+            });
+          Toast.success('Node created!');
+          // Small delay ensures store has fully persisted before opening
+          setTimeout(() => NodeDetailView.open(newNode.id), 300);
+        }
+        return;
+      }
+
+      // Rename module label inline
+      const moduleLabel = e.target.closest('.outcome-module-label');
+      if (moduleLabel?.dataset.outcomeId) {
+        const oId = moduleLabel.dataset.outcomeId;
+        const o = (this._currentNode.moduleOutcomes||[]).find(x => x.id === oId);
+        if (!o) return;
+        const current = 'Module ' + o.moduleNum;
+        const input = document.createElement('input');
+        input.value = current;
+        input.style.cssText = 'font-family:var(--font-mono);font-size:9px;font-weight:700;color:var(--accent);background:var(--accent-soft);border:1px solid var(--accent-dim);border-radius:10px;padding:2px 7px;width:80px;';
+        moduleLabel.replaceWith(input);
+        input.focus(); input.select();
+        const save = () => {
+          const val = input.value.trim() || current;
+          // Extract number or just store as text
+          const numMatch = val.match(/\d+/);
+          o.moduleNum = numMatch ? parseInt(numMatch[0]) : val;
+          nodeStore.save(this._currentNode);
+          this._refreshOutcomesBody(this._currentNode);
+        };
+        input.addEventListener('blur', save);
+        input.addEventListener('keydown', e2 => { if (e2.key === 'Enter') { e2.preventDefault(); save(); } });
+        return;
+      }
+      if (e.target.dataset?.deleteOutcome)                this._deleteOutcome(e.target.dataset.deleteOutcome);
+      if (e.target.classList.contains('outcome-check'))   this._toggleOutcomeAchieved(e.target.dataset.outcomeId, e.target.checked);
+    };
+    document.addEventListener('click', this._docClickHandler);
+  },
+
+  /* ─── BLOCK CANVAS: profile bar ───────────────────── */
+  _PROFILES: [
+    { k: 'primary', label: '🧒 Primary' },
+    { k: 'high',    label: '🎒 High school' },
+    { k: 'college', label: '🎓 College' },
+    { k: 'pro',     label: '💼 Professional' },
+  ],
+  // ═══════════════════════════════════════════════════════════════════════════
+  // ▶ PROFILE BAR
+  // ═══════════════════════════════════════════════════════════════════════════
+  _renderProfileBar(node) {
+    return '<div class="kn-profile-bar">'
+      + '<div style="display:flex;flex-direction:column;gap:6px;width:100%;">'
+      // Label row
+      + '<div style="display:flex;align-items:center;justify-content:space-between;">'
+      + '<span class="pl" style="font-family:var(--font-mono);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--text-muted);">Adapt explanation level</span>'
+      + '<button class="kn-pchip" id="kn-regen" title="Regenerate notes for the selected level" '
+      + 'style="margin:0;border-color:var(--accent-dim);color:var(--accent);font-size:11px;padding:4px 10px;display:flex;align-items:center;gap:4px;"><span>⟳</span><span>Regenerate</span></button>'
+      + '</div>'
+      // Chips row
+      + '<div style="display:flex;gap:6px;flex-wrap:wrap;">'
+      + this._PROFILES.map(p => {
+        const isCached  = !!(node.profileCache?.[p.k]?.length);
+        const isActive  = node.learnerProfile === p.k;
+        const cacheIcon = (!isActive && isCached) ? ' <span style="font-size:8px;opacity:.6;" title="Cached">●</span>' : '';
+        return '<button class="kn-pchip' + (isActive ? ' active' : '') + '" data-profile="' + p.k + '">' + p.label + cacheIcon + '</button>';
+      }).join('')
+      + '</div>'
+      + '</div>'
+      + '</div>';
+  },
+  _bindProfileBar(node) {
+    this._body.querySelectorAll('.kn-pchip[data-profile]').forEach(chip => {
+      chip.addEventListener('click', () => {
+        const prevProfile = node.learnerProfile || 'college';
+        const newProfile  = chip.dataset.profile;
+        if (prevProfile === newProfile) return;
+
+        // Save current blocks to cache before switching
+        if (node.blocks?.length) {
+          if (!node.profileCache) node.profileCache = {};
+          node.profileCache[prevProfile] = JSON.parse(JSON.stringify(node.blocks));
+        }
+
+        // Restore from cache if we've been here before
+        node.learnerProfile = newProfile;
+        AIService.setProfile(newProfile);
+
+        if (node.profileCache?.[newProfile]?.length) {
+          // Instant restore from cache — no API call needed
+          node.blocks = JSON.parse(JSON.stringify(node.profileCache[newProfile]));
+          nodeStore.save(node);
+          this._renderNotes(node);
+          Toast.success('Restored ' + chip.textContent + ' view ✓');
+        } else {
+          // First time on this profile — save and prompt to regenerate
+          nodeStore.save(node);
+          this._renderNotes(node);
+          Toast.info('Switched to ' + chip.textContent + ' level. Tap ⟳ Regenerate to adapt content.');
+        }
+      });
+    });
+    this._body.querySelector('#kn-regen')?.addEventListener('click', () => this._regenerateForProfile(node));
+  },
+  async _regenerateForProfile(node) {
+    if (!AIService.hasApiKey()) {
+      Toast.error('Configure AI first to regenerate. The canvas still adapts styling without it.');
+      return;
+    }
+    const btn = this._body.querySelector('#kn-regen');
+    if (btn) { btn.textContent = '⟳ Generating…'; btn.disabled = true; }
+    try {
+      const blocks = await AIService.generateBlocks(node.title, node.learnerProfile, node);
+      node.blocks = blocks.map(b => ({ id: KnowledgeNode._generateBlockId(), ...b }));
+      // Cache this result so switching back doesn't need another API call
+      if (!node.profileCache) node.profileCache = {};
+      node.profileCache[node.learnerProfile] = JSON.parse(JSON.stringify(node.blocks));
+      nodeStore.save(node);
+      this._renderNotes(node);
+      Toast.success('Regenerated for ' + node.learnerProfile + ' level — saved to cache ✓');
+    } catch (e) {
+      Toast.error(e.message || 'Regeneration failed.');
+      if (btn) { btn.textContent = '⟳ Regenerate'; btn.disabled = false; }
+    }
+  },
+
+  /* ─── BLOCK CANVAS: add-block palette ─────────────── */
+  _BLOCK_PALETTE: [
+    { type: 'prose',      label: '📝 Text' },
+    { type: 'callout',    label: '💡 Callout' },
+    { type: 'code',       label: '▶ Code runner' },
+    { type: 'calc',       label: '🧮 Calculator' },
+    { type: 'webpreview', label: '🎨 Live preview' },
+    { type: 'quiz',       label: '✅ Quiz' },
+    { type: 'cloze',      label: '✏ Fill the blanks' },
+    { type: 'match',      label: '🎮 Match game' },
+    { type: 'flashcards', label: '🃏 Flashcards' },
+    { type: 'diagram',    label: '➡ Diagram' },
+    { type: 'table',      label: '▦ Table' },
+  ],
+  // ═══════════════════════════════════════════════════════════════════════════
+  // ▶ ADD BLOCK
+  // ═══════════════════════════════════════════════════════════════════════════
+  _renderAddBlock() {
+    return '<div class="kn-add-block"><button class="kn-add-btn" id="kn-add-toggle">＋ Add block</button>'
+      + '<div class="kn-add-palette" id="kn-palette">'
+      + this._BLOCK_PALETTE.map(p => '<div class="kn-pal-item" data-add="' + p.type + '">' + p.label + '</div>').join('')
+      + '</div></div>';
+  },
+  _bindAddBlock(node) {
+    this._body.querySelector('#kn-add-toggle')?.addEventListener('click', () =>
+      this._body.querySelector('#kn-palette')?.classList.toggle('open'));
+    this._body.querySelectorAll('.kn-pal-item[data-add]').forEach(item =>
+      item.addEventListener('click', () => {
+        const blockType = item.dataset.add;
+        const aiBlocks = ['flashcards', 'quiz', 'cloze', 'match', 'calc'];
+        if (AIService.hasApiKey() && aiBlocks.includes(blockType)) {
+          this._generateAIBlock(this._currentNode, blockType);
+        } else {
+          node.addBlock(blockType, this._defaultBlockData(blockType));
+          nodeStore.save(node);
+          this._renderSection();
+        }
+        nodeStore.save(node);
+        this._renderNotes(node);
+      }));
+  },
+  async _generateAIBlock(node, blockType) {
+    Toast.info('Generating ' + blockType + ' from your notes…');
+    const subject = node.subject || node.title || 'this subject';
+    const defs = (node.definitions || []).slice(0, 8).map(d => d.term + ': ' + d.description).join('\n');
+    const formulas = (node.formulas || []).slice(0, 5).map(f => f.expression + ' — ' + f.description).join('\n');
+    const summary = node.summary || '';
+    const source = [defs, formulas, summary].filter(Boolean).join('\n\n').slice(0, 3000);
+
+    let prompt = '', fallback;
+
+    if (blockType === 'flashcards') {
+      prompt = 'Create 6 flashcards for a student studying "' + subject + '". Use ONLY the source material below.\n'
+        + 'Output ONLY raw JSON: {"title":"Flashcards","cards":[{"front":"term or question","back":"definition or answer"}]}\n'
+        + 'Each card front is a key term or concept. Each back is its definition from the source.\n\nSOURCE:\n' + source;
+      fallback = { title: 'Flashcards', cards: [{ front: 'Front', back: 'Back' }] };
+
+    } else if (blockType === 'quiz') {
+      prompt = 'Create a multiple-choice question for a student studying "' + subject + '". Use ONLY the source material below.\n'
+        + 'Output ONLY raw JSON: {"title":"Quick check","q":"question text","options":["A","B","C","D"],"answer":0,"fb":"explanation"}\n'
+        + '"answer" is the index (0-3) of the correct option. Make it challenging but fair.\n\nSOURCE:\n' + source;
+      fallback = this._defaultBlockData('quiz');
+
+    } else if (blockType === 'cloze') {
+      prompt = 'Create a fill-in-the-blank exercise for a student studying "' + subject + '". Use ONLY the source material below.\n'
+        + 'Output ONLY raw JSON: {"title":"Fill in the blanks","text":"A sentence from the source where 1-4 key terms are wrapped as {{term}}."}\n'
+        + 'Blank out the most important terms — definitions, key numbers, names. For terms with an accepted synonym use {{net|net amount}}.\n\nSOURCE:\n' + source;
+      fallback = this._defaultBlockData('cloze');
+
+    } else if (blockType === 'match') {
+      prompt = 'Create a matching exercise for a student studying "' + subject + '". Use ONLY the source material below.\n'
+        + 'Output ONLY raw JSON: {"title":"Match them up!","pairs":[["term","definition"],["term2","definition2"]]}\n'
+        + 'Create 4-6 pairs of terms and their matching definitions from the source.\n\nSOURCE:\n' + source;
+      fallback = this._defaultBlockData('match');
+
+    } else if (blockType === 'calc') {
+      const srcFormulas = formulas || defs;
+      prompt = 'Create an interactive calculator for a student studying "' + subject + '".\n'
+        + 'IMPORTANT: You MUST include at least 2 input fields. The calculator must have visible inputs the student can type into.\n'
+        + 'Output ONLY this exact JSON structure:\n'
+        + '{"title":"Tax Calculator","resultLabel":"Tax Payable","inputs":[{"key":"income","label":"Taxable Income (R)","default":100000},{"key":"rate","label":"Tax Rate (%)","default":18}],"formula":"income * rate / 100","breakdownSteps":[{"label":"Income × Rate","expr":"income * rate / 100"}]}\n'
+        + 'Rules: every "key" must be a simple word (no spaces, no special chars). "formula" must be valid JavaScript using those key names. Include 2-4 inputs.\n'
+        + '\nSource formulas from notes:\n' + (srcFormulas || 'Use a relevant formula for: ' + subject);
+      fallback = this._defaultBlockData('calc');
+    }
+
+    try {
+      const raw = await AIService._callWithFunction('noteProcessing', [{role:'user', content: prompt}], 800);
+      const data = AIService._parseJSON(raw);
+      if (!data) throw new Error('Empty response');
+      node.addBlock(blockType, data);
+      nodeStore.save(node);
+      Toast.success(blockType.charAt(0).toUpperCase() + blockType.slice(1) + ' generated from your notes!');
+      this._renderSection();
+    } catch(err) {
+      node.addBlock(blockType, fallback);
+      nodeStore.save(node);
+      Toast.info('Using default — edit to customise. (' + err.message + ')');
+      this._renderSection();
+    }
+  },
+
+  _defaultBlockData(type) {
+    switch (type) {
+      case 'prose':      return { title: 'New note', html: 'Write here…' };
+      case 'callout':    return { title: 'Tip', html: 'Key thing to remember.' };
+      case 'code':       return { title: 'Try it', lang: 'sql', setup: "CREATE TABLE t(id,name);INSERT INTO t VALUES(1,'a'),(2,'b');", code: 'SELECT * FROM t;' };
+      case 'calc':       return { title: 'Calculator', resultLabel: 'Result', inputs: [{ key: 'a', label: 'Value A', default: 0 }, { key: 'b', label: 'Value B', default: 0 }], formula: 'a + b', breakdownSteps: [{ label: 'A + B', expr: 'a + b' }] };
+      case 'webpreview': return { title: 'Live preview', code: '<h1 style="font-family:sans-serif">Hello</h1>\n<p>Edit me — the preview updates.</p>' };
+      case 'quiz':       return { title: 'Quick check', q: 'Your question?', options: ['Option A', 'Option B', 'Option C'], answer: 0, fb: 'Explanation here.' };
+      case 'cloze':      return { title: 'Fill in the blanks', text: 'The capital of France is {{Paris}}, and it sits on the river {{Seine}}.' };
+      case 'match':      return { title: 'Match them up!', pairs: [['A', '1'], ['B', '2'], ['C', '3']] };
+      case 'flashcards': return { title: 'Flashcards', cards: [{ front: 'Front', back: 'Back' }] };
+      case 'diagram':    return { title: 'Flow', steps: ['Step 1', 'Step 2', 'Step 3'] };
+      case 'table':      return { title: 'Table', columns: ['Col 1', 'Col 2'], rows: [['', '']] };
+      default:           return {};
+    }
+  },
+
+  /** Re-render just the canvas in place (called by BlockEngine after move/delete). */
+  _rerenderBlocks() {
+    if (!this._currentNode) return;
+    // Re-render just the block canvas without full page reload
+    const canvas = document.getElementById('kn-canvas');
+    if (canvas) {
+      canvas.innerHTML = BlockEngine.renderNode(this._currentNode);
+      if (typeof AICorrections !== 'undefined') AICorrections.bindCorrectionButtons(canvas, this._currentNode);
+      return;
+    }
+    // Fallback: full notes re-render
+    if (this._currentSection === 'notes') {
+      this._renderNotes(this._currentNode);
+    }
+  },
+
+  /* ─── MODULE OUTCOMES ─────────────────────────────── */
+  _refreshOutcomesBody(node) {
+    const body = document.getElementById('outcomes-body');
+    if (!body) return;
+    // Preserve current collapsed/expanded state — never force open
+    const isOpen = body.style.display !== 'none';
+    body.innerHTML = this._renderOutcomes(node);
+    if (!isOpen) body.style.display = 'none';
+    const cnt = document.querySelector('.outcomes-count');
+    const count = (node.moduleOutcomes||[]).length;
+    if (cnt) cnt.textContent = count > 0 ? count + ' section' + (count!==1?'s':'') : '';
+  },
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // ▶ OUTCOMES PANEL
+  // ═══════════════════════════════════════════════════════════════════════════
+  _renderOutcomes(node) {
+    const outcomes = node.moduleOutcomes || [];
+    // Only match within the same subject — outcomes belong to a subject, not a single node
+    const sameSubjectNodes = nodeStore.getAll().filter(n =>
+      n.id !== node.id &&
+      n.subject &&
+      node.subject &&
+      n.subject.toLowerCase().trim() === node.subject.toLowerCase().trim()
+    );
+
+    const rows = outcomes.length === 0
+      ? '<p style="font-family:var(--font-mono);font-size:12px;color:var(--text-muted);padding:4px 0 10px;">No sections yet. Tap 📷 Scan to extract from a module guide.</p>'
+      : outcomes.map((o, i) => {
+          // Auto-assign module number if missing
+          if (!o.moduleNum) o.moduleNum = i + 1;
+          const outcomeText = o.text.toLowerCase().trim();
+          const moduleLabel = ('module ' + (o.moduleNum||'')).toLowerCase();
+
+          // Find linked node — same subject only
+          // Priority: (1) stored linkedNodeId, (2) exact title match, (3) chapter contains outcome, (4) module number prefix
+          const linked = o.linkedNodeId
+            ? sameSubjectNodes.find(n => n.id === o.linkedNodeId)
+            : (
+                sameSubjectNodes.find(n =>
+                  (n.title||'').toLowerCase() === outcomeText ||
+                  outcomeText === (n.title||'').toLowerCase()
+                ) ||
+                sameSubjectNodes.find(n =>
+                  (n.chapter||'').toLowerCase().includes(outcomeText) ||
+                  outcomeText.includes((n.title||'').toLowerCase().trim()) && (n.title||'').length > 4
+                ) ||
+                (o.moduleNum ? sameSubjectNodes.find(n =>
+                  (n.chapter||'').toLowerCase().startsWith(moduleLabel)
+                ) : null)
+              );
+          const modLabel = 'Module ' + o.moduleNum;
+
+          // Check if this outcome refers to the current node itself
+          // (by stored linkedNodeId, or by title/chapter match)
+          const isCurrentNode = (
+            (o.linkedNodeId && o.linkedNodeId === node.id) ||
+            (linked && linked.id === node.id) ||
+            (node.title || '').toLowerCase().trim() === outcomeText ||
+            (node.chapter || '').toLowerCase().includes(outcomeText) ||
+            outcomeText.includes((node.title || '').toLowerCase().trim()) && (node.title || '').length > 4
+          );
+
+          // Determine what action button to show
+          let actionBtn = '';
+          if (isCurrentNode) {
+            actionBtn = '<span style="font-family:var(--font-mono);font-size:10px;color:var(--accent);padding:3px 8px;background:var(--accent-soft);border-radius:8px;border:1px solid var(--accent-dim);">📍 You are here</span>';
+          } else if (linked) {
+            actionBtn = '<button class="btn-secondary outcome-goto-btn" data-node-id="' + linked.id + '" style="font-size:11px;padding:4px 10px;">📖 Go to: ' + this._esc((linked.title||linked.chapter||'').slice(0,30)) + '</button>';
+          } else {
+            actionBtn = '<button class="btn-secondary outcome-create-btn" data-outcome-id="' + o.id + '" style="font-size:11px;padding:4px 10px;opacity:.75;">+ Create node for this</button>';
+          }
+
+          const hasSubContent = true; // every row has a Go to / Create node button
+          return '<div class="toc-row' + (o.achieved ? ' achieved' : '') + (isCurrentNode ? ' toc-row--current' : '') + '" data-row-id="' + o.id + '">'
+            + '<div class="toc-row__header">'
+            + '<input type="checkbox" class="outcome-check toc-row__check" data-outcome-id="' + o.id + '" ' + (o.achieved ? 'checked' : '') + '/>'
+            + '<span class="toc-row__badge' + (isCurrentNode ? ' toc-row__badge--current' : '') + '">' + this._esc(modLabel) + '</span>'
+            + '<span class="toc-row__title' + (isCurrentNode ? ' toc-row__title--current' : '') + '">' + this._esc(o.text) + '</span>'
+            + '<div class="toc-row__actions">'
+            + (hasSubContent ? '<button class="toc-row__chevron outcome-collapse-btn" data-row-id="' + o.id + '" title="Expand">▶</button>' : '')
+            + (AIService.hasApiKey() ? '<button class="toc-row__icon outcome-scan-btn" data-outcome-id="' + o.id + '" title="Scan outcomes">📷</button>' : '')
+            + '<button class="toc-row__icon toc-row__delete" data-delete-outcome="' + o.id + '" title="Remove">✕</button>'
+            + '</div>'
+            + '</div>'
+            + '<div class="toc-expandable" data-expand-id="' + o.id + '" style="display:none;">'
+            + '<div class="toc-action">' + actionBtn + (o.achieved ? '<span class="toc-achieved-badge">✓ Achieved</span>' : '') + '</div>'
+            + ((o.subOutcomes && o.subOutcomes.length)
+                ? '<div class="toc-suboutcomes">'
+                  + '<div class="toc-suboutcomes__label">Module Outcomes</div>'
+                  + o.subOutcomes.map(function(s,si){ return '<div class="toc-suboutcome-item">'
+                    + '<span class="toc-suboutcome-num">'+(si+1)+'.</span>'
+                    + '<span class="toc-suboutcome-text">'+NodeDetailView._escStr(s)+'</span>'
+                    + '</div>'; }).join('')
+                  + '</div>'
+                : '')
+            + '</div>'
+            + '</div>';
+        }).join('');
+
+    const nextModNum = (outcomes.length > 0 ? Math.max(...outcomes.map(o => o.moduleNum||0)) + 1 : 1);
+    return rows
+      + '<div class="toc-add-panel">'
+      + '<div class="toc-add-panel__label">Add to Table of Contents</div>'
+      + '<div class="toc-add-panel__inputs">'
+      + '<input type="text" id="new-outcome-module" class="config-input toc-add-panel__mod" placeholder="Module 1" value="Module ' + nextModNum + '"/>'
+      + '<input type="text" id="new-outcome-input" class="config-input toc-add-panel__text" placeholder="e.g. Gross Income, Allowable Deductions…"/>'
+      + '</div>'
+      + '<button class="btn-primary toc-add-panel__btn" id="add-outcome-btn">+ Add</button>'
+      + '</div>';
+  },
+
+  _scanOutcomeForModule(outcome) {
+    // Guard against re-entry
+    if (this._scanningOutcomes) return;
+    this._scanningOutcomes = true;
+    const node = this._currentNode;
+    const modLabel = 'Module ' + outcome.moduleNum + ' — ' + outcome.text;
+    const input = document.createElement('input');
+    input.type = 'file'; input.accept = 'image/*';
+    input.addEventListener('cancel', () => { this._scanningOutcomes = false; });
+    input.onchange = async () => {
+      const file = input.files[0];
+      if (!file) { this._scanningOutcomes = false; return; }
+      Toast.info('Reading image for ' + modLabel + '…');
+      // Normalise MIME type
+      const { base64, mediaType } = await new Promise((res, rej) => {
+        const r = new FileReader();
+        r.onload = () => {
+          const dataUrl = r.result;
+          const parts = dataUrl.split(',');
+          let mt = parts[0].match(/data:([^;]+);/)?.[1] || file.type || 'image/jpeg';
+          const supported = ['image/jpeg','image/png','image/gif','image/webp'];
+          if (!supported.includes(mt)) {
+            const img = new Image();
+            img.onload = () => { const c=document.createElement('canvas'); c.width=img.width; c.height=img.height; c.getContext('2d').drawImage(img,0,0); const j=c.toDataURL('image/jpeg',0.92); res({base64:j.split(',')[1],mediaType:'image/jpeg'}); };
+            img.onerror = rej; img.src = dataUrl;
+          } else { res({base64:parts[1],mediaType:mt}); }
+        };
+        r.onerror = rej; r.readAsDataURL(file);
+      });
+      try {
+        // Step 1: OCR
+        const ocrMsgs = [
+          { role:'user', content:[
+            {type:'image_url',image_url:{url:'data:'+mediaType+';base64,'+base64}},
+            {type:'text',text:'Extract ALL text from this image exactly as it appears. Output only the raw text.'}
+          ]}
+        ];
+        const ocrText = await AIService._callWithFunction('noteProcessing', ocrMsgs, 1500);
+
+        // Step 2: Extract module outcomes for this specific module
+        const extractPrompt = 'From the following text, extract ONLY the learning outcomes or objectives that belong to "'
+          + modLabel + '". These are the specific things a student should know or be able to do for this module.'
+          + ' If you cannot find specific outcomes for this module, extract the main topics covered.'
+          + ' Return ONLY a JSON array of strings, no explanation:\n\n' + ocrText;
+        const extractMsgs = [
+          {role:'user', content:extractPrompt},
+        ];
+        const raw = await AIService._callWithFunction('noteProcessing', extractMsgs, 800);
+        let outcomes = [];
+        try { outcomes = JSON.parse('[' + raw); } catch {
+          try { outcomes = AIService._parseJSON('{"outcomes":[' + raw).outcomes || []; } catch {}
+        }
+        if (!outcomes.length && ocrText.trim()) {
+          outcomes = ocrText.split('\n').map(l => l.replace(/^[\s\-•\*\d\.]+/,'').trim()).filter(l => l.length > 8 && l.length < 300);
+        }
+        if (!outcomes.length) { Toast.error('No outcomes found for this module.'); this._scanningOutcomes = false; return; }
+
+        // Store outcomes as a sub-list on the outcome object
+        if (!outcome.subOutcomes) outcome.subOutcomes = [];
+        outcomes.forEach(text => {
+          if (!outcome.subOutcomes.find(x => x.toLowerCase().trim() === text.toLowerCase().trim())) {
+            outcome.subOutcomes.push(String(text).trim());
+          }
+        });
+        nodeStore.save(node);
+        this._refreshOutcomesBody(node);
+        Toast.success(outcomes.length + ' outcomes added to ' + modLabel + '!');
+        this._scanningOutcomes = false;
+      } catch(err) { Toast.error('Error: ' + err.message); this._scanningOutcomes = false; }
+    };
+    input.click();
+  },
+
+  _scanOutcomesFromImage() {
+    // Guard against re-entry (prevents gallery opening multiple times)
+    if (this._scanningOutcomes) return;
+    this._scanningOutcomes = true;
+    const node = this._currentNode;
+    const input = document.createElement('input');
+    input.type = 'file'; input.accept = 'image/*';
+    // Reset flag when user cancels or finishes
+    input.addEventListener('cancel', () => { this._scanningOutcomes = false; });
+    input.onchange = async () => {
+      const file = input.files[0];
+      if (!file) { this._scanningOutcomes = false; return; }
+      Toast.info('Reading image for outcomes…');
+      // Normalise to Claude-supported MIME type
+      const { base64, mediaType } = await new Promise((res, rej) => {
+        const r = new FileReader();
+        r.onload = () => {
+          const dataUrl = r.result;
+          const parts = dataUrl.split(',');
+          let mt = parts[0].match(/data:([^;]+);/)?.[1] || file.type || 'image/jpeg';
+          const supported = ['image/jpeg','image/png','image/gif','image/webp'];
+          if (!supported.includes(mt)) {
+            const img = new Image();
+            img.onload = () => {
+              const c = document.createElement('canvas');
+              c.width = img.width; c.height = img.height;
+              c.getContext('2d').drawImage(img, 0, 0);
+              const j = c.toDataURL('image/jpeg', 0.92);
+              res({ base64: j.split(',')[1], mediaType: 'image/jpeg' });
+            };
+            img.onerror = rej;
+            img.src = dataUrl;
+          } else {
+            res({ base64: parts[1], mediaType: mt });
+          }
+        };
+        r.onerror = rej;
+        r.readAsDataURL(file);
+      });
+      try {
+        // Step 1: OCR — extract all text from the image first
+        const ocrPrompt = 'Extract ALL text from this image exactly as it appears. Include every word, bullet point, number, and line. Output only the raw text, nothing else.';
+        const ocrMsgs = [
+          { role: 'user', content: [
+            { type: 'image_url', image_url: { url: 'data:' + mediaType + ';base64,' + base64 } },
+            { type: 'text', text: ocrPrompt }
+          ]}
+        ];
+        const ocrText = await AIService._callWithFunction('noteProcessing', ocrMsgs, 1500);
+
+        // Step 2: Extract module titles
+        const extractPrompt = 'Look at this text and find all the learning module topics. For each module, give me just the topic name (not the module number). '
+          + 'Return a JSON array of strings. Example: ["Introduction to Income Tax", "Gross Income", "Exempt Income"]. '
+          + 'Output ONLY the array, nothing else.'
+          + '\n\nTEXT:\n' + ocrText;
+        const extractMsgs = [
+          { role: 'user', content: extractPrompt }
+        ];
+        // Use 'chat' not 'noteProcessing' — avoids forcing JSON-only system prompt
+        const raw = await AIService._callWithFunction('chat', extractMsgs, 800);
+        let outcomes = [];
+        let cleanRaw = raw.trim().replace(/^```(?:json)?\s*/i,'').replace(/\s*```$/i,'').trim();
+        if (cleanRaw.startsWith('{')) {
+          try { const obj = JSON.parse(cleanRaw); const v = Object.values(obj)[0]; cleanRaw = Array.isArray(v) ? JSON.stringify(v) : cleanRaw; } catch {}
+        }
+        try {
+          const parsed = JSON.parse(cleanRaw);
+          outcomes = Array.isArray(parsed) ? parsed : [];
+        } catch {
+          try { outcomes = AIService._parseJSON(raw).outcomes || []; } catch {}
+        }
+        // If still empty, split the OCR text into lines as fallback
+        if (!outcomes.length && ocrText.trim()) {
+          outcomes = ocrText
+            .split('\n')
+            .map(l => l.replace(/^[\s\-•\*\d\.]+/, '').trim())
+            .filter(l => l.length > 10 && l.length < 300);
+        }
+        if (!outcomes.length) {
+          Toast.error('Could not find outcomes. Please add them manually below.');
+          return;
+        }
+        if (!node.moduleOutcomes) node.moduleOutcomes = [];
+        const startNum = node.moduleOutcomes.length + 1;
+        outcomes.forEach((text, i) => {
+          node.moduleOutcomes.push({ id: 'oc_' + Math.random().toString(36).slice(2,8), text: String(text).trim(), achieved: false, moduleNum: startNum + i });
+        });
+        nodeStore.save(node);
+        // Share outcomes with all nodes of the same subject
+        if (node.subject) {
+          nodeStore.getAll()
+            .filter(n => n.id !== node.id && n.subject &&
+              n.subject.toLowerCase().trim() === node.subject.toLowerCase().trim()
+            )
+            .forEach(n => {
+              if (!n.moduleOutcomes) n.moduleOutcomes = [];
+              node.moduleOutcomes.forEach(o => {
+                if (!n.moduleOutcomes.find(x => x.text.toLowerCase().trim() === o.text.toLowerCase().trim())) {
+                  n.moduleOutcomes.push({ ...o, id: 'oc_' + Math.random().toString(36).slice(2,8) });
+                  nodeStore.save(n);
+                }
+              });
+            });
+        }
+        this._refreshOutcomesBody(node);
+        const count = node.moduleOutcomes.length;
+        const cnt = document.querySelector('.outcomes-count');
+        if (cnt) cnt.textContent = count + ' outcome' + (count !== 1 ? 's' : '');
+        Toast.success(outcomes.length + ' outcomes added and shared across ' + node.subject + ' nodes!');
+        this._scanningOutcomes = false;
+      } catch(err) { Toast.error('Error: ' + err.message); this._scanningOutcomes = false; }
+    };
+    input.click();
+  },
+
+  /* ─── STRUCTURE NOTES FROM TABLE OF CONTENTS ─────── */
+  async _structureNotesFromToC() {
+    const node = this._currentNode;
+    const toc = (node.moduleOutcomes || []).map(o => o.text).filter(Boolean);
+    if (!toc.length) {
+      Toast.error('Add sections to your Table of Contents first.');
+      return;
+    }
+    if (!AIService.hasApiKey()) {
+      Toast.error('Configure AI first in Settings.');
+      return;
+    }
+    // Show progress in the outcomes panel
+    const structureBtn = document.getElementById('outcomes-structure-btn');
+    if (structureBtn) { structureBtn.textContent = '⟳ Working…'; structureBtn.disabled = true; }
+    Toast.info('AI is structuring your notes…');
+    try {
+      const sourceContext = [
+        node.rawOCR || '',
+        node.summary || '',
+        (node.definitions||[]).map(d => d.term + ': ' + d.description).join('\n'),
+        (node.formulas||[]).map(f => f.expression + ' — ' + f.description).join('\n'),
+        (node.procedures||[]).flatMap(p => [p.title, ...(p.steps||[])]).join('\n'),
+        node.userNotes || '',
+      ].filter(Boolean).join('\n\n').slice(0, 7000);
+
+      const tocList = toc.map((t, i) => (i+1) + '. ' + t).join('\n');
+
+      const prompt = 'You are restructuring study notes for "' + node.title + '" (' + (node.subject||'') + ').'
+        + '\n\nThe student has defined these sections in their Table of Contents:\n' + tocList
+        + '\n\nUsing ONLY the source material below, write detailed study notes organised under each section heading.'
+        + ' For each section, include: key definitions relevant to that section, important rules or formulas, and a brief explanation.'
+        + ' ONLY use information from the source. If the source has nothing for a section, write "No content available in source material."'
+        + '\n\nFormat the output as plain text with each section clearly labelled as:\n=== [Section Name] ===\n[content]'
+        + '\n\nSOURCE MATERIAL:\n' + sourceContext;
+
+      const raw = await AIService._callWithFunction('restructure',
+        [{role:'user', content: prompt}], 3000);
+
+      // Parse sections from the response and update node's userNotes
+      node.userNotes = raw.trim();
+      nodeStore.save(node);
+      Toast.success('Notes structured from Table of Contents!');
+      this._renderSection();
+    } catch(err) {
+      Toast.error('Could not structure: ' + err.message);
+    } finally {
+      if (structureBtn) { structureBtn.textContent = '⬡ Structure'; structureBtn.disabled = false; }
+    }
+  },
+
+  _addOutcome() {
+    const input     = document.getElementById('new-outcome-input');
+    const modInput  = document.getElementById('new-outcome-module');
+    const text      = input?.value.trim();
+    if (!text) { input?.focus(); return; }
+    if (!this._currentNode.moduleOutcomes) this._currentNode.moduleOutcomes = [];
+    // Parse module number from the module label input (e.g. "Module 3" → 3, or keep as string)
+    const modRaw    = (modInput?.value || '').trim();
+    const numMatch  = modRaw.match(/\d+/);
+    const moduleNum = numMatch ? parseInt(numMatch[0]) : (this._currentNode.moduleOutcomes.length + 1);
+    this._currentNode.moduleOutcomes.push({
+      id: 'oc_' + Math.random().toString(36).slice(2,8),
+      text,
+      achieved: false,
+      moduleNum,
+    });
+    // Sort by module number so they stay in order
+    this._currentNode.moduleOutcomes.sort((a,b) => (a.moduleNum||0) - (b.moduleNum||0));
+    nodeStore.save(this._currentNode);
+    // Sync to same-subject nodes
+    if (this._currentNode.subject) {
+      nodeStore.getAll()
+        .filter(n => n.id !== this._currentNode.id && n.subject &&
+          n.subject.toLowerCase().trim() === this._currentNode.subject.toLowerCase().trim()
+        )
+        .forEach(n => {
+          if (!n.moduleOutcomes) n.moduleOutcomes = [];
+          const exists = n.moduleOutcomes.find(x => x.text.toLowerCase().trim() === text.toLowerCase().trim());
+          if (!exists) { n.moduleOutcomes.push({ id:'oc_'+Math.random().toString(36).slice(2,8), text, achieved:false, moduleNum }); n.moduleOutcomes.sort((a,b)=>(a.moduleNum||0)-(b.moduleNum||0)); nodeStore.save(n); }
+        });
+    }
+    this._refreshOutcomesBody(this._currentNode);
+    if (input) input.value = '';
+  },
+
+  _deleteOutcome(id) {
+    this._currentNode.moduleOutcomes = (this._currentNode.moduleOutcomes||[]).filter(o => o.id !== id);
+    nodeStore.save(this._currentNode);
+    this._refreshOutcomesBody(this._currentNode);
+  },
+
+  _toggleOutcomeAchieved(id, achieved) {
+    const o = this._currentNode.moduleOutcomes?.find(o => o.id === id);
+    if (o) { o.achieved = achieved; nodeStore.save(this._currentNode); }
+    const row = document.querySelector('.outcome-row [data-outcome-id="' + id + '"]')?.closest('.outcome-row');
+    if (row) row.classList.toggle('achieved', achieved);
+  },
+
+  /* ─── TEMPLATE PICKER (AI-driven, inline) ─────────── */
+  // ═══════════════════════════════════════════════════════════════════════════
+  // ▶ TEMPLATE PICKER
+  // ═══════════════════════════════════════════════════════════════════════════
+  _openTemplatePanel() {
+    const node = this._currentNode;
+    const current = node.noteTemplate || 'standard';
+    const hasAI = AIService.hasApiKey();
+
+    const templates = [
+      { id:'standard', icon:'📋', name:'Standard',      desc:'AI-structured definitions, tables, formulas and procedures.' },
+      { id:'cornell',  icon:'🗒',  name:'Cornell Method', desc:'Cues column + Notes column + Summary. Great for all subjects.' },
+      { id:'outline',  icon:'≡',  name:'Outline Method', desc:'Numbered hierarchy. Best for law, tax, procedures.' },
+      { id:'feynman',  icon:'💡', name:'Feynman Method', desc:'Explain it simply. Gaps in explanation = gaps in knowledge.' },
+    ];
+
+    // Suggest best template based on subject category
+    const suggestions = {
+      accounting: 'cornell',
+      law: 'outline',
+      programming: 'standard',
+      science: 'cornell',
+      medicine: 'outline',
+      maths: 'standard',
+      history: 'outline',
+      language: 'cornell',
+      general: 'standard',
+    };
+    const suggested = suggestions[node.subjectCategory] || 'standard';
+
+    Modal.open(
+      '<h2 style="font-family:var(--font-ui);font-size:18px;font-weight:800;margin-bottom:4px;">Change Note Format</h2>'
+      + '<p style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);margin-bottom:16px;">'
+      + (hasAI ? 'AI will rewrite your notes into the chosen format using your source material.' : 'Select a format to apply.')
+      + (node.subjectCategory ? ' · Suggested for ' + node.subjectCategory + ': <strong style="color:var(--accent);">' + templates.find(t=>t.id===suggested)?.name + '</strong>' : '')
+      + '</p>'
+      + '<div style="display:flex;flex-direction:column;gap:8px;margin-bottom:20px;">'
+      + templates.map(t =>
+          '<button class="nt-option' + (current === t.id ? ' active' : '') + (t.id === suggested && current !== t.id ? ' suggested' : '') + '" data-template="' + t.id + '" style="display:flex;align-items:flex-start;gap:12px;padding:12px 14px;border-radius:var(--radius-md);border:1px solid ' + (current===t.id?'var(--accent)':t.id===suggested?'var(--accent-dim)':'var(--border)') + ';background:' + (current===t.id?'var(--accent-soft)':'var(--bg-raised)') + ';cursor:pointer;text-align:left;width:100%;">'
+          + '<span style="font-size:20px;flex-shrink:0;">' + t.icon + '</span>'
+          + '<div><div style="font-family:var(--font-ui);font-size:13px;font-weight:700;color:var(--text-primary);">' + t.name
+          + (t.id === suggested && current !== t.id ? ' <span style="font-family:var(--font-mono);font-size:10px;color:var(--accent);font-weight:400;">· recommended</span>' : '')
+          + '</div><div style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);margin-top:2px;">' + t.desc + '</div></div>'
+          + '</button>'
+        ).join('')
+      + '</div>'
+      + '<div id="nt-warning" style="display:none;padding:10px 14px;background:var(--accent-soft);border:1px solid var(--accent-dim);border-radius:var(--radius-md);margin-bottom:16px;font-family:var(--font-mono);font-size:11px;color:var(--accent);">⬡ AI will restructure your notes into this format. This may take 15-30 seconds.</div>'
+      + '<div style="display:flex;gap:8px;">'
+      + '<button class="btn-primary" id="nt-apply-btn" style="flex:1;justify-content:center;">' + (hasAI ? '⬡ Apply with AI' : 'Apply') + '</button>'
+      + '<button class="btn-secondary" onclick="Modal.close()">Cancel</button>'
+      + '</div>'
+      + '<div id="nt-progress" style="display:none;margin-top:14px;text-align:center;"><div class="aif-loading" style="justify-content:center;"><div class="aif-dot"></div><div class="aif-dot"></div><div class="aif-dot"></div></div><p style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);margin-top:8px;">AI is restructuring your notes…</p></div>'
+    );
+
+    setTimeout(() => {
+      let selectedTemplate = current;
+
+      document.querySelectorAll('.nt-option').forEach(btn => {
+        btn.addEventListener('click', () => {
+          document.querySelectorAll('.nt-option').forEach(b => {
+            b.style.border = '1px solid var(--border)';
+            b.style.background = 'var(--bg-raised)';
+          });
+          btn.style.border = '1px solid var(--accent)';
+          btn.style.background = 'var(--accent-soft)';
+          selectedTemplate = btn.dataset.template;
+          const warn = document.getElementById('nt-warning');
+          if (warn) warn.style.display = (selectedTemplate !== current && selectedTemplate !== 'standard' && hasAI) ? 'block' : 'none';
+        });
+      });
+
+      document.getElementById('nt-apply-btn')?.addEventListener('click', async () => {
+        if (selectedTemplate === current) { Modal.close(); return; }
+
+        if (selectedTemplate === 'standard') {
+          node.noteTemplate = 'standard';
+          nodeStore.save(node);
+          Modal.close();
+          Toast.success('Reset to Standard format.');
+          this._editMode = false;
+          this._renderSection();
+          return;
+        }
+
+        if (!hasAI) {
+          node.noteTemplate = selectedTemplate;
+          nodeStore.save(node);
+          Modal.close();
+          Toast.success('Template: ' + (templates.find(t=>t.id===selectedTemplate)?.name || selectedTemplate));
+          this._editMode = false;
+          this._renderSection();
+          return;
+        }
+
+        // AI rewrite
+        const applyBtn = document.getElementById('nt-apply-btn');
+        const progress = document.getElementById('nt-progress');
+        if (applyBtn) { applyBtn.disabled = true; applyBtn.textContent = 'Rewriting…'; }
+        if (progress) progress.style.display = 'block';
+
+        try {
+          const result = await AIService.rewriteAsTemplate(node, selectedTemplate);
+          node.noteTemplate = selectedTemplate;
+          if (result.type === 'cornell')  node.cornellData = result.data;
+          if (result.type === 'outline')  node.outlineData = result.data;
+          if (result.type === 'feynman')  node.feynmanData2 = result.data;
+          nodeStore.save(node);
+          Modal.close();
+          Toast.success('Notes restructured as ' + (templates.find(t=>t.id===selectedTemplate)?.name || selectedTemplate) + '.');
+          this._editMode = false;
+          this._renderSection();
+        } catch(err) {
+          if (applyBtn) { applyBtn.disabled = false; applyBtn.textContent = '⬡ Apply with AI'; }
+          if (progress) progress.style.display = 'none';
+          Toast.error('Could not rewrite: ' + err.message);
+        }
+      });
+    }, 0);
+  },
+
+  /* ─── EDIT MODE ───────────────────────────────────── */
+  // ═══════════════════════════════════════════════════════════════════════════
+  // ▶ EDIT MODE
+  // ═══════════════════════════════════════════════════════════════════════════
+  _toggleEditMode() {
+    this._editMode = !this._editMode;
+    const btn = document.getElementById('edit-toggle-btn');
+    if (this._editMode) {
+      if (btn) { btn.textContent = '✓ Save'; btn.className = 'btn-primary'; btn.style.fontSize = '12px'; btn.style.padding = '8px 14px'; }
+      // Route to block editor for modern nodes, legacy form for old ones
+      const node = this._currentNode;
+      if (node.blocks?.length) {
+        this._renderBlockEditor(node);
+      } else {
+        this._renderEditForm(node);
+      }
+    } else {
+      const node = this._currentNode;
+      if (node.blocks?.length) {
+        this._saveBlockEdits();
+      } else {
+        this._saveEdits();
+      }
+    }
+  },
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // ▶ BLOCK EDITOR — inline editing for nodes with blocks[]
+  // ═══════════════════════════════════════════════════════════════════════════
+  _renderBlockEditor(node) {
+    const esc = this._esc.bind(this);
+    let html = '<div id="block-editor">';
+
+    // Title
+    html += '<div class="edit-section">'
+      + '<label class="config-label">Title</label>'
+      + '<input type="text" id="edit-title" class="config-input" value="' + esc(node.title) + '" style="font-family:var(--font-ui);font-size:15px;font-weight:700;padding:12px 14px;"/>'
+      + '</div>';
+
+    // Blocks
+    node.blocks.forEach((b, idx) => {
+      html += '<div class="edit-section block-edit-block" data-block-idx="' + idx + '" style="position:relative;">';
+      html += '<div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:8px;">'
+        + '<label class="config-label" style="margin:0;text-transform:uppercase;font-size:9px;letter-spacing:.1em;color:var(--accent);">' + esc(b.type) + (b.title ? ' — ' + esc(b.title) : '') + '</label>'
+        + '<button class="edit-del-btn block-del-btn" data-block-idx="' + idx + '" title="Remove this block">✕</button>'
+        + '</div>';
+
+      switch (b.type) {
+        case 'prose':
+        case 'callout':
+          html += '<input type="text" class="config-input bef-title" data-idx="' + idx + '" placeholder="Title (optional)" value="' + esc(b.title || '') + '" style="margin-bottom:8px;font-size:13px;"/>';
+          html += '<textarea class="config-input bef-html" data-idx="' + idx + '" rows="5" style="resize:vertical;touch-action:pan-y;font-size:14px;line-height:1.65;">' + esc((b.html || '').replace(/<[^>]+>/g, '')) + '</textarea>';
+          break;
+        case 'definition':
+          html += '<input type="text" class="config-input bef-title" data-idx="' + idx + '" placeholder="Block title" value="' + esc(b.title || '') + '" style="margin-bottom:10px;font-size:13px;"/>';
+          html += '<div class="bef-def-list" data-idx="' + idx + '">';
+          (b.items || []).forEach((d, di) => {
+            html += '<div class="bef-def-row" style="background:var(--bg-raised);border:1px solid var(--border);border-radius:8px;padding:12px;margin-bottom:8px;">'
+              + '<div style="display:flex;gap:8px;align-items:flex-start;">'
+              + '<div style="flex:1;display:flex;flex-direction:column;gap:6px;">'
+              + '<input type="text" class="config-input bef-def-term" data-idx="' + idx + '" data-di="' + di + '" placeholder="Term" value="' + esc(d.term) + '" style="font-weight:600;font-size:13px;"/>'
+              + '<input type="text" class="config-input bef-def-ex" data-idx="' + idx + '" data-di="' + di + '" placeholder="Examples (optional)" value="' + esc(d.examples || '') + '" style="font-size:12px;color:var(--text-secondary);"/>'
+              + '<textarea class="config-input bef-def-desc" data-idx="' + idx + '" data-di="' + di + '" rows="2" style="resize:vertical;font-size:13px;line-height:1.5;">' + esc(d.description) + '</textarea>'
+              + '</div>'
+              + '<button class="edit-del-btn bef-del-def" data-idx="' + idx + '" data-di="' + di + '">✕</button>'
+              + '</div></div>';
+          });
+          html += '</div>';
+          html += '<button class="btn-secondary bef-add-def" data-idx="' + idx + '" style="font-size:11px;padding:5px 12px;margin-top:4px;">+ Add definition</button>';
+          break;
+        case 'formula':
+          html += '<input type="text" class="config-input bef-title" data-idx="' + idx + '" placeholder="Block title" value="' + esc(b.title || '') + '" style="margin-bottom:10px;font-size:13px;"/>';
+          (b.items || []).forEach((f, fi) => {
+            html += '<div class="bef-formula-row" style="background:var(--bg-raised);border:1px solid var(--border);border-radius:8px;padding:12px;margin-bottom:8px;">'
+              + '<div style="display:flex;gap:8px;margin-bottom:6px;">'
+              + '<input type="text" class="config-input bef-f-expr" data-idx="' + idx + '" data-fi="' + fi + '" placeholder="Expression" value="' + esc(f.expression) + '" style="flex:1;font-family:var(--font-mono);font-size:13px;"/>'
+              + '<button class="edit-del-btn bef-del-formula" data-idx="' + idx + '" data-fi="' + fi + '">✕</button>'
+              + '</div>'
+              + '<input type="text" class="config-input bef-f-desc" data-idx="' + idx + '" data-fi="' + fi + '" placeholder="Description" value="' + esc(f.description || '') + '" style="margin-bottom:6px;font-size:13px;"/>'
+              + '<input type="text" class="config-input bef-f-con" data-idx="' + idx + '" data-fi="' + fi + '" placeholder="Constraints" value="' + esc(f.constraints || '') + '" style="font-size:13px;"/>'
+              + '</div>';
+          });
+          html += '<button class="btn-secondary bef-add-formula" data-idx="' + idx + '" style="font-size:11px;padding:5px 12px;margin-top:4px;">+ Add formula</button>';
+          break;
+        case 'procedure':
+          html += '<input type="text" class="config-input bef-title" data-idx="' + idx + '" placeholder="Procedure title" value="' + esc(b.title || '') + '" style="margin-bottom:6px;font-size:13px;"/>';
+          html += '<input type="text" class="config-input bef-applies" data-idx="' + idx + '" placeholder="Applies to (optional)" value="' + esc(b.appliesTo || '') + '" style="margin-bottom:10px;font-size:12px;color:var(--text-secondary);"/>';
+          html += '<div class="bef-steps-list" data-idx="' + idx + '">';
+          (b.steps || []).forEach((s, si) => {
+            html += '<div class="bef-step-row" style="display:flex;gap:8px;align-items:flex-start;margin-bottom:6px;">'
+              + '<span style="font-family:var(--font-mono);font-size:11px;font-weight:700;color:var(--accent);padding-top:10px;min-width:18px;">' + (si + 1) + '.</span>'
+              + '<textarea class="config-input bef-step" data-idx="' + idx + '" data-si="' + si + '" rows="2" style="flex:1;resize:vertical;font-size:13px;line-height:1.5;">' + esc(s) + '</textarea>'
+              + '<button class="edit-del-btn bef-del-step" data-idx="' + idx + '" data-si="' + si + '" style="margin-top:4px;">✕</button>'
+              + '</div>';
+          });
+          html += '</div>';
+          html += '<input type="text" class="config-input bef-notes" data-idx="' + idx + '" placeholder="Notes (optional)" value="' + esc(b.notes || '') + '" style="font-size:12px;color:var(--text-secondary);margin-top:4px;"/>';
+          html += '<button class="btn-secondary bef-add-step" data-idx="' + idx + '" style="font-size:11px;padding:5px 12px;margin-top:8px;">+ Add step</button>';
+          break;
+        case 'table':
+          html += '<input type="text" class="config-input bef-title" data-idx="' + idx + '" placeholder="Table title" value="' + esc(b.title || '') + '" style="margin-bottom:8px;font-size:13px;"/>';
+          html += '<div style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);margin-bottom:8px;">Table editing: use Edit → Plain Import to modify complex tables.</div>';
+          break;
+        default:
+          html += '<div style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);">Interactive block — title editable only.</div>';
+          html += '<input type="text" class="config-input bef-title" data-idx="' + idx + '" placeholder="Block title" value="' + esc(b.title || '') + '" style="font-size:13px;"/>';
+      }
+
+      html += '</div>';
+    });
+
+    html += '<div class="edit-section"><label class="config-label">My Notes</label>'
+      + '<textarea id="edit-user-notes" class="config-input" rows="4" style="resize:vertical;touch-action:pan-y;font-size:14px;line-height:1.65;" placeholder="Personal notes, mnemonics…">' + esc(node.userNotes || '') + '</textarea></div>';
+
+    html += '</div>';
+    document.getElementById('notes-display').innerHTML = html;
+    this._bindBlockEditorEvents(node);
+  },
+
+  _bindBlockEditorEvents(node) {
+    const container = document.getElementById('block-editor');
+    if (!container) return;
+
+    // Delete a whole block
+    container.querySelectorAll('.block-del-btn').forEach(btn => {
+      btn.addEventListener('click', e => {
+        e.stopPropagation();
+        const idx = parseInt(btn.dataset.blockIdx);
+        node.blocks.splice(idx, 1);
+        nodeStore.save(node);
+        this._renderBlockEditor(node);
+      });
+    });
+
+    // Delete a definition item
+    container.querySelectorAll('.bef-del-def').forEach(btn => {
+      btn.addEventListener('click', e => {
+        e.stopPropagation();
+        const idx = parseInt(btn.dataset.idx);
+        const di  = parseInt(btn.dataset.di);
+        node.blocks[idx].items?.splice(di, 1);
+        nodeStore.save(node);
+        this._renderBlockEditor(node);
+      });
+    });
+
+    // Add a definition item
+    container.querySelectorAll('.bef-add-def').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const idx = parseInt(btn.dataset.idx);
+        if (!node.blocks[idx].items) node.blocks[idx].items = [];
+        node.blocks[idx].items.push({ term: '', examples: '', description: '' });
+        nodeStore.save(node);
+        this._renderBlockEditor(node);
+      });
+    });
+
+    // Delete a formula item
+    container.querySelectorAll('.bef-del-formula').forEach(btn => {
+      btn.addEventListener('click', e => {
+        e.stopPropagation();
+        const idx = parseInt(btn.dataset.idx);
+        const fi  = parseInt(btn.dataset.fi);
+        node.blocks[idx].items?.splice(fi, 1);
+        nodeStore.save(node);
+        this._renderBlockEditor(node);
+      });
+    });
+
+    // Add a formula item
+    container.querySelectorAll('.bef-add-formula').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const idx = parseInt(btn.dataset.idx);
+        if (!node.blocks[idx].items) node.blocks[idx].items = [];
+        node.blocks[idx].items.push({ expression: '', description: '', constraints: '' });
+        nodeStore.save(node);
+        this._renderBlockEditor(node);
+      });
+    });
+
+    // Delete a procedure step
+    container.querySelectorAll('.bef-del-step').forEach(btn => {
+      btn.addEventListener('click', e => {
+        e.stopPropagation();
+        const idx = parseInt(btn.dataset.idx);
+        const si  = parseInt(btn.dataset.si);
+        node.blocks[idx].steps?.splice(si, 1);
+        nodeStore.save(node);
+        this._renderBlockEditor(node);
+      });
+    });
+
+    // Add a procedure step
+    container.querySelectorAll('.bef-add-step').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const idx = parseInt(btn.dataset.idx);
+        if (!node.blocks[idx].steps) node.blocks[idx].steps = [];
+        node.blocks[idx].steps.push('');
+        nodeStore.save(node);
+        this._renderBlockEditor(node);
+      });
+    });
+  },
+
+  _saveBlockEdits() {
+    const node = this._currentNode;
+    if (!node) { Toast.error('No node to save.'); return; }
+
+    const snapshot = JSON.stringify(node.toJSON ? node.toJSON() : node);
+    try {
+      // Title
+      const titleEl = document.getElementById('edit-title');
+      if (titleEl) node.title = titleEl.value.trim() || node.title;
+
+      // User notes
+      const notesEl = document.getElementById('edit-user-notes');
+      if (notesEl) node.userNotes = notesEl.value;
+
+      // Walk each block and read updated values
+      document.querySelectorAll('.block-edit-block').forEach(blockEl => {
+        const idx = parseInt(blockEl.dataset.blockIdx);
+        const b   = node.blocks[idx];
+        if (!b) return;
+
+        // Title applies to all block types
+        const titleInput = blockEl.querySelector('.bef-title');
+        if (titleInput) b.title = titleInput.value.trim();
+
+        switch (b.type) {
+          case 'prose':
+          case 'callout': {
+            const htmlEl = blockEl.querySelector('.bef-html');
+            if (htmlEl) b.html = htmlEl.value.replace(/\n/g, '<br>');
+            break;
+          }
+          case 'definition': {
+            const rows = blockEl.querySelectorAll('.bef-def-row');
+            b.items = Array.from(rows).map(row => ({
+              term:        row.querySelector('.bef-def-term')?.value.trim() || '',
+              examples:    row.querySelector('.bef-def-ex')?.value.trim()   || '',
+              description: row.querySelector('.bef-def-desc')?.value.trim() || '',
+            })).filter(d => d.term || d.description);
+            break;
+          }
+          case 'formula': {
+            const rows = blockEl.querySelectorAll('.bef-formula-row');
+            b.items = Array.from(rows).map(row => ({
+              expression:  row.querySelector('.bef-f-expr')?.value.trim() || '',
+              description: row.querySelector('.bef-f-desc')?.value.trim() || '',
+              constraints: row.querySelector('.bef-f-con')?.value.trim()  || '',
+            })).filter(f => f.expression);
+            break;
+          }
+          case 'procedure': {
+            const appEl = blockEl.querySelector('.bef-applies');
+            if (appEl) b.appliesTo = appEl.value.trim();
+            const notesEl2 = blockEl.querySelector('.bef-notes');
+            if (notesEl2) b.notes = notesEl2.value.trim();
+            const steps = blockEl.querySelectorAll('.bef-step');
+            b.steps = Array.from(steps).map(s => s.value.trim()).filter(Boolean);
+            break;
+          }
+        }
+      });
+
+      node.invalidateContentCaches();
+      nodeStore.save(node);
+      Toast.success('Notes saved!');
+      const btn = document.getElementById('edit-toggle-btn');
+      if (btn) { btn.textContent = '✏️ Edit'; btn.className = 'btn-secondary'; btn.style.fontSize = '12px'; btn.style.padding = '8px 14px'; }
+      this._editMode = false;
+      this._renderNotes(node);
+    } catch(e) {
+      console.error('[NodeDetailView] Block save failed, rolling back:', e);
+      try { Object.assign(node, JSON.parse(snapshot)); nodeStore.save(node); } catch(e2) {}
+      Toast.error('Save failed — your last edit was not stored. Try again.');
+    }
+  },
+
+  _renderEditForm(node) {
+    const tmpl = node.noteTemplate || 'standard';
+    const templateForm = tmpl !== 'standard' ? NoteTemplates.renderEditForm(node) : null;
+
+    document.getElementById('notes-display').innerHTML =
+      (templateForm
+        ? '<div class="edit-section"><label class="config-label" style="margin-bottom:12px;">' + (NoteTemplates.TEMPLATES[tmpl]?.icon||'') + ' ' + (NoteTemplates.TEMPLATES[tmpl]?.name||'') + '</label>' + templateForm + '</div>'
+        : '')
+
+      + '<div class="edit-section">'
+      + '<label class="config-label">Title</label>'
+      + '<input type="text" id="edit-title" class="config-input" value="' + this._esc(node.title) + '" style="font-family:var(--font-ui);font-size:15px;font-weight:700;padding:12px 14px;"/>'
+      + '</div>'
+
+      // ── DEFINITIONS with examples ──
+      + '<div class="edit-section">'
+      + '<div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:10px;">'
+      + '<label class="config-label" style="margin:0;">Definitions</label>'
+      + '<button class="btn-secondary" style="font-size:11px;padding:5px 12px;" id="add-def-btn">+ Add</button>'
+      + '</div>'
+      + '<div id="edit-defs" style="display:flex;flex-direction:column;gap:12px;">'
+      + node.definitions.map(d =>
+          '<div class="edit-def-row">'
+          + '<div style="display:flex;gap:8px;align-items:flex-start;">'
+          + '<div style="flex:1;display:flex;flex-direction:column;gap:6px;">'
+          + '<input type="text" class="config-input edit-def-term" placeholder="Term" value="' + this._esc(d.term) + '" style="font-family:var(--font-mono);font-size:13px;font-weight:600;padding:10px 12px;"/>'
+          + '<input type="text" class="config-input edit-def-examples" placeholder="Examples (optional): e.g. Cash, Equipment, Land…" value="' + this._esc(d.examples||'') + '" style="font-size:12px;padding:8px 12px;color:var(--text-secondary);"/>'
+          + '<textarea class="config-input edit-def-desc" placeholder="Definition / description…" rows="3" style="font-family:var(--font-body);font-size:14px;line-height:1.65;padding:10px 12px;resize:vertical;touch-action:pan-y;">' + this._esc(d.description) + '</textarea>'
+          + '</div>'
+          + '<button class="edit-del-btn" style="margin-top:4px;">✕</button>'
+          + '</div></div>'
+        ).join('')
+      + '</div></div>'
+
+      // ── TABLES ──
+      + '<div class="edit-section">'
+      + '<div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:10px;">'
+      + '<label class="config-label" style="margin:0;">Tables</label>'
+      + '<button class="btn-secondary" style="font-size:11px;padding:5px 12px;" id="add-table-btn">+ Add Table</button>'
+      + '</div>'
+      + '<div id="edit-tables" style="display:flex;flex-direction:column;gap:14px;">'
+      + (node.tables||[]).map((tbl, ti) => this._renderTableEditor(tbl, ti)).join('')
+      + '</div></div>'
+
+      // ── FORMULAS ──
+      + '<div class="edit-section">'
+      + '<div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:10px;">'
+      + '<label class="config-label" style="margin:0;">Formulas</label>'
+      + '<button class="btn-secondary" style="font-size:11px;padding:5px 12px;" id="add-formula-btn">+ Add</button>'
+      + '</div>'
+      + '<div id="edit-formulas" style="display:flex;flex-direction:column;gap:10px;">'
+      + node.formulas.map(f =>
+          '<div class="edit-row" style="flex-direction:column;gap:6px;align-items:stretch;padding:14px;background:var(--bg-raised);border:1px solid var(--border);border-radius:var(--radius-md);">'
+          + '<div style="display:flex;gap:8px;"><input type="text" class="config-input edit-f-expr" placeholder="Expression" value="' + this._esc(f.expression) + '" style="flex:1;font-family:var(--font-mono);font-size:13px;"/><button class="edit-del-btn">✕</button></div>'
+          + '<input type="text" class="config-input edit-f-desc" placeholder="Description" value="' + this._esc(f.description) + '" style="font-size:13px;"/>'
+          + '<input type="text" class="config-input edit-f-con"  placeholder="Constraints"  value="' + this._esc(f.constraints||'') + '" style="font-size:13px;"/>'
+          + '</div>'
+        ).join('')
+      + '</div></div>'
+
+      // ── STRUCTURED PROCEDURES ──
+      + '<div class="edit-section">'
+      + '<div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:10px;">'
+      + '<label class="config-label" style="margin:0;">Procedures</label>'
+      + '<button class="btn-secondary" style="font-size:11px;padding:5px 12px;" id="add-proc-group-btn">+ Add Procedure</button>'
+      + '</div>'
+      + '<div id="edit-proc-groups" style="display:flex;flex-direction:column;gap:14px;">'
+      + (node.procedures||[]).map((proc, gi) => this._renderProcEditor(proc, gi)).join('')
+      + '</div></div>'
+
+      // ── COMMON MISTAKES ──
+      + '<div class="edit-section">'
+      + '<div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:10px;">'
+      + '<label class="config-label" style="margin:0;">Common Mistakes</label>'
+      + '<button class="btn-secondary" style="font-size:11px;padding:5px 12px;" id="add-mistake-btn">+ Add</button>'
+      + '</div>'
+      + '<div id="edit-mistakes" style="display:flex;flex-direction:column;gap:8px;">'
+      + node.commonMistakes.map(m =>
+          '<div class="edit-row"><input type="text" class="config-input edit-mistake" placeholder="Mistake…" value="' + this._esc(m) + '" style="flex:1;font-size:13px;padding:10px 12px;"/><button class="edit-del-btn">✕</button></div>'
+        ).join('')
+      + '</div></div>'
+
+      + '<div class="edit-section"><label class="config-label">Summary</label>'
+      + '<textarea id="edit-summary" class="config-input" rows="4" style="resize:vertical;touch-action:pan-y;font-size:14px;line-height:1.65;">' + this._esc(node.summary) + '</textarea></div>'
+
+      + '<div class="edit-section"><label class="config-label">My Notes</label>'
+      + '<textarea id="edit-user-notes" class="config-input" rows="5" style="resize:vertical;touch-action:pan-y;font-size:14px;line-height:1.65;" placeholder="Personal notes, mnemonics…">' + this._esc(node.userNotes||'') + '</textarea></div>';
+
+    if (tmpl === 'outline') NoteTemplates.bindOutlineEditor();
+    ImageManager.bindEvents(this._body, node);
+    this._bindEditEvents(node);
+  },
+
+  /* ─── PROCEDURE EDITOR ────────────────────────────── */
+  _renderProcEditor(proc, gi) {
+    const steps = proc.steps || [];
+    const id    = proc.id || 'proc_' + gi;
+    return '<div class="proc-edit-group" data-proc-id="' + id + '">'
+      + '<div style="display:flex;align-items:center;gap:8px;margin-bottom:10px;flex-wrap:wrap;">'
+      + '<input type="text" class="config-input proc-title-input" placeholder="Procedure title…" value="' + this._esc(proc.title||'') + '" style="flex:1;font-size:14px;font-weight:700;padding:10px 12px;"/>'
+      + '<button class="edit-del-btn proc-del-btn" data-proc-id="' + id + '">✕ Remove</button>'
+      + '</div>'
+      + '<input type="text" class="config-input proc-applies-input" placeholder="Applies to / related concept (optional)…" value="' + this._esc(proc.appliesTo||'') + '" style="font-size:12px;padding:8px 12px;margin-bottom:10px;color:var(--text-secondary);"/>'
+      + '<div class="proc-steps-list" data-proc-id="' + id + '">'
+      + steps.map((s, si) =>
+          '<div class="edit-row proc-step-row" data-proc-id="' + id + '">'
+          + '<span style="font-family:var(--font-mono);font-size:11px;color:var(--accent);min-width:22px;padding-top:12px;">' + (si+1) + '.</span>'
+          + '<input type="text" class="config-input proc-step-input" placeholder="Step…" value="' + this._esc(s) + '" style="flex:1;font-size:13px;padding:10px 12px;" data-proc-id="' + id + '"/>'
+          + '<button class="edit-del-btn">✕</button>'
+          + '</div>'
+        ).join('')
+      + '</div>'
+      + '<button class="btn-secondary add-step-btn" data-proc-id="' + id + '" style="font-size:11px;padding:6px 12px;margin-top:6px;">+ Add Step</button>'
+      + '<details style="margin-top:10px;">'
+      + '<summary style="cursor:pointer;font-family:var(--font-ui);font-size:12px;font-weight:600;color:var(--text-muted);list-style:none;padding:6px 0;user-select:none;">📌 Procedure Notes &amp; Reminders</summary>'
+      + '<textarea class="config-input proc-notes-input" placeholder="Reminders, exceptions, warnings, tips…" rows="3" style="margin-top:8px;resize:vertical;touch-action:pan-y;font-size:13px;" data-proc-id="' + id + '">' + this._esc(proc.notes||'') + '</textarea>'
+      + '</details>'
+      + '</div>';
+  },
+
+  /* ─── TABLE EDITOR ────────────────────────────────── */
+  _renderTableEditor(tbl, ti) {
+    const cols = tbl.columns || ['Name','Type','Example'];
+    const rows = tbl.rows    || [];
+    const id   = tbl.id || 'tbl_' + ti;
+    return '<div class="table-edit-group" data-tbl-id="' + id + '">'
+      + '<div style="display:flex;align-items:center;gap:8px;margin-bottom:10px;">'
+      + '<input type="text" class="config-input tbl-title-input" placeholder="Table title…" value="' + this._esc(tbl.title||'') + '" style="flex:1;font-size:14px;font-weight:700;padding:10px 12px;" data-tbl-id="' + id + '"/>'
+      + '<button class="edit-del-btn tbl-del-btn" data-tbl-id="' + id + '">✕</button>'
+      + '</div>'
+      // Column headers (editable)
+      + '<div style="display:grid;grid-template-columns:repeat(' + cols.length + ',1fr) 40px;gap:4px;margin-bottom:4px;">'
+      + cols.map((c, ci) => '<input type="text" class="config-input tbl-col-input" value="' + this._esc(c) + '" style="font-size:11px;font-weight:700;padding:6px 8px;" data-tbl-id="' + id + '" data-col-idx="' + ci + '"/>').join('')
+      + '<div></div>'
+      + '</div>'
+      // Rows
+      + '<div class="tbl-rows-list" data-tbl-id="' + id + '" style="display:flex;flex-direction:column;gap:4px;">'
+      + rows.map((row, ri) =>
+          '<div class="tbl-row-wrap" style="display:grid;grid-template-columns:repeat(' + cols.length + ',1fr) 40px;gap:4px;" data-tbl-id="' + id + '">'
+          + cols.map((_, ci) => '<input type="text" class="config-input tbl-cell-input" value="' + this._esc(row[ci]||'') + '" style="font-size:13px;padding:8px 10px;" data-tbl-id="' + id + '" data-col-idx="' + ci + '" data-row-idx="' + ri + '"/>').join('')
+          + '<button class="edit-del-btn tbl-row-del-btn" data-tbl-id="' + id + '" data-row-idx="' + ri + '">✕</button>'
+          + '</div>'
+        ).join('')
+      + '</div>'
+      + '<button class="btn-secondary add-tbl-row-btn" data-tbl-id="' + id + '" style="font-size:11px;padding:6px 12px;margin-top:6px;">+ Add Row</button>'
+      + '</div>';
+  },
+
+  /* ─── BIND EDIT EVENTS ────────────────────────────── */
+  _bindEditEvents(node) {
+    const editDefs = document.getElementById('edit-defs');
+    const editProcs = document.getElementById('edit-proc-groups');
+    const editTables = document.getElementById('edit-tables');
+
+    // Add definition
+    document.getElementById('add-def-btn')?.addEventListener('click', () => {
+      const div = document.createElement('div');
+      div.className = 'edit-def-row';
+      div.innerHTML = '<div style="display:flex;gap:8px;align-items:flex-start;"><div style="flex:1;display:flex;flex-direction:column;gap:6px;"><input type="text" class="config-input edit-def-term" placeholder="Term" style="font-family:var(--font-mono);font-size:13px;font-weight:600;padding:10px 12px;"/><input type="text" class="config-input edit-def-examples" placeholder="Examples (optional)…" style="font-size:12px;padding:8px 12px;color:var(--text-secondary);"/><textarea class="config-input edit-def-desc" placeholder="Definition…" rows="3" style="font-family:var(--font-body);font-size:14px;line-height:1.65;padding:10px 12px;resize:vertical;touch-action:pan-y;"></textarea></div><button class="edit-del-btn" style="margin-top:4px;">✕</button></div>';
+      editDefs.appendChild(div);
+      div.querySelector('.edit-def-term').focus();
+    });
+
+    // Add procedure group
+    document.getElementById('add-proc-group-btn')?.addEventListener('click', () => {
+      const newProc = { id:'proc_' + Date.now().toString(36), title:'', appliesTo:'', steps:[], notes:'' };
+      node.procedures = node.procedures || [];
+      node.procedures.push(newProc);
+      const div = document.createElement('div');
+      div.innerHTML = this._renderProcEditor(newProc, node.procedures.length - 1);
+      editProcs.appendChild(div.firstElementChild);
+      editProcs.querySelector('.proc-edit-group:last-child .proc-title-input')?.focus();
+    });
+
+    // Add table
+    document.getElementById('add-table-btn')?.addEventListener('click', () => {
+      const newTbl = { id:'tbl_' + Date.now().toString(36), title:'', columns:['Name','Type','Example'], rows:[[]] };
+      node.tables = node.tables || [];
+      node.tables.push(newTbl);
+      const div = document.createElement('div');
+      div.innerHTML = this._renderTableEditor(newTbl, node.tables.length - 1);
+      editTables.appendChild(div.firstElementChild);
+      editTables.querySelector('.table-edit-group:last-child .tbl-title-input')?.focus();
+    });
+
+    // Delegate: add step, add table row, delete rows/procs/tables
+    editProcs.addEventListener('click', e => {
+      if (e.target.classList.contains('add-step-btn')) {
+        const procId = e.target.dataset.procId;
+        const list   = editProcs.querySelector('.proc-steps-list[data-proc-id="' + procId + '"]');
+        const si     = list.querySelectorAll('.proc-step-row').length;
+        const div = document.createElement('div');
+        div.className = 'edit-row proc-step-row';
+        div.dataset.procId = procId;
+        div.innerHTML = '<span style="font-family:var(--font-mono);font-size:11px;color:var(--accent);min-width:22px;padding-top:12px;">' + (si+1) + '.</span><input type="text" class="config-input proc-step-input" placeholder="Step…" style="flex:1;font-size:13px;padding:10px 12px;" data-proc-id="' + procId + '"/><button class="edit-del-btn">✕</button>';
+        list.appendChild(div);
+        div.querySelector('input').focus();
+      }
+      if (e.target.classList.contains('edit-del-btn')) {
+        const row = e.target.closest('.proc-step-row,.proc-edit-group');
+        if (row) row.remove();
+      }
+    });
+
+    editTables.addEventListener('click', e => {
+      if (e.target.classList.contains('add-tbl-row-btn')) {
+        const tblId = e.target.dataset.tblId;
+        const list  = editTables.querySelector('.tbl-rows-list[data-tbl-id="' + tblId + '"]');
+        const colCount = list.closest('.table-edit-group').querySelectorAll('.tbl-col-input').length;
+        const ri    = list.querySelectorAll('.tbl-row-wrap').length;
+        const div   = document.createElement('div');
+        div.className = 'tbl-row-wrap';
+        div.dataset.tblId = tblId;
+        div.style.cssText = 'display:grid;grid-template-columns:repeat(' + colCount + ',1fr) 40px;gap:4px;';
+        div.innerHTML = Array.from({length:colCount}).map((_, ci) =>
+          '<input type="text" class="config-input tbl-cell-input" style="font-size:13px;padding:8px 10px;" data-tbl-id="' + tblId + '" data-col-idx="' + ci + '" data-row-idx="' + ri + '"/>'
+        ).join('') + '<button class="edit-del-btn tbl-row-del-btn" data-tbl-id="' + tblId + '">✕</button>';
+        list.appendChild(div);
+        div.querySelector('input').focus();
+      }
+      if (e.target.classList.contains('tbl-row-del-btn')) {
+        e.target.closest('.tbl-row-wrap')?.remove();
+      }
+      if (e.target.classList.contains('tbl-del-btn')) {
+        e.target.closest('.table-edit-group')?.remove();
+      }
+    });
+
+    // Add formula
+    document.getElementById('add-formula-btn')?.addEventListener('click', () => {
+      const div = document.createElement('div');
+      div.className = 'edit-row';
+      div.style.cssText = 'flex-direction:column;gap:6px;align-items:stretch;padding:14px;background:var(--bg-raised);border:1px solid var(--border);border-radius:var(--radius-md);';
+      div.innerHTML = '<div style="display:flex;gap:8px;"><input type="text" class="config-input edit-f-expr" placeholder="Expression" style="flex:1;font-family:var(--font-mono);font-size:13px;"/><button class="edit-del-btn">✕</button></div><input type="text" class="config-input edit-f-desc" placeholder="Description" style="font-size:13px;"/><input type="text" class="config-input edit-f-con" placeholder="Constraints" style="font-size:13px;"/>';
+      div.querySelector('.edit-del-btn').addEventListener('click', () => div.remove());
+      document.getElementById('edit-formulas').appendChild(div);
+      div.querySelector('.edit-f-expr').focus();
+    });
+
+    // Add mistake
+    document.getElementById('add-mistake-btn')?.addEventListener('click', () => {
+      const div = document.createElement('div'); div.className = 'edit-row';
+      div.innerHTML = '<input type="text" class="config-input edit-mistake" placeholder="Mistake…" style="flex:1;font-size:13px;padding:10px 12px;"/><button class="edit-del-btn">✕</button>';
+      document.getElementById('edit-mistakes').appendChild(div);
+      div.querySelector('input').focus();
+    });
+
+    // Delegate delete from definition rows + formula rows + mistakes
+    document.getElementById('notes-display').addEventListener('click', e => {
+      if (e.target.classList.contains('edit-del-btn') && !e.target.closest('#edit-proc-groups') && !e.target.closest('#edit-tables')) {
+        e.target.closest('.edit-row, .edit-def-row')?.remove();
+      }
+    });
+  },
+
+  /* ─── SAVE EDITS ──────────────────────────────────── */
+  _saveEdits() {
+    const node = this._currentNode;
+    if (!node) { Toast.error('No node to save.'); return; }
+    const tmpl = node.noteTemplate || 'standard';
+
+    // Take a snapshot before editing so we can roll back if save fails
+    const snapshot = JSON.stringify(node.toJSON ? node.toJSON() : node);
+
+    try {
+    node.title    = document.getElementById('edit-title')?.value.trim()      || node.title;
+    node.summary  = document.getElementById('edit-summary')?.value.trim()    || '';
+    node.userNotes= document.getElementById('edit-user-notes')?.value        || '';
+
+    // Definitions with examples
+    node.definitions = Array.from(document.querySelectorAll('#edit-defs .edit-def-row')).map(r => ({
+      term:        r.querySelector('.edit-def-term')?.value.trim()     || '',
+      examples:    r.querySelector('.edit-def-examples')?.value.trim() || '',
+      description: r.querySelector('.edit-def-desc')?.value.trim()    || '',
+    })).filter(d => d.term || d.description);
+
+    // Tables
+    node.tables = [];
+    document.querySelectorAll('#edit-tables .table-edit-group').forEach(tblEl => {
+      const tblId  = tblEl.dataset.tblId;
+      const title  = tblEl.querySelector('.tbl-title-input')?.value.trim() || '';
+      const colEls = Array.from(tblEl.querySelectorAll('.tbl-col-input'));
+      const cols   = colEls.map(c => c.value.trim() || 'Column');
+      const rowEls = Array.from(tblEl.querySelectorAll('.tbl-row-wrap'));
+      const rows   = rowEls.map(rowEl =>
+        cols.map((_, ci) => rowEl.querySelector('[data-col-idx="' + ci + '"]')?.value.trim() || '')
+      ).filter(r => r.some(c => c));
+      if (title || rows.length) node.tables.push({ id:tblId, title, columns:cols, rows });
+    });
+
+    // Structured procedures
+    node.procedures = [];
+    document.querySelectorAll('#edit-proc-groups .proc-edit-group').forEach(grpEl => {
+      const procId   = grpEl.dataset.procId;
+      const title    = grpEl.querySelector('.proc-title-input')?.value.trim()   || '';
+      const appliesTo= grpEl.querySelector('.proc-applies-input')?.value.trim() || '';
+      const steps    = Array.from(grpEl.querySelectorAll('.proc-step-input')).map(i => i.value.trim()).filter(Boolean);
+      const notes    = grpEl.querySelector('.proc-notes-input')?.value.trim()   || '';
+      if (title || steps.length) node.procedures.push({ id:procId, title, appliesTo, steps, notes });
+    });
+
+    node.formulas    = Array.from(document.querySelectorAll('#edit-formulas .edit-row')).map(r => ({
+      expression:  r.querySelector('.edit-f-expr')?.value.trim() || '',
+      description: r.querySelector('.edit-f-desc')?.value.trim() || '',
+      constraints: r.querySelector('.edit-f-con')?.value.trim()  || '',
+    })).filter(f => f.expression);
+
+    node.commonMistakes = Array.from(document.querySelectorAll('.edit-mistake')).map(i => i.value.trim()).filter(Boolean);
+
+    if (tmpl === 'cornell') NoteTemplates.saveCornell(node);
+    if (tmpl === 'outline') NoteTemplates.saveOutline(node);
+    if (tmpl === 'feynman') NoteTemplates.saveFeynman(node);
+
+    document.querySelectorAll('.img-caption-input').forEach(inp => {
+      const img = node.userImages?.find(i => i.id === inp.dataset.imgId);
+      if (img) img.caption = inp.value.trim();
+    });
+
+    ImageResponseBlock.saveAll(document.getElementById('notes-display'), node);
+    node.invalidateContentCaches();
+    nodeStore.save(node);
+    Toast.success('Notes saved!');
+    const btn = document.getElementById('edit-toggle-btn');
+    if (btn) { btn.textContent='✏️ Edit'; btn.className='btn-secondary'; btn.style.fontSize='12px'; btn.style.padding='8px 14px'; }
+    this._editMode = false;
+    this._renderNotes(node);
+
+    } catch(e) {
+      // Rollback to snapshot
+      console.error('[NodeDetailView] Save failed, rolling back:', e);
+      try {
+        const snap = JSON.parse(snapshot);
+        Object.assign(node, snap);
+        nodeStore.save(node);
+      } catch(e2) { /* snapshot rollback failed, nothing we can do */ }
+      Toast.error('Save failed — your last edit was not stored. Try again.');
+    }
+  },
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // ▶ ADD IMAGE
+  // ═══════════════════════════════════════════════════════════════════════════
+  _addUserImage() {
+    const node   = this._currentNode;
+    const hasAI     = AIService.hasApiKey();
+    const hasVision = AIService.supportsVision();
+
+    Modal.open(`
+      <div style="font-family:var(--font-ui);">
+        <h2 style="font-size:18px;font-weight:800;margin-bottom:6px;">Add Image</h2>
+        <p style="font-family:var(--font-body);font-size:13px;color:var(--text-muted);margin-bottom:20px;">
+          What do you want to do with this image?
+        </p>
+
+        <div style="display:flex;flex-direction:column;gap:10px;">
+
+          <button id="img-opt-extract" style="display:flex;align-items:center;gap:14px;padding:16px;
+            background:${hasVision ? 'var(--accent-soft)' : 'var(--bg-raised)'};
+            border:1px solid ${hasVision ? 'var(--accent-dim)' : 'var(--border)'};
+            border-radius:14px;cursor:pointer;text-align:left;width:100%;
+            opacity:${hasVision ? '1' : '0.5'};">
+            <span style="font-size:26px;flex-shrink:0;">⬡</span>
+            <div>
+              <div style="font-size:14px;font-weight:700;color:var(--text-primary);margin-bottom:3px;">
+                Extract &amp; add to notes
+              </div>
+              <div style="font-family:var(--font-body);font-size:12px;color:var(--text-muted);">
+                AI reads the image and adds the content to this node — definitions, tables, formulas, questions.
+                ${!hasVision ? '<br><em>Requires a vision-capable AI provider (OpenRouter or Claude).</em>' : ''}
+              </div>
+            </div>
+          </button>
+
+          <button id="img-opt-question" style="display:flex;align-items:center;gap:14px;padding:16px;
+            background:var(--bg-raised);
+            border:1px solid var(--border);
+            border-radius:14px;cursor:pointer;text-align:left;width:100%;
+            opacity:${hasVision ? '1' : '0.5'};">
+            <span style="font-size:26px;flex-shrink:0;">❓</span>
+            <div>
+              <div style="font-size:14px;font-weight:700;color:var(--text-primary);margin-bottom:3px;">
+                Generate questions from image
+              </div>
+              <div style="font-family:var(--font-body);font-size:12px;color:var(--text-muted);">
+                AI reads the image and adds practice questions to this node's question bank.
+                ${!hasVision ? '<br><em>Requires a vision-capable AI provider (OpenRouter or Claude).</em>' : ''}
+              </div>
+            </div>
+          </button>
+
+          <button id="img-opt-reference" style="display:flex;align-items:center;gap:14px;padding:16px;
+            background:var(--bg-raised);border:1px solid var(--border);
+            border-radius:14px;cursor:pointer;text-align:left;width:100%;">
+            <span style="font-size:26px;flex-shrink:0;">🖼️</span>
+            <div>
+              <div style="font-size:14px;font-weight:700;color:var(--text-primary);margin-bottom:3px;">
+                Add as visual reference only
+              </div>
+              <div style="font-family:var(--font-body);font-size:12px;color:var(--text-muted);">
+                Attach the image to these notes as a diagram, chart, or reference photo.
+              </div>
+            </div>
+          </button>
+
+        </div>
+      </div>
+    `);
+
+    const pickFile = () => new Promise(resolve => {
+      const inp = document.createElement('input');
+      inp.type = 'file'; inp.accept = 'image/*'; inp.multiple = false;
+      inp.addEventListener('change', async () => {
+        if (!inp.files[0]) return resolve(null);
+        const file = inp.files[0];
+        const b64  = await new Promise((res, rej) => {
+          const r = new FileReader();
+          r.onload = () => res(r.result.split(',')[1]);
+          r.onerror = rej;
+          r.readAsDataURL(file);
+        });
+        resolve(b64);
+      });
+      inp.click();
+    });
+
+    // ── Option 1: extract & merge into node ──────────────────
+    document.getElementById('img-opt-extract')?.addEventListener('click', async () => {
+      if (!hasVision) {
+        Toast.error('Your current AI provider does not support image reading. Switch to OpenRouter or Claude in Settings.');
+        return;
+      }
+      Modal.close();
+      const b64 = await pickFile();
+      if (!b64) return;
+
+      Toast.info('⬡ Reading image and extracting content…');
+      try {
+        // Reuse processContent — treats image as additional source material
+        const meta = { subject: node.subject, chapter: node.chapter, detail: 'standard', profile: node.learnerProfile };
+        const extracted = await AIService.processContent([b64], '', meta, () => {});
+
+        // Merge definitions
+        if (extracted.definitions?.length) {
+          node.definitions = node.definitions || [];
+          extracted.definitions.forEach(d => {
+            if (!node.definitions.find(e => e.term === d.term)) node.definitions.push(d);
+          });
+        }
+        // Merge tables
+        if (extracted.tables?.length) {
+          node.tables = node.tables || [];
+          extracted.tables.forEach(t => node.tables.push(t));
+        }
+        // Merge formulas
+        if (extracted.formulas?.length) {
+          node.formulas = node.formulas || [];
+          extracted.formulas.forEach(f => {
+            if (!node.formulas.find(e => e.expression === f.expression)) node.formulas.push(f);
+          });
+        }
+        // Merge procedures
+        if (extracted.procedures?.length) {
+          node.procedures = node.procedures || [];
+          extracted.procedures.forEach(p => node.procedures.push(p));
+        }
+        // Merge questions
+        if (extracted.questions?.length) {
+          node.questions = node.questions || [];
+          extracted.questions.forEach(q => node.questions.push({ ...q, id: KnowledgeNode._generateQuestionId() }));
+        }
+        // Also merge into blocks if node uses them
+        if (node.blocks?.length && extracted.definitions?.length) {
+          const newDefs = extracted.definitions.filter(d =>
+            !node.blocks.some(b => b.type === 'definition' &&
+              b.items?.some(i => i.term === d.term))
+          );
+          if (newDefs.length) {
+            node.blocks.push({
+              id: KnowledgeNode._generateBlockId(),
+              type: 'definition',
+              title: 'From image',
+              items: newDefs,
+            });
+          }
+        }
+        // Store the image as a visual reference too
+        node.userImages = node.userImages || [];
+        node.userImages.push({ id: KnowledgeNode._generateImageId(), base64: b64, caption: extracted.title || 'Image', width: 60 });
+
+        node.invalidateContentCaches();
+        nodeStore.save(node);
+        this._renderSection();
+        const count = (extracted.definitions?.length||0) + (extracted.formulas?.length||0)
+                    + (extracted.procedures?.length||0) + (extracted.questions?.length||0);
+        Toast.success('Extracted ' + count + ' items from image and added to notes ✓');
+      } catch(e) {
+        Toast.error('Extraction failed: ' + (e.message || 'Try again'));
+      }
+    });
+
+    // ── Option 2: generate questions only ────────────────────
+    document.getElementById('img-opt-question')?.addEventListener('click', async () => {
+      if (!hasAI) { Toast.info('Configure AI in Settings first.'); return; }
+      if (!AIService.supportsVision()) {
+        Toast.error('Your current AI provider does not support image reading. Switch to OpenRouter or Claude in Settings.');
+        return;
+      }
+      Modal.close();
+      const b64 = await pickFile();
+      if (!b64) return;
+
+      Toast.info('⬡ Generating questions from image…');
+      try {
+        const prompt = LearnerContext.forQuestionGen(node)
+          + '\n\nAdditional image provided. Read the image and generate 3-5 practice questions '
+          + 'based on what is shown in it. Questions must be answerable from the image content. '
+          + 'Output ONLY JSON: {"recall":[{"question":"","answer":""}],"application":[{"question":"","answer":""}]}';
+
+        const msgs = [{
+          role: 'user',
+          content: [
+            { type: 'image_url', image_url: { url: 'data:image/jpeg;base64,' + b64 } },
+            { type: 'text', text: prompt },
+          ],
+        }];
+        const raw  = await AIService._callWithFunction('questionGen', msgs, 1200);
+        const data = AIService._parseJSON(raw);
+
+        const newQs = [
+          ...(data.recall||[]).map(q => ({ id: KnowledgeNode._generateQuestionId(), type: 'recall',      question: q.question, answer: q.answer })),
+          ...(data.application||[]).map(q => ({ id: KnowledgeNode._generateQuestionId(), type: 'application', question: q.question, answer: q.answer })),
+        ];
+
+        node.questions = node.questions || [];
+        node.questions.push(...newQs);
+
+        // Store image as reference
+        node.userImages = node.userImages || [];
+        node.userImages.push({ id: KnowledgeNode._generateImageId(), base64: b64, caption: 'Question source', width: 60 });
+
+        nodeStore.save(node);
+        this._renderSection();
+        Toast.success(newQs.length + ' questions generated from image ✓');
+      } catch(e) {
+        Toast.error('Question generation failed: ' + (e.message || 'Try again'));
+      }
+    });
+
+    // ── Option 3: visual reference only (original behaviour) ─
+    document.getElementById('img-opt-reference')?.addEventListener('click', async () => {
+      Modal.close();
+      const inp = document.createElement('input');
+      inp.type = 'file'; inp.accept = 'image/*'; inp.multiple = true;
+      inp.addEventListener('change', async () => {
+        for (const file of Array.from(inp.files)) {
+          const b64 = await new Promise((res, rej) => {
+            const r = new FileReader();
+            r.onload = () => res(r.result.split(',')[1]);
+            r.onerror = rej;
+            r.readAsDataURL(file);
+          });
+          node.userImages = node.userImages || [];
+          node.userImages.push({ id: KnowledgeNode._generateImageId(), base64: b64, caption: '', width: 50 });
+        }
+        nodeStore.save(node);
+        this._renderSection();
+        Toast.success('Image added to notes.');
+      });
+      inp.click();
+    });
+  },
+
+  /* ─── AI FLOATER — Redesigned ─────────────────────── */
+  // ═══════════════════════════════════════════════════════════════════════════
+  // ▶ AI FLOATER
+  // ═══════════════════════════════════════════════════════════════════════════
+  _showAIFloater() {
+    // Remove any existing floaters (guards against double-render)
+    document.querySelectorAll('#ai-floater, .ai-floater').forEach(el => el.remove());
+    const floater = document.createElement('div');
+    floater.id = 'ai-floater';
+    floater.innerHTML =
+      // Toggle button
+      '<button id="ai-floater-btn" title="AI Study Assistant" aria-label="Open AI Assistant">'
+      + '<span id="ai-floater-icon">⬡</span>'
+      + '</button>'
+
+      // Panel
+      + '<div id="ai-floater-panel" class="hidden">'
+
+      // Header
+      + '<div class="aif-header">'
+      + '<span class="aif-title">⬡ Ask AI</span>'
+      + '<button id="ai-floater-close" class="aif-close-btn" aria-label="Close">✕</button>'
+      + '</div>'
+
+      // Simplified 2-column grid — only the most useful actions
+      + '<div id="aif-home">'
+      + '<div class="aif-card-grid" style="grid-template-columns:repeat(2,1fr);gap:8px;padding:4px 0;">'
+      + '<button class="aif-card" id="aif-explain"><span class="aif-card-icon">💡</span><span class="aif-card-text">Explain<br><small>Why it matters</small></span></button>'
+      + '<button class="aif-card" id="aif-simplify"><span class="aif-card-icon">🔤</span><span class="aif-card-text">Simplify<br><small>Plain language</small></span></button>'
+      + '<button class="aif-card" id="aif-quiz"><span class="aif-card-icon">❓</span><span class="aif-card-text">Quick Quiz<br><small>Test yourself</small></span></button>'
+      + '<button class="aif-card" id="aif-gaps"><span class="aif-card-icon">🔍</span><span class="aif-card-text">My Gaps<br><small>What to focus on</small></span></button>'
+      + '<button class="aif-card" id="aif-adapt-to"><span class="aif-card-icon">📐</span><span class="aif-card-text">Adapt Format<br><small>Change style</small></span></button>'
+      + '<button class="aif-card" id="aif-gen-image"><span class="aif-card-icon">📷</span><span class="aif-card-text">From Image<br><small>Scan & add</small></span></button>'
+      + '</div>'
+
+      // Ask anything
+      + '<div class="aif-section-label">Ask Anything</div>'
+      + '<div class="aif-ask-row">'
+      + '<input type="text" id="aif-custom-input" class="aif-custom-input" placeholder="Ask a question about this topic…"/>'
+      + '<button id="aif-custom-send" class="aif-send-btn" aria-label="Send">→</button>'
+      + '</div>'
+
+      + '</div>' // end #aif-home
+
+      // RESULT SCREEN
+      + '<div id="aif-result-screen" class="hidden">'
+      + '<div class="aif-result-label" id="aif-result-label">Response</div>'
+      + '<div id="ai-floater-text" class="ai-floater-text"></div>'
+      + '<button class="aif-back-btn" id="aif-back">← Back</button>'
+      + '</div>'
+
+      + '</div>'; // end panel
+
+    document.body.appendChild(floater);
+
+    const btn    = document.getElementById('ai-floater-btn');
+    const panel  = document.getElementById('ai-floater-panel');
+    const home   = document.getElementById('aif-home');
+    const result = document.getElementById('aif-result-screen');
+    const textEl = document.getElementById('ai-floater-text');
+
+    // Toggle panel
+    btn.addEventListener('click', () => {
+      const hidden = panel.classList.toggle('hidden');
+      btn.classList.toggle('active', !hidden);
+    });
+    document.getElementById('ai-floater-close').addEventListener('click', () => {
+      panel.classList.add('hidden'); btn.classList.remove('active');
+    });
+
+    // Show result screen with label
+    const showResult = async (promptText, label) => {
+      home.classList.add('hidden');
+      result.classList.remove('hidden');
+      document.getElementById('aif-result-label').textContent = label || 'Response';
+      textEl.textContent = '';
+
+      // Spinner
+      textEl.innerHTML = '<div class="aif-loading"><div class="aif-dot"></div><div class="aif-dot"></div><div class="aif-dot"></div></div>';
+
+      try {
+        const node = this._currentNode;
+        // Route through the central brain — same context every other AI feature uses.
+        // This gives the floater hard rules, full source, the learner's weak areas,
+        // history, and any corrections the user has recorded for this node.
+        const ctx = LearnerContext.forNode(node);
+
+        const response = AIService.hasApiKey()
+          ? await AIService._callWithFunction('chat', [{role:'user', content: ctx + '\n\n' + promptText}], 800)
+          : this._mockAI(promptText, node);
+
+        // Render as formatted paragraphs (split on newlines)
+        textEl.innerHTML = response
+          .split('\n')
+          .filter(l => l.trim())
+          .map(l => '<p style="margin:0 0 10px;font-family:var(--font-body);font-size:14px;line-height:1.7;color:var(--text-primary);">' + this._esc(l) + '</p>')
+          .join('');
+
+      } catch(e) {
+        textEl.innerHTML = '<p style="font-family:var(--font-mono);font-size:13px;color:var(--red);">'
+          + this._esc(e.message || 'Something went wrong. Check your AI settings.') + '</p>'
+          + '<p style="font-family:var(--font-body);font-size:13px;color:var(--text-muted);margin-top:8px;">Go to More → Settings → Configure AI to set up your key.</p>';
+      }
+    };
+
+    // Wire action cards
+    document.getElementById('aif-explain')    ?.addEventListener('click', () => showResult(
+      'Explain this topic clearly. Cover: (1) what it is, (2) why it matters, (3) how it connects to real-world accounting/tax scenarios. Be thorough — 3-4 paragraphs.',
+      '💡 Explanation'));
+    document.getElementById('aif-simplify')   ?.addEventListener('click', () => showResult(
+      'Explain this topic as if talking to a 16-year-old with no accounting background. Use a simple real-world analogy. Avoid all jargon. Keep it conversational.',
+      '🔤 Simple Version'));
+    document.getElementById('aif-example')    ?.addEventListener('click', () => showResult(
+      'Give one detailed worked example applying this topic. Include: (1) a realistic scenario with specific numbers, (2) step-by-step working, (3) the final answer and interpretation. Format clearly.',
+      '🧩 Worked Example'));
+    document.getElementById('aif-quiz')       ?.addEventListener('click', () => showResult(
+      'Create 3 questions to test my understanding: 1 definition/recall, 1 application, 1 "what if" scenario question. Number them clearly. Include the answer below each question (labelled "Answer:").',
+      '❓ Quick Quiz'));
+    document.getElementById('aif-gaps')       ?.addEventListener('click', () => showResult(
+      'Identify the 3 most common gaps or mistakes students make on this topic. For each gap: (1) describe it clearly, (2) explain why it happens, (3) give the correct understanding. Be specific to this subject.',
+      '🔍 Common Gaps'));
+    document.getElementById('aif-exam-q')     ?.addEventListener('click', () => { panel.classList.add('hidden'); btn.classList.remove('active'); AINodeTools.generateExamQuestion(this._currentNode); });
+    document.getElementById('aif-gen-image')  ?.addEventListener('click', () => { panel.classList.add('hidden'); btn.classList.remove('active'); AINodeTools.generateFromImage(this._currentNode, 'auto'); });
+    document.getElementById('aif-restructure') ?.addEventListener('click', () => { panel.classList.add('hidden'); btn.classList.remove('active'); AINodeTools.restructureNotes(this._currentNode); });
+    document.getElementById('aif-adapt-to')    ?.addEventListener('click', () => { panel.classList.add('hidden'); btn.classList.remove('active'); this._openTemplatePanel(); });
+
+    // Ask anything — inline input, no native prompt()
+    const sendCustom = () => {
+      const q = document.getElementById('aif-custom-input')?.value?.trim();
+      if (!q) return;
+      document.getElementById('aif-custom-input').value = '';
+      showResult(q, '✏ ' + q.slice(0, 30) + (q.length > 30 ? '…' : ''));
+    };
+    document.getElementById('aif-custom-send')?.addEventListener('click', sendCustom);
+    document.getElementById('aif-custom-input')?.addEventListener('keydown', e => {
+      if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); sendCustom(); }
+    });
+
+    // Back button
+    document.getElementById('aif-back')?.addEventListener('click', () => {
+      result.classList.add('hidden');
+      home.classList.remove('hidden');
+      textEl.innerHTML = '';
+    });
+  },
+
+  _mockAI(prompt, node) {
+    if (prompt.includes('example'))  return 'Example: Given a scenario involving ' + node.title + ':\n1. Identify the relevant values\n2. Apply the rule\n3. Check exceptions\n4. Interpret the result\n\n(Configure AI in Settings for personalised examples.)';
+    if (prompt.includes('quiz'))     return 'Q1: Define ' + node.title + ' in your own words.\nQ2: When would you apply this concept?\nQ3: What is the most common mistake here?\n\n(Configure AI for personalised questions.)';
+    if (prompt.includes('gaps'))     return 'Common gap areas: 1. Confusing when to apply vs not apply\n2. Missing exceptions\n3. Formula variable meanings\n\n(Configure AI for personalised gap analysis.)';
+    return node.title + ' is a core concept in ' + node.subject + '. ' + (node.summary || 'Study the definitions and procedures carefully.') + '\n\n(Configure AI in Settings for personalised explanations.)';
+  },
+
+  /* ─── QUESTIONS ───────────────────────────────────── */
+  // ═══════════════════════════════════════════════════════════════════════════
+  // ▶ QUESTIONS TAB
+  // ═══════════════════════════════════════════════════════════════════════════
+  _renderQuestions(node) {
+    const hasAI = AIService.hasApiKey();
+    this._body.innerHTML =
+      '<div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:20px;flex-wrap:wrap;gap:12px;">'
+      + '<h2 style="font-family:var(--font-ui);font-size:21px;font-weight:800;letter-spacing:-0.02em;">Questions</h2>'
+      + '<div style="display:flex;gap:8px;flex-wrap:wrap;">'
+      + (hasAI ? '<button class="btn-secondary" id="regen-q-btn" style="font-size:12px;">⟳ Regenerate</button>' : '')
+      + '<button class="btn-secondary" id="add-q-btn" style="font-size:12px;">+ Add Question</button>'
+      + '</div>'
+      + '</div>'
+      + '<p style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);margin-bottom:18px;">💡 Select text in Notes to create a question instantly. Edit or delete any question using the buttons below.</p>'
+      + '<div id="questions-list">' + this._renderQList(node) + '</div>'
+      + '<div id="add-q-form" style="display:none;margin-top:18px;background:var(--bg-raised);border:1px solid var(--border);border-radius:var(--radius-lg);padding:22px;">'
+      + '<div class="notes-section-title" style="margin-bottom:14px;">New Question</div>'
+      + '<div class="config-row" style="margin-bottom:12px;"><label class="config-label">Type</label><select id="new-q-type" class="config-select"><option value="recall">🔁 Recall</option><option value="application">🧩 Application</option></select></div>'
+      + '<div class="config-row" style="margin-bottom:12px;"><label class="config-label">Question</label><textarea id="new-q-question" class="config-input" rows="2" style="resize:vertical;touch-action:pan-y;"></textarea></div>'
+      + '<div class="config-row" style="margin-bottom:16px;"><label class="config-label">Answer</label><textarea id="new-q-answer" class="config-input" rows="3" style="resize:vertical;touch-action:pan-y;"></textarea></div>'
+      + '<div style="display:flex;gap:8px;"><button class="btn-primary" id="save-q-btn">Add Question</button><button class="btn-secondary" id="cancel-q-btn">Cancel</button></div>'
+      + '</div>';
+
+    document.getElementById('regen-q-btn')?.addEventListener('click', async () => {
+      const btn = document.getElementById('regen-q-btn');
+      if (btn) { btn.textContent = '⟳ Regenerating…'; btn.disabled = true; }
+      try {
+        const meta = { subject: node.subject, chapter: node.chapter, detail: 'standard', profile: node.learnerProfile };
+        const src  = LearnerContext._buildSourceText(node, 8000);
+        const notes = {
+          title:       node.title,
+          definitions: node.definitions || [],
+          formulas:    node.formulas    || [],
+          procedures:  node.procedures  || [],
+          tables:      node.tables      || [],
+          summary:     node.summary     || src.slice(0, 500),
+        };
+        const qData = await AIService._generateQuestions(notes, meta);
+        const newQs = [
+          ...(qData.recall      || []).map(q => ({ id: KnowledgeNode._generateQuestionId(), type: 'recall',      question: q.question, answer: q.answer })),
+          ...(qData.application || []).map(q => ({ id: KnowledgeNode._generateQuestionId(), type: 'application', question: q.question, answer: q.answer })),
+        ];
+        if (newQs.length) {
+          node.questions = newQs;
+          node.ucQuestionCache = null; // content emphasis changed — regenerate UC questions next time
+          nodeStore.save(node);
+          document.getElementById('questions-list').innerHTML = this._renderQList(node);
+          Toast.success(newQs.length + ' questions regenerated from source ✓');
+        } else {
+          Toast.error('No questions returned. Try again.');
+        }
+      } catch(e) {
+        Toast.error('Regeneration failed: ' + (e.message || 'Try again'));
+      } finally {
+        if (btn) { btn.textContent = '⟳ Regenerate'; btn.disabled = false; }
+      }
+    });
+    document.getElementById('add-q-btn').addEventListener('click',    () => { document.getElementById('add-q-form').style.display='block'; document.getElementById('new-q-question').focus(); });
+    document.getElementById('save-q-btn').addEventListener('click',   () => this._saveNewQuestion());
+    document.getElementById('cancel-q-btn').addEventListener('click', () => { document.getElementById('add-q-form').style.display='none'; });
+    document.getElementById('questions-list').addEventListener('click', e => {
+      // Delete
+      const del = e.target.closest('[data-delete-q]');
+      if (del && !del.dataset.editQ) { this._deleteQuestion(del.dataset.deleteQ); return; }
+
+      // Toggle answer
+      const tog = e.target.closest('.question-answer-toggle');
+      if (tog) {
+        const qid = tog.dataset.qid;
+        const ans = document.getElementById('qa-' + qid);
+        if (ans) {
+          const hidden = ans.classList.toggle('hidden');
+          tog.textContent = hidden ? 'Show Answer' : 'Hide Answer';
+        }
+        return;
+      }
+
+      // Open edit form
+      const edit = e.target.closest('[data-edit-q]');
+      if (edit) {
+        const qid = edit.dataset.editQ;
+        const form = document.getElementById('qef-' + qid);
+        // Close any other open forms first
+        document.querySelectorAll('.question-edit-form').forEach(f => {
+          if (f.id !== 'qef-' + qid) f.classList.add('hidden');
+        });
+        form?.classList.toggle('hidden');
+        if (!form?.classList.contains('hidden')) form.querySelector('.qef-question')?.focus();
+        return;
+      }
+
+      // Save edit
+      const save = e.target.closest('.qef-save-btn');
+      if (save) {
+        const qid = save.dataset.qid;
+        const q   = this._currentNode.questions.find(q => q.id === qid);
+        if (!q) return;
+        const qText  = document.querySelector('.qef-question[data-qid="' + qid + '"]')?.value.trim();
+        const aText  = document.querySelector('.qef-answer[data-qid="' + qid + '"]')?.value.trim();
+        const qType  = document.querySelector('.qef-type[data-qid="' + qid + '"]')?.value;
+        if (!qText || !aText) { Toast.error('Question and answer cannot be empty.'); return; }
+        q.question = qText; q.answer = aText; q.type = qType;
+        nodeStore.save(this._currentNode);
+        Toast.success('Question updated!');
+        document.getElementById('questions-list').innerHTML = this._renderQList(this._currentNode);
+        return;
+      }
+
+      // Cancel edit
+      const cancel = e.target.closest('.qef-cancel-btn');
+      if (cancel) {
+        const qid = cancel.dataset.qid;
+        document.getElementById('qef-' + qid)?.classList.add('hidden');
+        return;
+      }
+    });
+  },
+
+  _renderQList(node) {
+    if (!node.questions?.length) {
+      return '<p style="color:var(--text-muted);font-family:var(--font-mono);font-size:13px;">No questions yet. Use + Add Question or select text in Notes.</p>';
+    }
+    return node.questions.map(q => {
+      const typeLabel = q.type === 'recall' ? '🔁 Recall' : '🧩 Application';
+      const qe = this._esc;
+      return ''
+        + '<div class="question-card" data-qid="' + q.id + '">'
+
+        // Header row: type pill + edit/delete buttons
+        + '<div class="question-card-header">'
+        + '<span class="question-label">' + typeLabel + '</span>'
+        + '<div class="question-card-actions">'
+        + '<button class="qc-action-btn" data-edit-q="' + q.id + '">✏ Edit</button>'
+        + '<button class="qc-action-btn danger" data-delete-q="' + q.id + '">✕</button>'
+        + '</div>'
+        + '</div>'
+
+        // Question body
+        + '<div class="question-text">' + (window.KNText ? KNText.html(q.question) : this._esc(q.question)) + '</div>'
+
+        // Answer toggle + answer box
+        + '<button class="question-answer-toggle" data-qid="' + q.id + '">Show Answer</button>'
+        + '<div class="question-answer hidden" id="qa-' + q.id + '">' + (window.KNText ? KNText.html(q.answer) : this._esc(q.answer)) + '</div>'
+
+        // Inline edit form — starts hidden
+        + '<div class="question-edit-form hidden" id="qef-' + q.id + '">'
+        + '<div style="margin-bottom:10px;">'
+        + '<label class="config-label">Type</label>'
+        + '<select class="config-select qef-type" data-qid="' + q.id + '">'
+        + '<option value="recall"'      + (q.type === 'recall'      ? ' selected' : '') + '>🔁 Recall</option>'
+        + '<option value="application"' + (q.type === 'application' ? ' selected' : '') + '>🧩 Application</option>'
+        + '</select>'
+        + '</div>'
+        + '<div style="margin-bottom:10px;">'
+        + '<label class="config-label">Question</label>'
+        + '<textarea class="config-input qef-question" data-qid="' + q.id + '" rows="3" style="resize:vertical;touch-action:pan-y;font-size:14px;line-height:1.6;">' + this._esc(q.question) + '</textarea>'
+        + '</div>'
+        + '<div style="margin-bottom:14px;">'
+        + '<label class="config-label">Answer</label>'
+        + '<textarea class="config-input qef-answer" data-qid="' + q.id + '" rows="3" style="resize:vertical;touch-action:pan-y;font-size:14px;line-height:1.6;">' + this._esc(q.answer) + '</textarea>'
+        + '</div>'
+        + '<div style="display:flex;gap:8px;">'
+        + '<button class="btn-primary qef-save-btn" data-qid="' + q.id + '" style="font-size:12px;padding:8px 18px;">✓ Save</button>'
+        + '<button class="btn-secondary qef-cancel-btn" data-qid="' + q.id + '" style="font-size:12px;padding:8px 14px;">Cancel</button>'
+        + '</div>'
+        + '</div>'
+
+        + '</div>';
+    }).join('');
+  },
+
+  _saveNewQuestion() {
+    const type=document.getElementById('new-q-type').value;
+    const q=document.getElementById('new-q-question').value.trim();
+    const a=document.getElementById('new-q-answer').value.trim();
+    if(!q||!a){Toast.error('Fill in both fields.');return;}
+    this._currentNode.questions.push({id:KnowledgeNode._generateQuestionId(),type,question:q,answer:a});
+    nodeStore.save(this._currentNode);
+    Toast.success('Question added!');
+    this._renderQuestions(this._currentNode);
+  },
+
+  _deleteQuestion(qId) {
+    this._currentNode.questions=this._currentNode.questions.filter(q=>q.id!==qId);
+    delete this._currentNode.srsState[qId];
+    nodeStore.save(this._currentNode);
+    document.getElementById('questions-list').innerHTML=this._renderQList(this._currentNode);
+    Toast.success('Question removed.');
+  },
+
+  /* ─── EXAMPLES TAB ──────────────────────────────────── */
+  // ═══════════════════════════════════════════════════════════════════════════
+  // ▶ EXAMPLES TAB
+  // ═══════════════════════════════════════════════════════════════════════════
+  _renderExamples(node) {
+    const examples = node.workedExamples || [];
+    const hasAI = AIService.hasApiKey();
+    let html = '<div>';
+    html += '<h2 style="font-family:var(--font-ui);font-size:21px;font-weight:800;margin-bottom:6px;letter-spacing:-0.02em;">💡 Worked Examples</h2>';
+    html += '<p style="font-family:var(--font-body);font-size:14px;color:var(--text-secondary);margin-bottom:18px;">Upload worked examples with full solutions. The AI tutors you through them step by step.</p>';
+    html += '<div style="display:flex;gap:8px;margin-bottom:20px;">';
+    html += '<button class="btn-primary" id="ex-add-text-btn" style="font-size:13px;">+ Type Example</button>';
+    html += '<button class="btn-secondary" id="ex-add-image-btn" style="font-size:13px;">📷 Scan Example</button>';
+    html += '</div>';
+    if (examples.length === 0) {
+      html += '<div style="padding:32px;text-align:center;border:1px dashed var(--border);border-radius:var(--radius-lg);">';
+      html += '<div style="font-size:32px;margin-bottom:12px;">📖</div>';
+      html += '<div style="font-family:var(--font-ui);font-size:15px;font-weight:700;color:var(--text-primary);margin-bottom:8px;">No examples yet</div>';
+      html += '<div style="font-family:var(--font-mono);font-size:12px;color:var(--text-muted);">Add a worked example and the AI will teach you how to solve similar problems.</div>';
+      html += '</div>';
+    } else {
+      examples.forEach((ex, i) => {
+        // ── Example card — clean layout ────────────────────────
+        html += '<div class="ex-card" style="background:var(--bg-raised);border:1px solid var(--border);border-radius:16px;margin-bottom:16px;overflow:hidden;">';
+
+        // Header bar — two rows: [chevron · badge · pages · delete] then [full-width title]
+        html += '<div class="ex-collapse-hdr" data-ex-id="' + ex.id + '" style="padding:10px 14px 10px;background:var(--bg-elevated,var(--bg-base));border-bottom:1px solid var(--border-soft);cursor:pointer;">';
+        // Row 1: meta row
+        html += '<div style="display:flex;align-items:center;gap:8px;margin-bottom:6px;">';
+        html += '<span class="ex-chevron" data-ex-id="' + ex.id + '" style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);transition:transform .2s;display:inline-block;flex-shrink:0;">▶</span>';
+        html += '<span style="font-family:var(--font-mono);font-size:10px;font-weight:800;color:var(--accent);background:var(--accent-soft);border:1px solid var(--accent-dim);padding:2px 10px;border-radius:20px;flex-shrink:0;">Example ' + (i+1) + '</span>';
+        if (ex.pageCount > 1) html += '<span style="font-family:var(--font-mono);font-size:9px;color:var(--text-muted);flex-shrink:0;">' + ex.pageCount + ' pages</span>';
+        html += '<span style="flex:1;"></span>'; // spacer
+        html += '<button class="ex-rename-btn" data-ex-id="' + ex.id + '" title="Rename" style="background:transparent;border:none;color:var(--text-muted);cursor:pointer;font-size:13px;padding:2px 6px;line-height:1;flex-shrink:0;">✏️</button>';
+        html += '<button class="ex-delete-btn" data-ex-id="' + ex.id + '" style="background:transparent;border:none;color:var(--text-muted);cursor:pointer;font-size:15px;padding:2px 4px;line-height:1;flex-shrink:0;">✕</button>';
+        html += '</div>';
+        // Row 2: title — full width, wraps freely (tapping collapses, not renames)
+        html += '<span class="ex-title-display" data-ex-id="' + ex.id + '" style="font-family:var(--font-ui);font-size:15px;font-weight:800;color:var(--text-primary);line-height:1.35;display:block;word-break:break-word;">' + this._esc(ex.title || 'Worked Example') + '</span>';
+        html += '<input class="ex-title-input config-input" data-ex-id="' + ex.id + '" value="' + this._esc(ex.title || 'Worked Example') + '" style="display:none;width:100%;font-family:var(--font-ui);font-size:15px;font-weight:800;padding:4px 8px;box-sizing:border-box;" />';
+        html += '</div>';
+
+        // Collapsible body — COLLAPSED by default
+        html += '<div class="ex-body" data-ex-id="' + ex.id + '" style="display:none;">';
+        html += '<div style="padding:14px 16px 0;">';
+
+        // Question block
+        html += '<div style="background:var(--bg-base);border:1px solid var(--border-soft);border-radius:10px;padding:14px;margin-bottom:12px;">';
+        html += '<div style="font-family:var(--font-mono);font-size:9px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--text-muted);margin-bottom:8px;">Question</div>';
+        html += '<div style="font-family:var(--font-body);font-size:14px;color:var(--text-primary);line-height:1.7;">' + this._esc(ex.question) + '</div>';
+        html += '</div>';
+
+        // Solution (collapsible)
+        if (ex.solution) {
+          html += '<details style="margin-bottom:4px;">';
+          html += '<summary style="display:flex;align-items:center;gap:8px;padding:10px 0;cursor:pointer;list-style:none;">';
+          html += '<span style="font-family:var(--font-mono);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--accent);">▶▶ Show Solution</span>';
+          html += '</summary>';
+
+          // Steps if available
+          if (ex.steps && ex.steps.length) {
+            html += '<div style="margin-top:4px;">';
+            ex.steps.forEach((step, si) => {
+              html += '<div style="display:flex;gap:12px;align-items:flex-start;padding:10px 0;border-bottom:1px solid var(--border-soft);">';
+              html += '<div style="display:flex;flex-direction:column;align-items:center;flex-shrink:0;">';
+              html += '<span style="width:24px;height:24px;border-radius:50%;background:var(--accent-soft);border:1px solid var(--accent-dim);display:flex;align-items:center;justify-content:center;font-family:var(--font-mono);font-size:11px;font-weight:700;color:var(--accent);">' + (si+1) + '</span>';
+              if (si < ex.steps.length - 1) html += '<div style="width:1px;flex:1;background:var(--border-soft);min-height:8px;margin-top:3px;"></div>';
+              html += '</div>';
+              html += '<div style="padding-top:3px;">';
+              html += '<span style="font-family:var(--font-body);font-size:13.5px;color:var(--text-primary);line-height:1.65;">' + this._esc(step) + '</span>';
+              html += '</div></div>';
+            });
+            html += '</div>';
+          } else {
+            html += '<div style="font-family:var(--font-body);font-size:13.5px;color:var(--text-secondary);line-height:1.7;padding:10px 0;white-space:pre-wrap;">' + this._esc(ex.solution) + '</div>';
+          }
+
+          // Structured tables (ledger accounts, journals) — rendered as the textbook shows
+          if (ex.tables && ex.tables.length) {
+            ex.tables.forEach(tbl => {
+              html += '<div style="margin:14px 0;overflow-x:auto;">';
+              if (tbl.caption) html += '<div style="font-family:var(--font-ui);font-size:13px;font-weight:700;color:var(--text-primary);margin-bottom:6px;">' + this._esc(tbl.caption) + '</div>';
+              html += '<table style="width:100%;border-collapse:collapse;font-family:var(--font-mono);font-size:12px;">';
+              if (tbl.columns && tbl.columns.length) {
+                html += '<thead><tr>';
+                tbl.columns.forEach(c => { html += '<th style="border:1px solid var(--border);padding:6px 8px;text-align:left;background:var(--bg-raised);color:var(--text-primary);font-weight:700;white-space:nowrap;">' + this._esc(c) + '</th>'; });
+                html += '</tr></thead>';
+              }
+              html += '<tbody>';
+              (tbl.rows || []).forEach(row => {
+                html += '<tr>';
+                (row || []).forEach(cell => { html += '<td style="border:1px solid var(--border-soft);padding:6px 8px;color:var(--text-secondary);white-space:nowrap;">' + this._esc(cell) + '</td>'; });
+                html += '</tr>';
+              });
+              html += '</tbody></table></div>';
+            });
+          }
+          html += '</details>';
+        }
+
+        html += '</div>'; // end padding div
+
+        // Tutor button — full width at bottom
+        if (hasAI) {
+          html += '<div style="padding:12px 16px 14px;border-top:1px solid var(--border-soft);margin-top:8px;">';
+          html += '<button class="btn-primary ex-tutor-btn" data-ex-id="' + ex.id + '" style="width:100%;justify-content:center;font-size:14px;padding:12px;">⬡ Tutor me through this</button>';
+          html += '</div>';
+        }
+
+        html += '</div>'; // end ex-body
+        html += '</div>'; // end ex-card
+      });
+    }
+    // Session history
+    const tutorLog = (node.sessionLog||[]).filter(s => s.type === 'tutor').slice(-5).reverse();
+    if (tutorLog.length) {
+      html += '<div style="margin-top:24px;">';
+      html += '<div style="font-family:var(--font-mono);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--text-muted);margin-bottom:12px;">📊 Recent Tutor Sessions</div>';
+      tutorLog.forEach(s => {
+        html += '<div style="display:flex;gap:12px;align-items:flex-start;padding:10px 0;border-bottom:1px solid var(--border-soft);">';
+        html += '<span style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);flex-shrink:0;padding-top:1px;">' + this._esc(s.date) + '</span>';
+        html += '<div>';
+        html += '<div style="font-family:var(--font-mono);font-size:10px;color:var(--accent);margin-bottom:2px;">' + this._esc(s.example||'') + '</div>';
+        html += '<div style="font-family:var(--font-body);font-size:13px;color:var(--text-secondary);line-height:1.5;">' + this._esc(s.summary) + '</div>';
+        html += '</div></div>';
+      });
+      html += '</div>';
+    }
+
+    html += '</div>';
+    this._body.innerHTML = html;
+    document.getElementById('ex-add-text-btn')?.addEventListener('click', () => this._openAddExampleModal(node));
+    document.getElementById('ex-add-image-btn')?.addEventListener('click', () => this._scanExampleFromImage(node));
+
+    // ── Collapse/expand ──────────────────────────────────────
+    document.querySelectorAll('.ex-collapse-hdr').forEach(hdr => {
+      hdr.addEventListener('click', e => {
+        // Don't collapse when clicking delete, rename, or the rename input
+        if (e.target.closest('.ex-delete-btn') || e.target.closest('.ex-rename-btn') || e.target.closest('.ex-title-input')) return;
+        const id   = hdr.dataset.exId;
+        const body = this._body.querySelector(`.ex-body[data-ex-id="${id}"]`);
+        const chev = this._body.querySelector(`.ex-chevron[data-ex-id="${id}"]`);
+        if (!body) return;
+        const collapsed = body.style.display === 'none';
+        body.style.display  = collapsed ? 'block' : 'none';
+        if (chev) chev.style.transform = collapsed ? 'rotate(90deg)' : '';
+      });
+    });
+
+    // ── Rename (explicit pencil button → show input) ─────────
+    document.querySelectorAll('.ex-rename-btn').forEach(btn => {
+      btn.addEventListener('click', e => {
+        e.stopPropagation(); // don't trigger collapse
+        const id    = btn.dataset.exId;
+        const label = this._body.querySelector(`.ex-title-display[data-ex-id="${id}"]`);
+        const input = this._body.querySelector(`.ex-title-input[data-ex-id="${id}"]`);
+        if (!input || !label) return;
+        label.style.display = 'none';
+        input.style.display = 'block';
+        input.focus();
+        input.select();
+      });
+    });
+    document.querySelectorAll('.ex-title-input').forEach(input => {
+      const save = () => {
+        const id    = input.dataset.exId;
+        const label = this._body.querySelector(`.ex-title-display[data-ex-id="${id}"]`);
+        const ex    = (node.workedExamples || []).find(x => x.id === id);
+        if (!ex) return;
+        const newTitle = input.value.trim() || 'Worked Example';
+        ex.title        = newTitle;
+        label.textContent = newTitle;
+        label.style.display = '';
+        input.style.display  = 'none';
+        nodeStore.save(node);
+      };
+      input.addEventListener('blur', save);
+      input.addEventListener('keydown', e => {
+        if (e.key === 'Enter') { e.preventDefault(); save(); }
+        if (e.key === 'Escape') {
+          const id    = input.dataset.exId;
+          const label = this._body.querySelector(`.ex-title-display[data-ex-id="${id}"]`);
+          label.style.display = '';
+          input.style.display  = 'none';
+        }
+      });
+      input.addEventListener('click', e => e.stopPropagation());
+    });
+
+    // Wire tutor buttons — show progress bar then open tutor
+    document.querySelectorAll('.ex-tutor-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const ex = (node.workedExamples||[]).find(x => x.id === btn.dataset.exId);
+        if (!ex) return;
+
+        // Show progress bar inside button
+        btn.disabled = true;
+        btn.innerHTML =
+          '<div style="width:100%;display:flex;flex-direction:column;gap:6px;align-items:center;">'
+          + '<span style="font-size:13px;font-weight:700;">⬡ Starting tutor…</span>'
+          + '<div style="width:100%;height:4px;background:rgba(0,0,0,.2);border-radius:2px;overflow:hidden;">'
+          + '<div id="tutor-progress-bar" style="height:100%;background:#060709;border-radius:2px;width:0%;transition:width .4s ease;"></div>'
+          + '</div>'
+          + '</div>';
+
+        // Animate progress bar
+        const bar = btn.querySelector('#tutor-progress-bar');
+        let pct = 0;
+        const tick = setInterval(() => {
+          pct = Math.min(pct + 15, 90);
+          if (bar) bar.style.width = pct + '%';
+        }, 80);
+
+        setTimeout(() => {
+          clearInterval(tick);
+          if (bar) bar.style.width = '100%';
+          setTimeout(() => {
+            SocraticTutor.open(node, ex);
+            btn.disabled = false;
+            btn.innerHTML = '⬡ Tutor me through this';
+          }, 300);
+        }, 600);
+      });
+    });
+
+    // Wire delete buttons
+    document.querySelectorAll('.ex-delete-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        if (!confirm('Delete this example?')) return;
+        node.workedExamples = (node.workedExamples||[]).filter(x => x.id !== btn.dataset.exId);
+        nodeStore.save(node);
+        this._renderExamples(node);
+      });
+    });
+  },
+
+  _scanExampleFromImage(node) {
+    // Open gallery with multiple selection — same as main upload
+    const inp = document.createElement('input');
+    inp.type = 'file';
+    inp.accept = 'image/*';
+    inp.multiple = true;
+    inp.addEventListener('change', async () => {
+      const files = Array.from(inp.files);
+      if (!files.length) return;
+      Toast.info('Reading ' + files.length + ' image' + (files.length > 1 ? 's' : '') + '…');
+
+      // Read all files as base64
+      const readFile = function(file) {
+        return new Promise(function(res, rej) {
+          const r = new FileReader();
+          r.onload = function() {
+            const d = r.result, parts = d.split(',');
+            let mt = parts[0].match(/data:([^;]+);/)?.[1] || 'image/jpeg';
+            const sup = ['image/jpeg','image/png','image/gif','image/webp'];
+            if (!sup.includes(mt)) {
+              const img = new Image();
+              img.onload = function() {
+                const c = document.createElement('canvas');
+                c.width = img.width; c.height = img.height;
+                c.getContext('2d').drawImage(img, 0, 0);
+                res({ base64: c.toDataURL('image/jpeg', .92).split(',')[1], mediaType: 'image/jpeg' });
+              };
+              img.src = d;
+            } else {
+              res({ base64: parts[1], mediaType: mt });
+            }
+          };
+          r.onerror = rej;
+          r.readAsDataURL(file);
+        });
+      };
+
+      try {
+        // Step 1: Read files
+        Toast.info('📖 Step 1/3 — Reading ' + files.length + ' image' + (files.length > 1 ? 's' : '') + '…');
+        const images = await Promise.all(files.map(readFile));
+        const b64s   = images.map(function(i) { return i.base64; });
+        const mts    = images.map(function(i) { return i.mediaType; });
+
+        // Step 2: OCR
+        Toast.info('🔍 Step 2/3 — Extracting text' + (files.length > 1 ? ' from ' + files.length + ' pages in parallel' : '') + '…');
+        const ocrText = files.length === 1
+          ? await AIService._extractSingleImageText(b64s[0], mts[0])
+          : await AIService._extractMultiPageText(b64s, mts);
+
+        // Step 3: Structure — scale limits to the number of pages so 4+ page
+        // examples aren't truncated to the first few pages.
+        Toast.info('⬡ Step 3/3 — Structuring example…');
+        const inputChars = Math.min(20000, Math.max(6000, files.length * 4000));
+        const outputTokens = Math.min(8000, Math.max(1500, files.length * 1200));
+        const prompt = 'Extract the worked accounting/exam example from this text. It may span multiple pages — process EVERY page, do not stop after the first few. Capture any ledger accounts, journals, or financial tables as STRUCTURED tables — preserve every column (e.g. Date, Details, Fol, Debit, Credit) and every row exactly as shown, including totals.\n'
+          + 'Output ONLY raw JSON:\n'
+          + '{"title":"brief title","question":"full question","solution":"full solution text (narrative parts only)","steps":["step 1","step 2"],'
+          + '"tables":[{"caption":"e.g. Trading account","columns":["col1","col2"],"rows":[["",""]]}]}\n'
+          + 'Include a separate table for EACH account/ledger found across ALL pages. If there are no tables, use an empty array. Keep numbers exactly as written.\n\nTEXT:\n' + ocrText.slice(0, inputChars);
+        const raw = await AIService._callWithFunction('noteProcessing', [{ role: 'user', content: prompt }], outputTokens);
+
+        let data = null;
+        try { data = AIService._parseJSON(raw); } catch(e) {}
+
+        if (!data || !data.question) {
+          const ocrLines = ocrText.split('\n').filter(function(l) { return l.trim().length > 10; });
+          data = { title: 'Scanned Example', question: ocrLines.slice(0, 3).join(' '), solution: ocrText.slice(0, 2000), steps: [] };
+          Toast.info('✓ Saved — you can edit the question and solution.');
+        } else {
+          Toast.success('✓ Example saved from ' + files.length + ' image' + (files.length > 1 ? 's' : '') + '!');
+        }
+
+        if (!node.workedExamples) node.workedExamples = [];
+        node.workedExamples.push({
+          id: 'ex_' + Math.random().toString(36).slice(2, 9),
+          title:    data.title    || 'Scanned Example',
+          question: data.question || '',
+          solution: data.solution || ocrText,
+          steps:    data.steps    || [],
+          tables:   Array.isArray(data.tables) ? data.tables : [],
+          pageCount: files.length,
+          addedAt:  Date.now(),
+        });
+        nodeStore.save(node);
+        NodeDetailView._renderExamples(node);
+      } catch(err) {
+        Toast.error('✗ Failed: ' + err.message);
+      }
+    });
+    inp.click();
+  },
+
+  _openAddExampleModal(node) {
+    Modal.open(
+      '<h2 style="font-family:var(--font-ui);font-size:18px;font-weight:800;margin-bottom:16px;">Add Worked Example</h2>'
+      + '<div class="config-row" style="margin-bottom:12px;"><label class="config-label">Title</label><input type="text" id="ex-title" class="config-input" placeholder="e.g. Calculate Tax Liability"/></div>'
+      + '<div class="config-row" style="margin-bottom:12px;"><label class="config-label">Question *</label><textarea id="ex-question" class="config-input" placeholder="Paste the full question here..." style="height:100px;resize:vertical;"></textarea></div>'
+      + '<div class="config-row" style="margin-bottom:12px;"><label class="config-label">Full Solution *</label><textarea id="ex-solution" class="config-input" placeholder="Paste the complete worked solution..." style="height:120px;resize:vertical;"></textarea></div>'
+      + '<div class="config-row" style="margin-bottom:18px;"><label class="config-label">Key Steps (one per line)</label><textarea id="ex-steps" class="config-input" placeholder="Step 1: Identify gross income&#10;Step 2: Apply deductions" style="height:80px;resize:vertical;"></textarea></div>'
+      + '<div style="display:flex;gap:8px;"><button class="btn-primary" id="ex-save-btn" style="flex:1;justify-content:center;">Save Example</button><button class="btn-secondary" onclick="Modal.close()">Cancel</button></div>'
+    );
+    setTimeout(() => {
+      document.getElementById('ex-save-btn')?.addEventListener('click', () => {
+        const question = document.getElementById('ex-question')?.value.trim();
+        if (!question) { Toast.error('Please enter the question.'); return; }
+        const solution = document.getElementById('ex-solution')?.value.trim() || '';
+        const stepsRaw = document.getElementById('ex-steps')?.value.trim();
+        const steps = stepsRaw ? stepsRaw.split('\n').map(s=>s.trim()).filter(Boolean) : [];
+        if (!node.workedExamples) node.workedExamples = [];
+        node.workedExamples.push({ id:'ex_'+Math.random().toString(36).slice(2,9), title:document.getElementById('ex-title')?.value.trim()||'Example '+(node.workedExamples.length+1), question, solution, steps, addedAt:Date.now() });
+        nodeStore.save(node); Modal.close(); Toast.success('Example saved!'); this._renderExamples(node);
+      });
+    }, 0);
+  },
+
+
+  _openSocraticTutor(node, ex) {
+    SocraticTutor.open(node, ex);
+  },
+
+  /* ─── MASTERY ─────────────────────────────────────── */
+  // ═══════════════════════════════════════════════════════════════════════════
+  // ▶ MASTERY TAB
+  // ═══════════════════════════════════════════════════════════════════════════
+  _renderMastery(node) {
+    const stats=[{value:node.masteryScore+'%',label:'Mastery'},{value:node.reviewCount,label:'Reviews'},{value:node.dueQuestions().length,label:'Due Today'},{value:node.questions.length,label:'Questions'}];
+    const rows=node.questions.map(q=>{const s=node.srsState[q.id];const preview=q.question.length>60?q.question.slice(0,60)+'…':q.question;return'<tr><td style="padding:10px 12px;font-family:var(--font-body);font-size:13px;border-bottom:1px solid var(--border-soft);max-width:180px;"><div style="white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:170px;" title="'+this._esc(q.question)+'">'+this._esc(preview)+'</div></td><td style="padding:10px 12px;font-family:var(--font-mono);font-size:11px;color:var(--'+(q.type==='recall'?'blue':'green')+');border-bottom:1px solid var(--border-soft);">'+q.type+'</td><td style="padding:10px 12px;font-family:var(--font-mono);font-size:11px;color:var(--text-muted);border-bottom:1px solid var(--border-soft);">'+SpacedRepetition.intervalLabel(s)+'</td><td style="padding:10px 12px;border-bottom:1px solid var(--border-soft);"><div class="mastery-bar-track" style="width:80px"><div class="mastery-bar-fill" style="width:'+(s?Math.min(100,s.repetitions*20):0)+'%"></div></div></td></tr>';}).join('');
+    const outstanding = node.masteryOutstandingText();
+    const weak = node.missedQuestionsForReview();
+    const weakHtml = weak.length
+      ? '<div class="notes-section" style="margin-top:20px;border-color:rgba(240,86,74,0.25);"><div class="notes-section-title">📖 Review in your textbook</div>'
+        + '<p style="font-family:var(--font-body);font-size:13px;color:var(--text-secondary);line-height:1.6;margin-bottom:14px;">Questions you\'ve struggled with, worst first — the highest-value places to go back and re-read.</p>'
+        + weak.map(w => '<div style="background:var(--bg-raised);border:1px solid var(--border);border-radius:10px;padding:12px 14px;margin-bottom:10px;">'
+          + '<div style="display:flex;align-items:center;gap:8px;margin-bottom:6px;flex-wrap:wrap;">'
+          + '<span style="font-family:var(--font-mono);font-size:9px;font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--red,#f87171);background:rgba(240,86,74,0.1);border:1px solid rgba(240,86,74,0.25);padding:2px 8px;border-radius:12px;">missed '+w.count+'×</span>'
+          + '</div><p style="font-family:var(--font-body);font-size:14px;color:var(--text-primary);line-height:1.6;margin:0 0 6px;">'+this._esc(w.question)+'</p>'
+          + (w.answer ? '<p style="font-family:var(--font-body);font-size:13px;color:var(--text-secondary);line-height:1.55;margin:0;">'+this._esc(w.answer)+'</p>' : '')
+          + '</div>').join('')
+        + '</div>'
+      : '';
+    this._body.innerHTML='<h2 style="font-family:var(--font-ui);font-size:21px;font-weight:800;margin-bottom:26px;letter-spacing:-0.02em;">Mastery</h2><div class="mastery-overview">'+stats.map(s=>'<div class="mastery-stat-card"><span class="mastery-stat-value">'+s.value+'</span><span class="mastery-stat-label">'+s.label+'</span></div>').join('')+'</div>'+(node.masteryScore<100?'<div class="notes-section" style="background:var(--accent-soft);border:1px solid var(--accent-dim);"><div class="notes-section-title" style="color:var(--accent);">What\'s left for 100%</div><p style="font-family:var(--font-body);font-size:13px;line-height:1.65;color:var(--text-primary);margin:0;">'+this._esc(outstanding)+'</p></div>':'')+'<div class="notes-section"><div class="notes-section-title">Question Progress</div><div style="overflow-x:auto;"><table style="width:100%;border-collapse:collapse;"><thead><tr style="border-bottom:1px solid var(--border);"><th style="padding:8px 12px;text-align:left;font-family:var(--font-ui);font-size:10px;text-transform:uppercase;letter-spacing:0.1em;color:var(--text-muted);">Question</th><th style="padding:8px 12px;text-align:left;font-family:var(--font-ui);font-size:10px;text-transform:uppercase;letter-spacing:0.1em;color:var(--text-muted);">Type</th><th style="padding:8px 12px;text-align:left;font-family:var(--font-ui);font-size:10px;text-transform:uppercase;letter-spacing:0.1em;color:var(--text-muted);">Next Review</th><th style="padding:8px 12px;text-align:left;font-family:var(--font-ui);font-size:10px;text-transform:uppercase;letter-spacing:0.1em;color:var(--text-muted);">Reps</th></tr></thead><tbody>'+(rows||'<tr><td colspan="4" style="padding:20px;text-align:center;color:var(--text-muted);font-family:var(--font-mono);font-size:13px;">No reviews yet.</td></tr>')+'</tbody></table></div></div>'
+      + weakHtml
+      + '<div class="notes-section" style="margin-top:20px;"><div class="notes-section-title">🔗 Connections</div>'
+      + '<p style="font-family:var(--font-body);font-size:13px;color:var(--text-secondary);line-height:1.6;margin-bottom:12px;">See how this topic links to others in <strong>' + this._esc(node.subject || 'this subject') + '</strong> — what it builds on and what builds on it.</p>'
+      + '<div id="connections-area"><button class="btn-secondary" id="find-connections-btn" style="font-size:12px;">🔗 Find connections</button></div>'
+      + '</div>'
+      + '<div class="notes-section" style="margin-top:20px;"><div class="notes-section-title">Reset</div>'
+      + '<p style="font-family:var(--font-body);font-size:13px;color:var(--text-secondary);line-height:1.6;margin-bottom:12px;">If your mastery went up by accident (e.g. flipping through questions), you can reset all progress for this node back to zero. This clears mastery, review history, and spaced-repetition scheduling. Your notes and questions are kept.</p>'
+      + '<button class="btn-secondary" id="reset-mastery-btn" style="font-size:12px;color:var(--red,#f87171);border-color:rgba(248,113,113,.3);">↺ Reset progress for this node</button>'
+      + '</div>';
+
+    document.getElementById('find-connections-btn')?.addEventListener('click', async () => {
+      const area = document.getElementById('connections-area');
+      if (!AIService.hasApiKey()) {
+        area.innerHTML = '<p style="font-family:var(--font-mono);font-size:12px;color:var(--text-muted);">Configure AI in Settings to find connections.</p>';
+        return;
+      }
+      area.innerHTML = '<div class="aif-loading"><div class="aif-dot"></div><div class="aif-dot"></div><div class="aif-dot"></div></div>';
+      try {
+        const subjKey = (node.subject || '').toLowerCase().trim();
+        const siblings = nodeStore.getAll()
+          .filter(n => n.id !== node.id && n.processingStatus === 'ready'
+            && (n.subject || '').toLowerCase().trim() === subjKey && subjKey)
+          .map(n => ({ id: n.id, title: n.title, summary: n.summary || '' }));
+        if (!siblings.length) {
+          area.innerHTML = '<p style="font-family:var(--font-mono);font-size:12px;color:var(--text-muted);">No other topics in this subject yet. Add more nodes to see connections.</p>';
+          return;
+        }
+        const result = await AIService.findConnections(node, siblings);
+        const conns = result?.connections || [];
+        if (!conns.length) {
+          area.innerHTML = '<p style="font-family:var(--font-mono);font-size:12px;color:var(--text-muted);">No strong connections found yet.</p>';
+          return;
+        }
+        area.innerHTML = conns.map(c => {
+          const target = nodeStore.getAll().find(n => n.id === c.id);
+          return '<div style="background:var(--bg-base);border:1px solid var(--border-soft);border-radius:10px;padding:12px 14px;margin-bottom:10px;">'
+            + '<div style="display:flex;align-items:center;gap:8px;margin-bottom:5px;flex-wrap:wrap;">'
+            + '<span style="font-family:var(--font-mono);font-size:9px;font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--accent);background:var(--accent-soft);border:1px solid var(--accent-dim);padding:2px 8px;border-radius:12px;">' + this._esc(c.relationship || 'related') + '</span>'
+            + '<span style="font-family:var(--font-ui);font-size:13px;font-weight:700;color:var(--text-primary);">' + this._esc(c.title || (target?.title) || 'Related topic') + '</span>'
+            + '</div>'
+            + '<p style="font-family:var(--font-body);font-size:13px;color:var(--text-secondary);line-height:1.5;margin:0;">' + this._esc(c.explanation || '') + '</p>'
+            + (target ? '<button class="btn-secondary conn-open" data-node-id="' + target.id + '" style="font-size:11px;margin-top:8px;padding:5px 10px;">Open →</button>' : '')
+            + '</div>';
+        }).join('');
+        area.querySelectorAll('.conn-open').forEach(btn => {
+          btn.addEventListener('click', () => {
+            const target = nodeStore.getAll().find(n => n.id === btn.dataset.nodeId);
+            if (target) this.open(target);
+          });
+        });
+      } catch(e) {
+        area.innerHTML = '<p style="font-family:var(--font-mono);font-size:12px;color:var(--red);">Could not load connections. ' + this._esc(e.message||'') + '</p>';
+      }
+    });
+
+    document.getElementById('reset-mastery-btn')?.addEventListener('click', () => {
+      Modal.open(`
+        <div style="font-family:var(--font-ui);text-align:center;">
+          <div style="font-size:32px;margin-bottom:12px;">↺</div>
+          <h2 style="font-size:18px;font-weight:800;margin-bottom:8px;">Reset progress?</h2>
+          <p style="font-family:var(--font-body);font-size:13px;color:var(--text-secondary);line-height:1.6;margin-bottom:20px;">
+            This sets mastery back to 0% and clears all review history for <strong>${this._esc(node.title)}</strong>.
+            Your notes, questions, and examples stay exactly as they are. This can't be undone.
+          </p>
+          <div style="display:flex;gap:10px;justify-content:center;">
+            <button class="btn-danger" id="confirm-reset-btn" style="font-size:13px;padding:9px 18px;">Yes, reset to 0%</button>
+            <button class="btn-secondary" onclick="Modal.close()" style="font-size:13px;padding:9px 18px;">Cancel</button>
+          </div>
+        </div>
+      `);
+      setTimeout(() => {
+        document.getElementById('confirm-reset-btn')?.addEventListener('click', () => {
+          node.resetProgress();
+          nodeStore.save(node);
+          Modal.close();
+          Toast.success('Progress reset for "' + node.title + '"');
+          this._renderMastery(node);
+        });
+      }, 0);
+    });
+  },
+
+  _esc: s => String(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'),
+};

--- a/knowledgenode/www/js/ui/NoteTemplates.js
+++ b/knowledgenode/www/js/ui/NoteTemplates.js
@@ -1,0 +1,317 @@
+/**
+ * NoteTemplates.js
+ * Four note-taking method templates for the node editor.
+ * Templates change how the note editor and display renders.
+ * Stored as node.noteTemplate: 'standard' | 'cornell' | 'outline' | 'feynman'
+ */
+
+const NoteTemplates = {
+
+  TEMPLATES: {
+    standard: {
+      id:    'standard',
+      name:  'Standard',
+      icon:  '📋',
+      desc:  'AI-structured blocks. Best for first reading and reference.',
+      badge: null,
+    },
+    feynman: {
+      id:    'feynman',
+      name:  'Feynman Method',
+      icon:  '💡',
+      desc:  'Explain it in plain English as if teaching someone else. Gaps become obvious.',
+      badge: '⭐ Best for understanding',
+    },
+    cornell: {
+      id:    'cornell',
+      name:  'Cornell Method',
+      icon:  '🗒',
+      desc:  'Cues column + Notes column + Summary. Good for lecture-style notes.',
+      badge: null,
+    },
+    outline: {
+      id:    'outline',
+      name:  'Outline Method',
+      icon:  '≡',
+      desc:  'Hierarchical numbered structure. Good for law, tax, and procedures.',
+      badge: null,
+    },
+  },
+
+  /** Render template picker UI */
+  renderPicker(currentTemplate) {
+    return `
+      <div class="nt-picker">
+        ${Object.values(this.TEMPLATES).map(t => `
+          <button class="nt-option ${(currentTemplate||'standard') === t.id ? 'active' : ''}"
+                  data-template="${t.id}">
+            <span class="nt-icon">${t.icon}</span>
+            <div>
+              <div class="nt-name">${t.name}${t.badge ? ' <span style="font-family:var(--font-mono);font-size:9px;font-weight:700;color:var(--accent);background:var(--accent-soft);padding:2px 6px;border-radius:10px;vertical-align:middle;">' + t.badge + '</span>' : ''}</div>
+              <div class="nt-desc">${t.desc}</div>
+            </div>
+          </button>`).join('')}
+      </div>`;
+  },
+
+  /** Render the edit form for a given template */
+  renderEditForm(node) {
+    const template = node.noteTemplate || 'standard';
+    switch (template) {
+      case 'cornell':  return this._cornellForm(node);
+      case 'outline':  return this._outlineForm(node);
+      case 'feynman':  return this._feynmanForm(node);
+      default:         return null; // standard uses NodeDetailView's existing form
+    }
+  },
+
+  /** Render display (read-only) for a given template */
+  renderDisplay(node) {
+    const template = node.noteTemplate || 'standard';
+    switch (template) {
+      case 'cornell':  return this._cornellDisplay(node);
+      case 'outline':  return this._outlineDisplay(node);
+      case 'feynman':  return this._feynmanDisplay(node);
+      default:         return null;
+    }
+  },
+
+  // ─── CORNELL ──────────────────────────────────────────
+
+  _cornellForm(node) {
+    const c = node.cornellData || { cues: '', notes: '', summary: '' };
+    return `
+      <div class="cornell-editor">
+        <div class="cornell-top">
+          <div class="cornell-cues">
+            <div class="cornell-label">🔑 Cues / Keywords</div>
+            <textarea id="cn-cues" class="config-input" rows="12"
+              placeholder="Key terms, questions, headings…&#10;&#10;e.g.&#10;What is taxable income?&#10;Formula?&#10;Exceptions?"
+              style="resize:none;height:100%;font-size:13px;">${this._esc(c.cues)}</textarea>
+          </div>
+          <div class="cornell-notes">
+            <div class="cornell-label">📝 Notes</div>
+            <textarea id="cn-notes" class="config-input" rows="12"
+              placeholder="Main content — explanations, examples, details…"
+              style="resize:none;height:100%;font-size:13px;">${this._esc(c.notes)}</textarea>
+          </div>
+        </div>
+        <div class="cornell-summary">
+          <div class="cornell-label">📄 Summary (bottom)</div>
+          <textarea id="cn-summary" class="config-input" rows="3"
+            placeholder="Summarise the page in 2-3 sentences in your own words…"
+            style="resize:none;font-size:13px;">${this._esc(c.summary)}</textarea>
+        </div>
+      </div>`;
+  },
+
+  _cornellDisplay(node) {
+    const c = node.cornellData || {};
+    if (!c.cues && !c.notes && !c.summary) return '<p style="color:var(--text-muted);font-family:var(--font-mono);font-size:13px;">No Cornell notes yet. Click 📐 Adapt Format to generate.</p>';
+
+    // Split cues and notes into individual lines/items for aligned display
+    const splitLines = str => (str||'').split('\n').map(l => l.trim()).filter(l => l.length > 0);
+    const cueLines  = splitLines(c.cues);
+    const noteLines = splitLines(c.notes);
+    const maxRows   = Math.max(cueLines.length, noteLines.length, 1);
+
+    // Build paired rows so cue and note align side by side
+    let rows = '';
+    for (let i = 0; i < maxRows; i++) {
+      const cue  = cueLines[i]  || '';
+      const note = noteLines[i] || '';
+      const isLast = i === maxRows - 1;
+      rows += '<div class="cn-row' + (isLast ? ' cn-row-last' : '') + '">'
+        + '<div class="cn-cue">' + (cue  ? this._esc(cue)  : '') + '</div>'
+        + '<div class="cn-note">' + (note ? this._esc(note) : '') + '</div>'
+        + '</div>';
+    }
+
+    return '<div class="cornell-display">'
+      + '<div class="cn-header-row">'
+      + '<div class="cornell-label cn-label-cue">🔑 Cues</div>'
+      + '<div class="cornell-label cn-label-note">📝 Notes</div>'
+      + '</div>'
+      + '<div class="cn-body">' + rows + '</div>'
+      + (c.summary
+          ? '<div class="cornell-summary-display"><div class="cornell-label" style="margin-bottom:10px;">📄 Summary</div><div style="font-family:var(--font-body);font-size:14.5px;line-height:1.75;color:var(--text-primary);">' + this._esc(c.summary) + '</div></div>'
+          : '')
+      + '</div>';
+  },
+
+  saveCornell(node) {
+    node.cornellData = {
+      cues:    document.getElementById('cn-cues')?.value    || '',
+      notes:   document.getElementById('cn-notes')?.value   || '',
+      summary: document.getElementById('cn-summary')?.value || '',
+    };
+  },
+
+  // ─── OUTLINE ──────────────────────────────────────────
+
+  _outlineForm(node) {
+    const items = node.outlineData?.items || [{ level:0, text:'' }];
+    return `
+      <div style="margin-bottom:12px;">
+        <p style="font-family:var(--font-mono);font-size:12px;color:var(--text-muted);margin-bottom:10px;">
+          Use Tab to indent, Shift+Tab to outdent. Each line is a topic level.
+        </p>
+        <div id="outline-editor" class="outline-editor">
+          ${items.map((item,i) => `
+            <div class="outline-item" data-level="${item.level}" style="padding-left:${item.level*24}px;">
+              <span class="outline-bullet">${this._outlineBullet(item.level)}</span>
+              <input type="text" class="outline-input config-input"
+                     value="${this._esc(item.text)}"
+                     placeholder="${item.level===0?'Main topic':'Sub-point…'}"
+                     data-idx="${i}"/>
+            </div>`).join('')}
+        </div>
+        <button class="btn-secondary" id="outline-add-btn" style="margin-top:8px;font-size:12px;padding:7px 14px;">+ Add line</button>
+      </div>`;
+  },
+
+  _outlineBullet(level) {
+    return ['I.','A.','1.','a.','i.'][Math.min(level, 4)];
+  },
+
+  _outlineDisplay(node) {
+    const items = node.outlineData?.items || [];
+    if (!items.length) return '<p style="color:var(--text-muted);font-family:var(--font-mono);font-size:13px;">No outline notes yet. Click Edit to add.</p>';
+    return `<div class="outline-display">
+      ${items.filter(i=>i.text).map(item => `
+        <div class="outline-display-item" style="padding-left:${item.level*24}px;">
+          <span class="outline-bullet">${this._outlineBullet(item.level)}</span>
+          <span>${this._esc(item.text)}</span>
+        </div>`).join('')}
+    </div>`;
+  },
+
+  bindOutlineEditor() {
+    const editor = document.getElementById('outline-editor');
+    if (!editor) return;
+
+    editor.addEventListener('keydown', e => {
+      const input = e.target;
+      if (!input.classList.contains('outline-input')) return;
+      const item  = input.closest('.outline-item');
+
+      if (e.key === 'Tab') {
+        e.preventDefault();
+        let level = parseInt(item.dataset.level) || 0;
+        level = e.shiftKey ? Math.max(0, level-1) : Math.min(4, level+1);
+        item.dataset.level = level;
+        item.style.paddingLeft = `${level*24}px`;
+        item.querySelector('.outline-bullet').textContent = this._outlineBullet(level);
+      }
+
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        const newItem = document.createElement('div');
+        const level   = parseInt(item.dataset.level) || 0;
+        newItem.className = 'outline-item';
+        newItem.dataset.level = level;
+        newItem.style.paddingLeft = `${level*24}px`;
+        newItem.innerHTML = `<span class="outline-bullet">${this._outlineBullet(level)}</span><input type="text" class="outline-input config-input" placeholder="Sub-point…"/>`;
+        item.after(newItem);
+        newItem.querySelector('input').focus();
+      }
+    });
+
+    document.getElementById('outline-add-btn')?.addEventListener('click', () => {
+      const newItem = document.createElement('div');
+      newItem.className = 'outline-item';
+      newItem.dataset.level = 0;
+      newItem.innerHTML = `<span class="outline-bullet">I.</span><input type="text" class="outline-input config-input" placeholder="Main topic"/>`;
+      editor.appendChild(newItem);
+      newItem.querySelector('input').focus();
+    });
+  },
+
+  saveOutline(node) {
+    const items = Array.from(document.querySelectorAll('.outline-item')).map(item => ({
+      level: parseInt(item.dataset.level) || 0,
+      text:  item.querySelector('input')?.value || '',
+    }));
+    node.outlineData = { items };
+  },
+
+  // ─── FEYNMAN ──────────────────────────────────────────
+
+  _feynmanForm(node) {
+    const f = node.feynmanData || { simple:'', gaps:'', refined:'' };
+    return `
+      <div style="display:flex;flex-direction:column;gap:16px;">
+
+        <div class="feynman-phase">
+          <div class="feynman-phase-label">
+            <span class="feynman-num">1</span>
+            Explain it simply — as if teaching a 12-year-old
+          </div>
+          <textarea id="fn-simple" class="config-input" rows="5"
+            placeholder="In simple terms, ${this._esc(node.title)} is about…"
+            style="resize:vertical;">${this._esc(f.simple)}</textarea>
+        </div>
+
+        <div class="feynman-phase">
+          <div class="feynman-phase-label">
+            <span class="feynman-num">2</span>
+            Where did you get stuck or use jargon? (your gaps)
+          </div>
+          <textarea id="fn-gaps" class="config-input" rows="3"
+            placeholder="I wasn't sure about… I used a technical word for…"
+            style="resize:vertical;">${this._esc(f.gaps)}</textarea>
+        </div>
+
+        <div class="feynman-phase">
+          <div class="feynman-phase-label">
+            <span class="feynman-num">3</span>
+            Refined explanation (after reviewing your notes)
+          </div>
+          <textarea id="fn-refined" class="config-input" rows="5"
+            placeholder="Now I understand it as…"
+            style="resize:vertical;">${this._esc(f.refined)}</textarea>
+        </div>
+
+      </div>`;
+  },
+
+  _outlineDisplay(node) {
+    const data = node.outlineData || {};
+    const text = data.outline || '';
+    if (!text) return '<p style="color:var(--text-muted);font-family:var(--font-mono);font-size:13px;">No outline yet. Click 📐 Template to generate one.</p>';
+    const lines = text.split('\n').filter(l => l.trim());
+    const html = lines.map(line => {
+      const trimmed = line.trim();
+      const indent = line.length - line.trimStart().length;
+      const level = Math.floor(indent / 2);
+      const isMain = /^\d+\./.test(trimmed);
+      const isSub  = /^[a-z]\./.test(trimmed);
+      const isDetail = /^[ivx]+\./.test(trimmed);
+      const style = isMain
+        ? 'font-weight:700;color:var(--text-primary);font-size:14px;margin-top:14px;'
+        : isSub
+          ? 'color:var(--text-secondary);font-size:13px;margin-left:20px;margin-top:4px;'
+          : 'color:var(--text-muted);font-size:12px;margin-left:40px;margin-top:2px;';
+      return '<div style="font-family:var(--font-body);line-height:1.6;' + style + '">' + this._esc(trimmed) + '</div>';
+    }).join('');
+    return '<div style="padding:4px 0;">' + html + '</div>';
+  },
+
+  /* ── Display for AI-rewritten Feynman ──────────────── */
+  _feynmanDisplay(node) {
+    const data = node.feynmanData2 || node.feynmanData || {};
+    const explanation = data.explanation || data.explanation2 || '';
+    const analogies   = data.analogies   || '';
+    const gaps        = data.gaps        || '';
+    const takeaway    = data.keyTakeaway || data.takeaway || '';
+    if (!explanation && !takeaway) return '<p style="color:var(--text-muted);font-family:var(--font-mono);font-size:13px;">No Feynman notes yet. Click 📐 Template to generate.</p>';
+    let html = '';
+    if (explanation) html += '<div style="margin-bottom:18px;"><div style="font-family:var(--font-mono);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:0.08em;color:var(--accent);margin-bottom:8px;">💡 Plain Explanation</div><div style="font-family:var(--font-body);font-size:14px;line-height:1.75;color:var(--text-primary);">' + this._esc(explanation) + '</div></div>';
+    if (analogies) html += '<div style="margin-bottom:18px;padding:14px 16px;background:var(--accent-soft);border:1px solid var(--accent-dim);border-radius:var(--radius-md);"><div style="font-family:var(--font-mono);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:0.08em;color:var(--accent);margin-bottom:6px;">🔗 Analogies</div><div style="font-family:var(--font-body);font-size:13px;line-height:1.65;color:var(--text-secondary);">' + this._esc(analogies) + '</div></div>';
+    if (gaps) html += '<div style="margin-bottom:18px;padding:14px 16px;background:var(--red-dim, rgba(255,80,80,0.08));border:1px solid rgba(255,80,80,0.2);border-radius:var(--radius-md);"><div style="font-family:var(--font-mono);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:0.08em;color:var(--red, #ff5050);margin-bottom:6px;">⚠ Knowledge Gaps to Study</div><div style="font-family:var(--font-body);font-size:13px;line-height:1.65;color:var(--text-secondary);">' + this._esc(gaps) + '</div></div>';
+    if (takeaway) html += '<div style="padding:14px 16px;background:var(--green-dim);border:1px solid rgba(52,199,123,0.2);border-radius:var(--radius-md);"><div style="font-family:var(--font-mono);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:0.08em;color:var(--green);margin-bottom:6px;">✓ Key Takeaway</div><div style="font-family:var(--font-body);font-size:13px;font-weight:600;line-height:1.65;color:var(--text-primary);">' + this._esc(takeaway) + '</div></div>';
+    return html;
+  },
+
+    _esc: s => String(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'),
+};

--- a/knowledgenode/www/js/ui/NotesRenderer.js
+++ b/knowledgenode/www/js/ui/NotesRenderer.js
@@ -1,0 +1,190 @@
+/**
+ * NotesRenderer.js — Final
+ * Renders structured procedures (multi-group), definitions with examples, tables
+ */
+const NotesRenderer = {
+
+  renderFullNotes(node) {
+    // If the scan captured the handbook's section order, render in that exact
+    // sequence so the digital notes mirror the textbook's flow. Each section type
+    // is emitted the first time it's referenced, then skipped afterwards.
+    const order = node.sectionOrder;
+    if (Array.isArray(order) && order.length) {
+      const out = [];
+      const done = new Set();
+      const emit = kind => {
+        if (done.has(kind)) return '';
+        done.add(kind);
+        switch (kind) {
+          case 'definition': return this.renderDefinitions(node.definitions);
+          case 'table':      return this.renderTables(node.tables);
+          case 'formula':    return this.renderFormulas(node.formulas);
+          case 'procedure':  return this.renderProcedures(node.procedures);
+          default:           return '';
+        }
+      };
+      order.forEach(b => { const html = emit((b.kind || '').toLowerCase()); if (html) out.push(html); });
+      // Append any section types the order map didn't mention, so nothing is lost
+      ['definition','table','formula','procedure'].forEach(k => { const html = emit(k); if (html) out.push(html); });
+      out.push(this.renderMistakes(node.commonMistakes));
+      out.push(this.renderSummary(node.summary));
+      out.push(this.renderUserSection(node));
+      return out.join('');
+    }
+
+    // Fallback: fixed type order (older nodes without a captured sequence)
+    return [
+      this.renderDefinitions(node.definitions),
+      this.renderTables(node.tables),
+      this.renderFormulas(node.formulas),
+      this.renderProcedures(node.procedures),
+      this.renderMistakes(node.commonMistakes),
+      this.renderSummary(node.summary),
+      this.renderUserSection(node),
+    ].join('');
+  },
+
+  /* ─── DEFINITIONS with examples ────────────────────── */
+  renderDefinitions(defs) {
+    if (!defs?.length) return '';
+    return '<div class="notes-section" id="section-definitions"><div class="notes-section-title">Key Definitions</div>'
+      + defs.map(d => {
+          const examples = d.examples?.trim();
+          return '<div class="definition-item">'
+            + '<div class="definition-term">' + this._esc(d.term) + '</div>'
+            + (examples ? '<div class="definition-examples">Examples: ' + this._esc(examples) + '</div>' : '')
+            + '<div class="definition-desc">' + this._esc(d.description) + '</div>'
+            + '</div>';
+        }).join('')
+      + '</div>';
+  },
+
+  /* ─── TABLES ────────────────────────────────────────── */
+  renderTables(tables) {
+    if (!tables?.length) return '';
+    return tables.map(tbl => {
+      const cols = tbl.columns || ['Name','Type','Example'];
+      const rows = tbl.rows    || [];
+      return '<div class="notes-section" id="section-tables">'
+        + '<div class="notes-section-title">' + this._esc(tbl.title || 'Table') + '</div>'
+        + '<div class="node-table-wrap"><table class="node-table">'
+        + '<thead><tr>' + cols.map(c => '<th>' + this._esc(c) + '</th>').join('') + '</tr></thead>'
+        + '<tbody>'
+        + (rows.length
+            ? rows.map(row => '<tr>' + cols.map((_, ci) => '<td>' + this._esc(row[ci] || '') + '</td>').join('') + '</tr>').join('')
+            : '<tr><td colspan="' + cols.length + '" style="text-align:center;color:var(--text-muted);font-style:italic;">No rows yet</td></tr>')
+        + '</tbody></table></div></div>';
+    }).join('');
+  },
+
+  /* ─── FORMULAS ──────────────────────────────────────── */
+  renderFormulas(formulas) {
+    if (!formulas?.length) return '';
+    return '<div class="notes-section" id="section-formulas"><div class="notes-section-title">Formulas &amp; Equations</div>'
+      + formulas.map(f =>
+          '<div class="formula-block">'
+          + '<div class="formula-expr">'   + this._esc(f.expression)  + '</div>'
+          + '<div class="formula-desc">'   + this._esc(f.description) + '</div>'
+          + (f.constraints ? '<div class="formula-constraints">Constraints: ' + this._esc(f.constraints) + '</div>' : '')
+          + '</div>'
+        ).join('')
+      + '</div>';
+  },
+
+  /* ─── PROCEDURES — structured multi-group ────────────── */
+  renderProcedures(procedures) {
+    if (!procedures?.length) return '';
+    return '<div class="notes-section" id="section-procedures"><div class="notes-section-title">Procedures</div>'
+      + procedures.map((proc, idx) => {
+          const steps = proc.steps || [];
+          const notes = proc.notes?.trim();
+          const appliesTo = proc.appliesTo?.trim();
+          return '<details class="proc-card">'
+            + '<summary class="proc-card-summary">'
+            + '<span class="proc-card-num">' + (idx + 1) + '</span>'
+            + '<span class="proc-card-title">' + this._esc(proc.title || 'Procedure') + '</span>'
+            + (appliesTo ? '<span class="proc-card-applies">Applies to: ' + this._esc(appliesTo) + '</span>' : '')
+            + '</summary>'
+            + '<div class="proc-card-body">'
+            + (steps.length
+                ? steps.map((s, i) => '<div class="procedure-step"><div class="procedure-num">' + (i+1) + '</div><div class="procedure-text">' + this._esc(s) + '</div></div>').join('')
+                : '<p style="color:var(--text-muted);font-family:var(--font-mono);font-size:12px;">No steps yet.</p>')
+            + (notes
+                ? '<div class="proc-notes-section"><div class="proc-notes-title">📌 Notes &amp; Reminders</div><div class="proc-notes-text">' + this._esc(notes) + '</div></div>'
+                : '')
+            + '</div></details>';
+        }).join('')
+      + '</div>';
+  },
+
+  /* ─── MISTAKES ──────────────────────────────────────── */
+  renderMistakes(mistakes) {
+    if (!mistakes?.length) return '';
+    return '<div class="notes-section" id="section-mistakes"><div class="notes-section-title">Common Mistakes</div>'
+      + mistakes.map(m => {
+          const t = typeof m === 'string' ? m
+            : (m && typeof m === 'object'
+                ? (m.mistake || m.text || m.description || Object.values(m).filter(v => typeof v === 'string').join(' — '))
+                : '');
+          return t ? '<div class="mistake-item">' + this._esc(t) + '</div>' : '';
+        }).join('')
+      + '</div>';
+  },
+
+  /* ─── SUMMARY ───────────────────────────────────────── */
+  renderSummary(summary) {
+    if (!summary) return '';
+    return '<div class="notes-section" id="section-summary"><div class="notes-section-title">Summary</div><div class="summary-block">' + this._esc(summary) + '</div></div>';
+  },
+
+  /* ─── USER NOTES + IMAGES ───────────────────────────── */
+  renderUserSection(node) {
+    const hasNotes  = node.userNotes?.trim();
+    const hasImages = node.userImages?.length;
+    if (!hasNotes && !hasImages) return '';
+    let html = '<div class="notes-section" id="section-usernotes"><div class="notes-section-title">My Notes</div>';
+    if (hasImages) {
+      html += '<div class="user-images-area">';
+      (node.userImages || []).forEach(img => {
+        html += ImageResponseBlock.render(img, node, false);
+      });
+      html += '</div>';
+    }
+    if (hasNotes) html += '<div class="user-notes-block" style="margin-top:' + (hasImages ? '16px' : '0') + ';">' + this._esc(node.userNotes) + '</div>';
+    html += '</div>';
+    return html;
+  },
+
+  /* ─── QUESTIONS ─────────────────────────────────────── */
+  renderQuestions(questions) {
+    if (!questions?.length) return '<p style="color:var(--text-muted);font-family:var(--font-mono);font-size:13px;">No questions.</p>';
+    const recall = questions.filter(q => q.type === 'recall');
+    const apply  = questions.filter(q => q.type === 'application');
+    return [
+      recall.length ? '<div class="notes-section"><div class="notes-section-title">Recall Questions</div>'   + recall.map(q => this._qCard(q)).join('') + '</div>' : '',
+      apply.length  ? '<div class="notes-section"><div class="notes-section-title">Application Questions</div>' + apply.map(q => this._qCard(q)).join('') + '</div>' : '',
+    ].join('');
+  },
+
+  _qCard(q) {
+    return '<div class="question-card" data-qid="' + q.id + '">'
+      + '<div class="question-label">' + (q.type === 'recall' ? '🔁 Recall' : '🧩 Application') + '</div>'
+      + '<div class="question-text">'  + this._esc(q.question) + '</div>'
+      + '<button class="question-answer-toggle" onclick="NotesRenderer._toggleAnswer(this)">Show Answer</button>'
+      + '<div class="question-answer hidden">' + this._esc(q.answer) + '</div>'
+      + '</div>';
+  },
+
+  _toggleAnswer(btn) {
+    const ans = btn.closest('.question-card').querySelector('.question-answer');
+    const vis = !ans.classList.contains('hidden');
+    ans.classList.toggle('hidden', vis);
+    btn.textContent = vis ? 'Show Answer' : 'Hide Answer';
+  },
+
+  renderSummaryText(summary) { return this.renderSummary(summary); },
+
+  _esc(s = '') {
+    return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+  },
+};

--- a/knowledgenode/www/js/ui/OCRReview.js
+++ b/knowledgenode/www/js/ui/OCRReview.js
@@ -1,0 +1,104 @@
+/**
+ * OCRReview.js
+ * Split-screen review of scanned images before saving.
+ * Left: original image, Right: editable extracted text.
+ * Highlights low-confidence words, lets user correct before import.
+ */
+
+const OCRReview = {
+  /**
+   * Show the split-screen review modal.
+   * @param {File} imageFile  - original scanned image
+   * @param {string} rawText  - OCR extracted text
+   * @param {Array} words     - Tesseract word data with confidence scores
+   * @param {function} onConfirm(text) - called when user confirms
+   * @param {function} onSkip         - called when user skips review
+   */
+  show(imageFile, rawText, words, onConfirm, onSkip) {
+    const imageURL  = URL.createObjectURL(imageFile);
+    const annotated = this._annotateText(rawText, words);
+
+    const html = '<div id="ocr-review-modal" style="display:flex;flex-direction:column;height:100%;">'
+
+      // Header
+      + '<div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:16px;flex-wrap:wrap;gap:10px;">'
+      + '<div>'
+      + '<h2 style="font-family:var(--font-ui);font-size:18px;font-weight:800;margin-bottom:3px;">Review Scanned Notes</h2>'
+      + '<p style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);">Edit the extracted text before saving. <span style="color:var(--red);">Red text</span> = low confidence.</p>'
+      + '</div>'
+      + '<div style="display:flex;gap:8px;">'
+      + '<button class="btn-primary" id="ocr-confirm-btn">✓ Save Notes</button>'
+      + '<button class="btn-secondary" id="ocr-skip-btn">Skip Review</button>'
+      + '</div>'
+      + '</div>'
+
+      // Split panel
+      + '<div id="ocr-split" style="display:grid;grid-template-columns:1fr 1fr;gap:14px;flex:1;min-height:0;">'
+
+      // Left — original image
+      + '<div style="display:flex;flex-direction:column;gap:8px;">'
+      + '<div style="font-family:var(--font-ui);font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:0.1em;color:var(--text-muted);">Original Image</div>'
+      + '<div style="background:var(--bg-raised);border:1px solid var(--border);border-radius:var(--radius-md);overflow:hidden;flex:1;display:flex;align-items:flex-start;justify-content:center;min-height:300px;">'
+      + '<img src="' + imageURL + '" style="width:100%;height:auto;display:block;" onload="URL.revokeObjectURL(this.src)" alt="Scanned page"/>'
+      + '</div>'
+      + '</div>'
+
+      // Right — extracted text editor
+      + '<div style="display:flex;flex-direction:column;gap:8px;">'
+      + '<div style="font-family:var(--font-ui);font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:0.1em;color:var(--text-muted);">Extracted Text <span id="ocr-word-count" style="font-weight:400;color:var(--text-muted);"></span></div>'
+      + '<textarea id="ocr-text-editor" class="config-input" style="flex:1;min-height:300px;resize:none;font-family:var(--font-body);font-size:14px;line-height:1.7;touch-action:pan-y;white-space:pre-wrap;">' + this._esc(rawText) + '</textarea>'
+      + '</div>'
+      + '</div>'
+
+      // Low confidence hints
+      + (annotated.lowConfidenceWords.length > 0 ? (
+        '<div style="margin-top:14px;background:var(--red-dim);border:1px solid rgba(240,86,74,0.2);border-radius:var(--radius-md);padding:12px 16px;">'
+        + '<div style="font-family:var(--font-ui);font-size:12px;font-weight:700;color:var(--red);margin-bottom:6px;">⚠ Low Confidence Words — check these:</div>'
+        + '<div style="font-family:var(--font-mono);font-size:12px;color:var(--text-secondary);line-height:1.8;">'
+        + annotated.lowConfidenceWords.slice(0, 12).map(w =>
+            '<span style="background:var(--red-dim);border:1px solid rgba(240,86,74,0.3);border-radius:3px;padding:1px 6px;margin:2px;">' + this._esc(w.text) + ' (' + w.confidence + '%)</span>'
+          ).join(' ')
+        + '</div>'
+        + '</div>'
+      ) : '')
+
+      + '</div>';
+
+    Modal.open(html);
+
+    // Word counter
+    setTimeout(() => {
+      const editor  = document.getElementById('ocr-text-editor');
+      const counter = document.getElementById('ocr-word-count');
+      if (editor && counter) {
+        const updateCount = () => {
+          const words = (editor.value.trim().match(/\S+/g) || []).length;
+          counter.textContent = '(' + words + ' words)';
+        };
+        updateCount();
+        editor.addEventListener('input', updateCount);
+      }
+
+      document.getElementById('ocr-confirm-btn')?.addEventListener('click', () => {
+        const text = document.getElementById('ocr-text-editor')?.value?.trim() || '';
+        Modal.close();
+        onConfirm(text);
+      });
+
+      document.getElementById('ocr-skip-btn')?.addEventListener('click', () => {
+        Modal.close();
+        onSkip?.();
+      });
+    }, 0);
+  },
+
+  _annotateText(text, words) {
+    const LOW_CONFIDENCE = 70;
+    const lowConfidenceWords = (words || [])
+      .filter(w => w.confidence < LOW_CONFIDENCE && w.text?.trim().length > 2)
+      .map(w => ({ text: w.text, confidence: Math.round(w.confidence) }));
+    return { lowConfidenceWords };
+  },
+
+  _esc: s => String(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'),
+};

--- a/knowledgenode/www/js/ui/Onboarding.js
+++ b/knowledgenode/www/js/ui/Onboarding.js
@@ -1,0 +1,423 @@
+/**
+ * Onboarding.js — First-run journey
+ *
+ * New users get a clear, step-by-step journey:
+ *   1. Welcome screen (choose tour or jump in)
+ *   2. 3-slide tour explaining the study loop
+ *   3. Action gate — guided setup with 3 concrete steps
+ *      shown as a persistent checklist until completed:
+ *        ① Upload your first notes
+ *        ② Add your exam date (Study Plan)
+ *        ③ Do your first Study session
+ *   4. Once all 3 done — journey complete, checklist hides
+ *
+ * The checklist is shown as a banner at the top of every
+ * screen until dismissed, so the student always knows what
+ * to do next regardless of where they navigate.
+ *
+ * Stored in localStorage — never shown again after dismissed.
+ */
+
+const Onboarding = {
+  _key:        'kn_onboarded_v1',
+  _journeyKey: 'kn_journey_v1',
+  _dismissKey: 'kn_checklist_dismissed', // session-scoped: stays closed until app reopened
+  _ran:        false,
+  _currentSlide: 0,
+
+  _slides: [
+    {
+      icon: '⬡',
+      title: 'The Study Loop',
+      subtitle: 'One method. Proven by research.',
+      content: `
+        <div class="ob-loop">
+          <div class="ob-loop-step"><span class="ob-loop-icon">📖</span><span>Read</span></div>
+          <div class="ob-loop-arrow">→</div>
+          <div class="ob-loop-step"><span class="ob-loop-icon">💡</span><span>Understand</span></div>
+          <div class="ob-loop-arrow">→</div>
+          <div class="ob-loop-step"><span class="ob-loop-icon">✍</span><span>Recall</span></div>
+          <div class="ob-loop-arrow">→</div>
+          <div class="ob-loop-step"><span class="ob-loop-icon">❓</span><span>Test</span></div>
+          <div class="ob-loop-arrow">→</div>
+          <div class="ob-loop-step accent"><span class="ob-loop-icon">🔁</span><span>Repeat</span></div>
+        </div>
+        <p class="ob-body">Most students re-read their notes. That feels productive but doesn't build memory. KnowledgeNode forces retrieval — the only thing that actually works.</p>`,
+    },
+    {
+      icon: '⊞',
+      title: 'Knowledge Nodes',
+      subtitle: 'Your notes, structured for learning.',
+      content: `
+        <div class="ob-features">
+          <div class="ob-feature">
+            <span class="ob-feature-icon">📷</span>
+            <div>
+              <div class="ob-feature-title">Scan anything</div>
+              <div class="ob-feature-desc">Photo, PDF, or type. AI pulls out definitions, formulas, procedures — from your source only.</div>
+            </div>
+          </div>
+          <div class="ob-feature">
+            <span class="ob-feature-icon">🎓</span>
+            <div>
+              <div class="ob-feature-title">Adapt to your level</div>
+              <div class="ob-feature-desc">Primary, High School, College, or Professional. Same content, explained at your pace.</div>
+            </div>
+          </div>
+          <div class="ob-feature">
+            <span class="ob-feature-icon">✍</span>
+            <div>
+              <div class="ob-feature-title">Recall before reading</div>
+              <div class="ob-feature-desc">Write everything you remember first. That struggle is where real learning happens.</div>
+            </div>
+          </div>
+          <div class="ob-feature">
+            <span class="ob-feature-icon">🔁</span>
+            <div>
+              <div class="ob-feature-title">Spaced repetition</div>
+              <div class="ob-feature-desc">The app decides when to show each question again. Easy cards fade out. Hard ones resurface.</div>
+            </div>
+          </div>
+        </div>`,
+    },
+    {
+      icon: '📅',
+      title: 'Three steps to get started',
+      subtitle: "Here's exactly what to do first.",
+      content: `
+        <div class="ob-steps">
+          <div class="ob-step">
+            <div class="ob-step-num">1</div>
+            <div>
+              <div class="ob-step-title">Upload your first notes</div>
+              <div class="ob-step-desc">Photograph a page, drag in a PDF, or type. The AI structures it into your first node. <strong>Scan one topic at a time</strong> — e.g. "M1.1 Gross Income" as one node, not the whole module.</div>
+            </div>
+          </div>
+          <div class="ob-step">
+            <div class="ob-step-num">2</div>
+            <div>
+              <div class="ob-step-title">Set your exam date</div>
+              <div class="ob-step-desc">Go to Study Plan and enter your deadline. The app builds a day-by-day schedule automatically.</div>
+            </div>
+          </div>
+          <div class="ob-step">
+            <div class="ob-step-num">3</div>
+            <div>
+              <div class="ob-step-title">Do your first Study session</div>
+              <div class="ob-step-desc">Tap Study in the bottom bar. Walk through Orient → Read → Recall → Practice for your first node.</div>
+            </div>
+          </div>
+        </div>
+        <div class="ob-tip">A checklist will guide you through these steps — visible until all three are done.</div>`,
+    },
+  ],
+
+  /* ─────────────────────────────────────────────────
+     JOURNEY STATE
+  ───────────────────────────────────────────────── */
+  _getJourney() {
+    let j;
+    try { j = JSON.parse(localStorage.getItem(this._journeyKey) || '{}'); } catch(e) { j = {}; }
+    // Self-heal: if any node exists, the "upload" step is done — no matter which
+    // save path created it. Keeps the checklist from drifting out of sync.
+    try {
+      if (!j.uploaded && typeof nodeStore !== 'undefined' && nodeStore.getAll && nodeStore.getAll().length > 0) {
+        j.uploaded = true;
+      }
+    } catch(e) {}
+    return j;
+  },
+  _saveJourney(state) {
+    try { localStorage.setItem(this._journeyKey, JSON.stringify(state)); } catch(e) {}
+  },
+  _journeyComplete() {
+    const j = this._getJourney();
+    return j.uploaded && j.planSet && j.studied;
+  },
+
+  /* Mark individual journey steps */
+  markUploaded()  { const j = this._getJourney(); j.uploaded = true;  this._saveJourney(j); this._refreshChecklist(); },
+  markPlanSet()   { const j = this._getJourney(); j.planSet  = true;  this._saveJourney(j); this._refreshChecklist(); },
+  markStudied()   { const j = this._getJourney(); j.studied  = true;  this._saveJourney(j); this._refreshChecklist(); },
+
+  /* ─────────────────────────────────────────────────
+     ENTRY POINT
+  ───────────────────────────────────────────────── */
+  checkFirstLaunch() {
+    if (this._ran) return;
+    this._ran = true;
+    try {
+      const onboarded = localStorage.getItem(this._key);
+      if (!onboarded) {
+        this._showWelcome();
+      } else if (!this._journeyComplete()) {
+        // Returning user who hasn't finished setup
+        setTimeout(() => this._mountChecklist(), 800);
+      }
+    } catch(e) {
+      console.warn('[Onboarding] localStorage unavailable:', e.message);
+    }
+  },
+
+  /* ─────────────────────────────────────────────────
+     WELCOME SCREEN
+  ───────────────────────────────────────────────── */
+  _showWelcome() {
+    const overlay = document.createElement('div');
+    overlay.id = 'onboarding-overlay';
+    overlay.className = 'ob-overlay';
+    overlay.setAttribute('data-kn-overlay', '');
+    overlay.setAttribute('data-kn-close', '#ob-skip');
+    overlay.innerHTML = `
+      <div class="ob-welcome">
+        <div class="ob-logo">
+          <div class="ob-logo-mark">K</div>
+          <div class="ob-logo-text">KnowledgeNode</div>
+        </div>
+        <h1 class="ob-welcome-title">Study smarter.<br>Remember more.</h1>
+        <p class="ob-welcome-sub">An AI-powered study system built around how memory actually works.</p>
+        <div class="ob-choice-btns">
+          <button class="ob-btn-primary" id="ob-show-tour">🚀 Show me how it works</button>
+          <button class="ob-btn-secondary" id="ob-skip">⬡ I know what I'm doing — jump in</button>
+        </div>
+        <p class="ob-small">Prefer the details? <button id="ob-open-guide" style="background:none;border:none;padding:0;color:var(--accent);font:inherit;cursor:pointer;text-decoration:underline;">Read the full guide</button> — also in Settings anytime.</p>
+      </div>`;
+    document.body.appendChild(overlay);
+
+    document.getElementById('ob-show-tour').addEventListener('click', () => {
+      overlay.remove();
+      this._currentSlide = 0;
+      this._showSlide();
+    });
+    document.getElementById('ob-open-guide')?.addEventListener('click', () => {
+      if (typeof Guide !== 'undefined') Guide.open();
+    });
+    document.getElementById('ob-skip').addEventListener('click', () => {
+      overlay.remove();
+      this._markDone();
+      this._mountChecklist();
+      App.navigateTo('upload');
+    });
+  },
+
+  /* ─────────────────────────────────────────────────
+     3-SLIDE TOUR
+  ───────────────────────────────────────────────── */
+  _showSlide() {
+    document.getElementById('onboarding-overlay')?.remove();
+    const slide  = this._slides[this._currentSlide];
+    const total  = this._slides.length;
+    const isLast = this._currentSlide === total - 1;
+    const dots   = this._slides.map((_, i) =>
+      `<div class="ob-dot ${i === this._currentSlide ? 'active' : ''}"></div>`
+    ).join('');
+
+    const overlay = document.createElement('div');
+    overlay.id = 'onboarding-overlay';
+    overlay.setAttribute('data-kn-overlay', '');
+    overlay.setAttribute('data-kn-close', '#ob-skip-tour');
+    overlay.className = 'ob-overlay';
+    overlay.innerHTML = `
+      <div class="ob-slide">
+        <button class="ob-skip-link" id="ob-skip-tour">Skip</button>
+        <div class="ob-slide-icon">${slide.icon}</div>
+        <h2 class="ob-slide-title">${slide.title}</h2>
+        <p class="ob-slide-sub">${slide.subtitle}</p>
+        <div class="ob-slide-content">${slide.content}</div>
+        <div class="ob-dots">${dots}</div>
+        <div class="ob-slide-nav">
+          ${this._currentSlide > 0
+            ? `<button class="ob-btn-ghost" id="ob-prev">← Back</button>`
+            : `<div></div>`}
+          <button class="ob-btn-primary" id="ob-next">
+            ${isLast ? "Let's go →" : 'Next →'}
+          </button>
+        </div>
+      </div>`;
+    document.body.appendChild(overlay);
+
+    // Swipe support
+    let startX = 0;
+    overlay.addEventListener('touchstart', e => { startX = e.touches[0].clientX; }, { passive: true });
+    overlay.addEventListener('touchend',   e => {
+      const diff = startX - e.changedTouches[0].clientX;
+      if (Math.abs(diff) > 50) diff > 0 ? this._next() : this._prev();
+    });
+
+    document.getElementById('ob-next')?.addEventListener('click',     () => this._next());
+    document.getElementById('ob-prev')?.addEventListener('click',     () => this._prev());
+    document.getElementById('ob-skip-tour')?.addEventListener('click', () => {
+      overlay.remove();
+      this._markDone();
+      this._mountChecklist();
+      App.navigateTo('upload');
+    });
+  },
+
+  _next() {
+    document.getElementById('onboarding-overlay')?.remove();
+    if (this._currentSlide < this._slides.length - 1) {
+      this._currentSlide++;
+      this._showSlide();
+    } else {
+      this._markDone();
+      this._mountChecklist();
+      App.navigateTo('upload');
+    }
+  },
+  _prev() {
+    if (this._currentSlide > 0) {
+      this._currentSlide--;
+      document.getElementById('onboarding-overlay')?.remove();
+      this._showSlide();
+    }
+  },
+  _markDone() {
+    try { localStorage.setItem(this._key, '1'); } catch(e) {}
+  },
+
+  /* ─────────────────────────────────────────────────
+     PERSISTENT CHECKLIST BANNER
+     Mounts once, stays visible across all views
+     until all 3 journey steps are complete.
+  ───────────────────────────────────────────────── */
+  _checklistDismissed() {
+    try { return sessionStorage.getItem(this._dismissKey) === '1'; } catch (e) { return false; }
+  },
+
+  _mountChecklist() {
+    if (document.getElementById('ob-checklist')) return; // already mounted
+    if (this._journeyComplete()) return;
+    if (this._checklistDismissed()) return; // dismissed this session — stays closed until app reopened
+
+    const bar = document.createElement('div');
+    bar.id = 'ob-checklist';
+    bar.style.cssText = [
+      'position:fixed',
+      'bottom:calc(56px + env(safe-area-inset-bottom, 0px))', // sits above mobile nav
+      'left:0','right:0',
+      'z-index:500',
+      'background:var(--bg-raised,#1a1e2a)',
+      'border-top:1px solid var(--border,rgba(255,255,255,.08))',
+      'padding:12px 16px 10px',
+      'box-shadow:0 -4px 24px rgba(0,0,0,.35)',
+      'transition:transform .3s ease',
+    ].join(';');
+    document.body.appendChild(bar);
+    document.body.classList.add('has-checklist');
+    this._renderChecklist(bar);
+  },
+
+  _renderChecklist(bar) {
+    const j    = this._getJourney();
+    const done = (j.uploaded ? 1 : 0) + (j.planSet ? 1 : 0) + (j.studied ? 1 : 0);
+    const pct  = Math.round((done / 3) * 100);
+
+    const step = (flag, label, action, view) => {
+      const checked = !!flag;
+      return `
+        <button class="ob-cl-step ${checked ? 'done' : ''}" data-view="${view}" style="
+          display:flex;align-items:center;gap:8px;
+          background:${checked ? 'transparent' : 'var(--accent-soft,rgba(240,165,0,.08))'};
+          border:1px solid ${checked ? 'var(--border,rgba(255,255,255,.07))' : 'var(--accent-dim,rgba(240,165,0,.2))'};
+          border-radius:8px;padding:7px 10px;cursor:${checked ? 'default' : 'pointer'};
+          font-family:var(--font-ui,sans-serif);font-size:12px;font-weight:600;
+          color:${checked ? 'var(--text-muted,#6b7280)' : 'var(--text-primary,#e8eaf0)'};
+          text-align:left;flex:1;min-width:0;
+        ">
+          <span style="font-size:14px;flex-shrink:0;">${checked ? '✅' : '○'}</span>
+          <span style="white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">${label}</span>
+        </button>`;
+    };
+
+    bar.innerHTML = `
+      <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:8px;">
+        <span style="font-family:var(--font-mono,monospace);font-size:10px;font-weight:700;
+                     text-transform:uppercase;letter-spacing:.08em;color:var(--accent,#f0a500);">
+          Getting started — ${done}/3 done
+        </span>
+        <button id="ob-cl-dismiss" style="
+          background:transparent;border:none;
+          color:var(--text-muted,#6b7280);font-size:18px;
+          cursor:pointer;padding:0 4px;line-height:1;
+        " title="Dismiss">×</button>
+      </div>
+      <div style="height:3px;background:var(--border,rgba(255,255,255,.07));border-radius:2px;margin-bottom:10px;overflow:hidden;">
+        <div style="height:100%;width:${pct}%;background:var(--accent,#f0a500);border-radius:2px;transition:width .4s;"></div>
+      </div>
+      <div style="display:flex;gap:7px;flex-wrap:wrap;">
+        ${step(j.uploaded, '① Upload notes',     'go-upload',   'upload')}
+        ${step(j.planSet,  '② Set exam date',    'go-plan',     'studyplan')}
+        ${step(j.studied,  '③ First study session','go-study',  'guided')}
+      </div>`;
+
+    // Step buttons — navigate and highlight
+    bar.querySelectorAll('.ob-cl-step:not(.done)').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const view = btn.dataset.view;
+        if (view) App.navigateTo(view);
+        this._pulseNav(view);
+      });
+    });
+
+    // Dismiss — stays closed for the rest of this session (returns next app open).
+    document.getElementById('ob-cl-dismiss')?.addEventListener('click', () => {
+      try { sessionStorage.setItem(this._dismissKey, '1'); } catch (e) {}
+      bar.style.transform = 'translateY(120%)';
+      document.body.classList.remove('has-checklist');
+      setTimeout(() => bar.remove(), 320);
+    });
+  },
+
+  _refreshChecklist() {
+    const bar = document.getElementById('ob-checklist');
+    if (!bar) {
+      if (!this._journeyComplete()) this._mountChecklist();
+      return;
+    }
+    if (this._journeyComplete()) {
+      // All done — celebrate and remove
+      bar.innerHTML = `
+        <div style="display:flex;align-items:center;justify-content:center;gap:10px;padding:4px 0;">
+          <span style="font-size:22px;">🎉</span>
+          <span style="font-family:var(--font-ui,sans-serif);font-size:14px;font-weight:700;
+                       color:var(--text-primary,#e8eaf0);">
+            Setup complete — you're ready to study!
+          </span>
+        </div>`;
+      setTimeout(() => {
+        bar.style.transition = 'transform .4s ease, opacity .4s ease';
+        bar.style.transform = 'translateY(120%)';
+        bar.style.opacity = '0';
+        document.body.classList.remove('has-checklist');
+        setTimeout(() => bar.remove(), 420);
+      }, 2000);
+    } else {
+      this._renderChecklist(bar);
+    }
+  },
+
+  _pulseNav(view) {
+    const btn = document.querySelector(`.mobile-nav-btn[data-view="${view}"]`)
+             || document.querySelector(`.nav-item[data-view="${view}"]`);
+    if (!btn) return;
+    btn.style.animation = 'pulse-accent 1.2s ease 3';
+    setTimeout(() => { btn.style.animation = ''; }, 3600);
+  },
+
+  /* ─────────────────────────────────────────────────
+     PUBLIC
+  ───────────────────────────────────────────────── */
+  showTour() {
+    this._currentSlide = 0;
+    this._showSlide();
+  },
+  reset() {
+    try {
+      localStorage.removeItem(this._key);
+      localStorage.removeItem(this._journeyKey);
+    } catch(e) {}
+    this._ran = false;
+    document.getElementById('ob-checklist')?.remove();
+  },
+};

--- a/knowledgenode/www/js/ui/PastPaperDrill.js
+++ b/knowledgenode/www/js/ui/PastPaperDrill.js
@@ -1,0 +1,97 @@
+/**
+ * PastPaperDrill.js — practice the REAL questions extracted from uploaded
+ * past exam papers.
+ *
+ * Analysing a paper (UploadView → Past Exam Paper) stores each paper's
+ * example questions with model answers per subject. Until now they only
+ * steered question *generation*; this drill replays the authentic questions
+ * themselves: answer → reveal the model answer → self-mark. No AI credits
+ * needed — everything comes from the stored analysis, so it works offline.
+ */
+const PastPaperDrill = {
+  _qs: [], _i: 0, _right: 0, _subject: '',
+
+  _key(subject) { return 'kn_exam_style_' + String(subject || '').toLowerCase().replace(/\s+/g, '_'); },
+
+  collect(subject) {
+    try {
+      const data = JSON.parse(localStorage.getItem(this._key(subject)) || '{"papers":[]}');
+      const out = [];
+      (data.papers || []).forEach(p => {
+        ((p.analysis && p.analysis.examQuestions) || []).forEach(q => {
+          if (q && q.question) out.push({
+            question: q.question, marks: q.marks || 0, type: q.type || '',
+            modelAnswer: q.modelAnswer || '', paper: p.name || 'Past paper',
+          });
+        });
+      });
+      return out;
+    } catch (e) { return []; }
+  },
+
+  count(subject) { return this.collect(subject).length; },
+
+  open(subject) {
+    const qs = this.collect(subject);
+    if (!qs.length) { if (window.Toast) Toast.info('No past-paper questions saved for this subject yet — upload a paper first.'); return; }
+    // shuffle
+    for (let i = qs.length - 1; i > 0; i--) { const j = Math.floor(Math.random() * (i + 1)); [qs[i], qs[j]] = [qs[j], qs[i]]; }
+    this._qs = qs; this._i = 0; this._right = 0; this._subject = subject;
+    this._render();
+  },
+
+  _esc(s) { return String(s == null ? '' : s).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c])); },
+
+  _render() {
+    if (this._i >= this._qs.length) return this._summary();
+    const q = this._qs[this._i];
+    Modal.open(
+      '<div style="font-family:var(--font-mono);font-size:10px;letter-spacing:.08em;text-transform:uppercase;color:var(--accent);margin-bottom:6px;">📝 Past Paper Practice — ' + this._esc(this._subject) + '</div>'
+      + '<div style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);margin-bottom:14px;">Question ' + (this._i + 1) + ' of ' + this._qs.length
+      + ' · from “' + this._esc(q.paper) + '”' + (q.marks ? ' · ' + q.marks + ' marks' : '') + (q.type ? ' · ' + this._esc(q.type) : '') + '</div>'
+      + '<div style="font-family:var(--font-body);font-size:15px;line-height:1.65;color:var(--text-primary);background:var(--bg-raised);border:1px solid var(--border);border-radius:var(--radius-md);padding:14px 16px;margin-bottom:14px;">' + (window.KNText ? KNText.html(q.question) : this._esc(q.question)) + '</div>'
+      + '<textarea id="ppd-answer" class="config-input" rows="5" style="resize:vertical;touch-action:pan-y;margin-bottom:12px;" placeholder="Write your answer as you would in the exam…"></textarea>'
+      + '<div id="ppd-reveal-zone"></div>'
+      + '<div style="display:flex;gap:8px;">'
+      + '<button class="btn-primary" id="ppd-reveal" style="flex:1;justify-content:center;">Reveal model answer</button>'
+      + '<button class="btn-secondary" onclick="Modal.close()">Stop</button>'
+      + '</div>'
+    );
+    setTimeout(() => {
+      document.getElementById('ppd-reveal')?.addEventListener('click', () => {
+        const zone = document.getElementById('ppd-reveal-zone');
+        if (!zone) return;
+        zone.innerHTML =
+          '<div style="font-family:var(--font-mono);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--green);margin-bottom:6px;">✓ Model answer</div>'
+          + '<div style="font-family:var(--font-body);font-size:14px;line-height:1.65;color:var(--text-primary);background:var(--green-dim);border:1px solid rgba(52,199,123,0.25);border-radius:var(--radius-md);padding:12px 14px;margin-bottom:12px;">' + (window.KNText ? KNText.html(this._qs[this._i].modelAnswer || 'No model answer captured for this question.') : this._esc(this._qs[this._i].modelAnswer || '')) + '</div>'
+          + '<p style="font-family:var(--font-ui);font-size:13px;font-weight:600;margin-bottom:8px;">How did you do?</p>'
+          + '<div style="display:flex;gap:8px;margin-bottom:12px;">'
+          + '<button class="btn-secondary" id="ppd-right" style="flex:1;justify-content:center;">✓ Got it</button>'
+          + '<button class="btn-secondary" id="ppd-wrong" style="flex:1;justify-content:center;">✗ Missed it</button>'
+          + '</div>';
+        const btn = document.getElementById('ppd-reveal'); if (btn) btn.style.display = 'none';
+        document.getElementById('ppd-right')?.addEventListener('click', () => { this._right++; this._i++; this._render(); });
+        document.getElementById('ppd-wrong')?.addEventListener('click', () => { this._i++; this._render(); });
+      });
+    }, 0);
+  },
+
+  _summary() {
+    const n = this._qs.length, pct = n ? Math.round((this._right / n) * 100) : 0;
+    const color = pct >= 80 ? 'var(--green)' : pct >= 50 ? 'var(--accent)' : 'var(--red)';
+    const msg = pct >= 80 ? 'Exam-ready on these. Re-drill in a few days to lock it in.'
+      : pct >= 50 ? 'Solid base — study the model answers you missed, then drill again.'
+      : 'These are your highest-value study targets — the examiner literally asked them.';
+    Modal.open(
+      '<div style="text-align:center;padding:8px 0;">'
+      + '<div style="font-family:var(--font-mono);font-size:10px;letter-spacing:.08em;text-transform:uppercase;color:var(--accent);margin-bottom:10px;">📝 Past Paper Practice — done</div>'
+      + '<div style="font-family:var(--font-mono);font-size:44px;font-weight:800;color:' + color + ';">' + this._right + '/' + n + '</div>'
+      + '<p style="font-family:var(--font-body);font-size:14px;color:var(--text-primary);line-height:1.6;margin:12px 0 18px;">' + msg + '</p>'
+      + '<div style="display:flex;gap:8px;">'
+      + '<button class="btn-primary" style="flex:1;justify-content:center;" onclick="Modal.close();PastPaperDrill.open(PastPaperDrill._subject)">Practice again</button>'
+      + '<button class="btn-secondary" onclick="Modal.close()">Done</button>'
+      + '</div></div>'
+    );
+  },
+};
+if (typeof window !== 'undefined') window.PastPaperDrill = PastPaperDrill;

--- a/knowledgenode/www/js/ui/Paywall.js
+++ b/knowledgenode/www/js/ui/Paywall.js
@@ -1,0 +1,161 @@
+/**
+ * Paywall.js — subscription gate for the managed-AI build (RevenueCat + Play Billing).
+ *
+ * SECURITY MODEL: the entitlement state here is a UX HINT only. The proxy is the
+ * real authority — it independently asks RevenueCat whether this user has an
+ * active entitlement before spending the API key, and returns 402 if not. So a
+ * tampered client cannot get free AI; it can only mis-draw its own buttons.
+ *
+ * Requires the RevenueCat Capacitor plugin (@revenuecat/purchases-capacitor) in
+ * the Android build. On web / when the plugin is absent, the app still runs but
+ * purchases are unavailable (init no-ops). See SETUP_PAYWALL.md.
+ */
+const Paywall = {
+  _entitled: false,
+  _userId: null,
+  _ready: false,
+
+  _entId() { return (typeof AppConfig !== 'undefined' && AppConfig.ENTITLEMENT_ID) || 'premium'; },
+
+  /** RevenueCat plugin handle, if present (Capacitor native or a web shim). */
+  _rc() {
+    try {
+      if (typeof window === 'undefined') return null;
+      return (window.Capacitor && window.Capacitor.Plugins && window.Capacitor.Plugins.Purchases)
+          || window.Purchases || null;
+    } catch (e) { return null; }
+  },
+
+  _uuid() {
+    try { if (typeof crypto !== 'undefined' && crypto.randomUUID) return crypto.randomUUID(); } catch (e) {}
+    return Date.now().toString(36) + Math.random().toString(36).slice(2, 10);
+  },
+
+  /** Stable, anonymous per-install id. Sent to the proxy as x-app-user-id and
+   *  used as the RevenueCat appUserID so a subscription follows the install. */
+  userId() {
+    if (!this._userId) {
+      try { this._userId = localStorage.getItem('kn_app_user_id'); } catch (e) {}
+      if (!this._userId) {
+        this._userId = 'knu_' + this._uuid();
+        try { localStorage.setItem('kn_app_user_id', this._userId); } catch (e) {}
+      }
+    }
+    return this._userId;
+  },
+
+  isEntitled() { return this._entitled === true; },
+
+  async init() {
+    this.userId();
+    try { this._entitled = localStorage.getItem('kn_entitled_hint') === '1'; } catch (e) {}
+    const RC = this._rc();
+    const key = (typeof AppConfig !== 'undefined') ? AppConfig.REVENUECAT_PUBLIC_SDK_KEY : '';
+    if (RC && key && key !== 'goog_REPLACE_ME') {
+      try {
+        await RC.configure({ apiKey: key, appUserID: this.userId() });
+        await this.refresh();
+        try { RC.addListener && RC.addListener('customerInfoUpdate', (info) => this._apply(info)); } catch (e) {}
+      } catch (e) { console.warn('[Paywall] RevenueCat init failed:', e); }
+    } else if ((typeof AppConfig !== 'undefined' && AppConfig.MANAGED_ONLY) && (!RC || key === 'goog_REPLACE_ME')) {
+      console.warn('[Paywall] RevenueCat not configured (plugin missing or REVENUECAT_PUBLIC_SDK_KEY unset) — purchases disabled.');
+    }
+    this._ready = true;
+  },
+
+  async refresh() {
+    const RC = this._rc();
+    if (!RC) return this._entitled;
+    try { const r = await RC.getCustomerInfo(); this._apply((r && r.customerInfo) || r); }
+    catch (e) { console.warn('[Paywall] refresh failed:', e); }
+    return this._entitled;
+  },
+
+  /** Apply a RevenueCat customerInfo object to local state. Pure enough to test. */
+  _apply(info) {
+    const active = (info && info.entitlements && info.entitlements.active) || {};
+    const was = this._entitled;
+    this._entitled = !!active[this._entId()];
+    try { localStorage.setItem('kn_entitled_hint', this._entitled ? '1' : '0'); } catch (e) {}
+    if (was !== this._entitled && typeof document !== 'undefined') {
+      try { document.dispatchEvent(new CustomEvent('kn-entitlement-changed', { detail: { entitled: this._entitled } })); } catch (e) {}
+    }
+    return this._entitled;
+  },
+
+  /** Gate to call before an AI action. true = allowed; false = paywall shown. */
+  guard(reason) {
+    if (typeof AppConfig === 'undefined' || !AppConfig.MANAGED_ONLY) return true;
+    if (this._entitled) return true;
+    this.show(reason);
+    return false;
+  },
+
+  async purchaseCurrent() {
+    const RC = this._rc();
+    if (!RC) { this._toast('error', 'In-app purchases aren’t available on this device.'); return false; }
+    try {
+      const off = await RC.getOfferings();
+      const cur = (off && off.offerings && off.offerings.current) || (off && off.current) || null;
+      const pkg = cur && cur.availablePackages && cur.availablePackages[0];
+      if (!pkg) { this._toast('error', 'No subscription is available right now.'); return false; }
+      const r = await RC.purchasePackage({ aPackage: pkg });
+      this._apply((r && r.customerInfo) || r);
+      return this._entitled;
+    } catch (e) {
+      if (!/cancel/i.test((e && e.message) || '')) this._toast('error', 'Purchase failed: ' + ((e && e.message) || 'try again'));
+      return false;
+    }
+  },
+
+  async restore() {
+    const RC = this._rc();
+    if (!RC) return false;
+    try {
+      const r = await RC.restorePurchases();
+      this._apply((r && r.customerInfo) || r);
+      this._toast(this._entitled ? 'success' : 'info', this._entitled ? 'Subscription restored.' : 'No active subscription found.');
+    } catch (e) { this._toast('error', 'Restore failed.'); }
+    return this._entitled;
+  },
+
+  /** Render the upgrade screen. Uses the app's Modal if present. */
+  show(reason) {
+    if (typeof Modal === 'undefined' || !Modal.open) { this._toast('info', reason || 'A subscription is required.'); return; }
+    const esc = s => String(s == null ? '' : s).replace(/[&<>"]/g, c => ({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;' }[c]));
+    Modal.open(
+      '<div style="text-align:center;">'
+      + '<div style="font-size:34px;margin-bottom:8px;">⬡</div>'
+      + '<h2 style="font-family:var(--font-ui);font-size:20px;font-weight:800;margin-bottom:6px;">Unlock AI Study Tools</h2>'
+      + (reason ? '<p style="font-family:var(--font-body);font-size:13px;color:var(--text-secondary);margin-bottom:14px;">' + esc(reason) + '</p>' : '')
+      + '<ul style="text-align:left;display:inline-block;font-family:var(--font-body);font-size:13px;color:var(--text-secondary);line-height:1.8;margin:0 0 18px;padding-left:18px;">'
+      + '<li>Turn photos &amp; PDFs into structured notes</li>'
+      + '<li>Auto-generated questions, lectures &amp; slides</li>'
+      + '<li>AI tutor, grading, and study planning</li>'
+      + '</ul>'
+      + '<div style="display:flex;flex-direction:column;gap:8px;">'
+      + '<button class="btn-primary" id="pw-subscribe" style="justify-content:center;padding:13px;font-size:15px;">Subscribe</button>'
+      + '<button class="btn-secondary" id="pw-restore" style="justify-content:center;">Restore purchase</button>'
+      + '<button style="background:none;border:none;color:var(--text-muted);font-family:var(--font-mono);font-size:11px;cursor:pointer;margin-top:4px;" onclick="Modal.close()">Not now</button>'
+      + '</div></div>'
+    );
+    setTimeout(() => {
+      const sub = document.getElementById('pw-subscribe');
+      const rest = document.getElementById('pw-restore');
+      if (sub) sub.addEventListener('click', async () => {
+        sub.disabled = true; sub.textContent = 'Processing…';
+        const okBuy = await this.purchaseCurrent();
+        if (okBuy) { try { Modal.close(); } catch (e) {} this._toast('success', 'You’re subscribed — enjoy!'); }
+        else { sub.disabled = false; sub.textContent = 'Subscribe'; }
+      });
+      if (rest) rest.addEventListener('click', async () => {
+        const okR = await this.restore();
+        if (okR) { try { Modal.close(); } catch (e) {} }
+      });
+    }, 0);
+  },
+
+  _toast(kind, msg) { try { if (typeof Toast !== 'undefined' && Toast[kind]) return Toast[kind](msg); } catch (e) {} if (typeof console !== 'undefined') console.log('[Paywall] ' + msg); },
+};
+if (typeof window !== 'undefined') window.Paywall = Paywall;
+if (typeof module !== 'undefined' && module.exports) module.exports = Paywall;

--- a/knowledgenode/www/js/ui/PrintExport.js
+++ b/knowledgenode/www/js/ui/PrintExport.js
@@ -1,0 +1,756 @@
+/**
+ * PrintExport.js v3
+ *
+ * Export formats:
+ *  - PDF      → opens a styled print window → user clicks Save as PDF (browser native)
+ *  - Word     → generates a real .docx using pure JS (no server needed)
+ *  - HTML     → self-contained HTML file
+ *  - JSON     → raw data backup (for re-importing)
+ *
+ * Works for single nodes AND all nodes (multi-node PDF / Word).
+ */
+
+const PrintExport = {
+
+  // ─── Public: show format picker ───────────────────────
+
+  /** Show format picker for a single node */
+  showNodeExportMenu(node) {
+    Modal.open(`
+      <h2 style="font-family:var(--font-ui);font-size:20px;font-weight:800;margin-bottom:6px;">Export Node</h2>
+      <p style="font-family:var(--font-mono);font-size:12px;color:var(--text-muted);margin-bottom:24px;">${this._esc(node.title)}</p>
+
+      <div style="display:flex;flex-direction:column;gap:10px;">
+
+        <button class="export-format-btn" id="exp-pdf">
+          <span class="exp-icon">📄</span>
+          <div>
+            <div class="exp-title">PDF</div>
+            <div class="exp-desc">Opens print dialog — choose "Save as PDF". Best for sharing &amp; printing.</div>
+          </div>
+        </button>
+
+        <button class="export-format-btn" id="exp-word">
+          <span class="exp-icon">📝</span>
+          <div>
+            <div class="exp-title">Word Document (.docx)</div>
+            <div class="exp-desc">Downloads a .docx file you can open and edit in Microsoft Word.</div>
+          </div>
+        </button>
+
+        <button class="export-format-btn" id="exp-html">
+          <span class="exp-icon">🌐</span>
+          <div>
+            <div class="exp-title">HTML File</div>
+            <div class="exp-desc">Self-contained file viewable in any browser. Easy to share.</div>
+          </div>
+        </button>
+
+        <button class="export-format-btn" id="exp-json">
+          <span class="exp-icon">🗄</span>
+          <div>
+            <div class="exp-title">JSON Backup</div>
+            <div class="exp-desc">Raw data export. Use to back up or import into another device.</div>
+          </div>
+        </button>
+
+      </div>
+    `);
+
+    setTimeout(() => {
+      document.getElementById('exp-pdf') ?.addEventListener('click', () => { Modal.close(); PrintExport.printNode(node); });
+      document.getElementById('exp-word')?.addEventListener('click', () => { Modal.close(); PrintExport.exportWord(node); });
+      document.getElementById('exp-html')?.addEventListener('click', () => { Modal.close(); PrintExport.exportHTML(node); });
+      document.getElementById('exp-json')?.addEventListener('click', () => { Modal.close(); PrintExport.exportJSON(node); });
+    }, 0);
+  },
+
+  /** Show format picker for all nodes */
+  showAllExportMenu(nodes) {
+    if (!nodes.length) { Toast.info('No nodes to export.'); return; }
+
+    Modal.open(`
+      <h2 style="font-family:var(--font-ui);font-size:20px;font-weight:800;margin-bottom:6px;">Export All Nodes</h2>
+      <p style="font-family:var(--font-mono);font-size:12px;color:var(--text-muted);margin-bottom:24px;">${nodes.length} node${nodes.length > 1 ? 's' : ''}</p>
+
+      <div style="display:flex;flex-direction:column;gap:10px;">
+
+        <button class="export-format-btn" id="exp-all-pdf">
+          <span class="exp-icon">📄</span>
+          <div>
+            <div class="exp-title">PDF — All Nodes</div>
+            <div class="exp-desc">All nodes in one print-ready document. Each node starts on a new page.</div>
+          </div>
+        </button>
+
+        <button class="export-format-btn" id="exp-all-word">
+          <span class="exp-icon">📝</span>
+          <div>
+            <div class="exp-title">Word Document — All Nodes (.docx)</div>
+            <div class="exp-desc">All nodes in one editable Word file with headings and structure.</div>
+          </div>
+        </button>
+
+        <button class="export-format-btn" id="exp-all-json">
+          <span class="exp-icon">🗄</span>
+          <div>
+            <div class="exp-title">JSON Backup (all data)</div>
+            <div class="exp-desc">Full backup of all nodes. Use to restore or transfer to another device.</div>
+          </div>
+        </button>
+
+      </div>
+    `);
+
+    setTimeout(() => {
+      document.getElementById('exp-all-pdf') ?.addEventListener('click', () => { Modal.close(); PrintExport.printAllNodes(nodes); });
+      document.getElementById('exp-all-word')?.addEventListener('click', () => { Modal.close(); PrintExport.exportAllWord(nodes); });
+      document.getElementById('exp-all-json')?.addEventListener('click', () => { Modal.close(); PrintExport.exportAllJSON(nodes); });
+    }, 0);
+  },
+
+  // ─── PDF / Print ──────────────────────────────────────
+
+  printNode(node) {
+    this._openPrintWindow(this._buildPrintHTML(node), node.title);
+  },
+
+  printAllNodes(nodes) {
+    const body = nodes.map((n, i) => {
+      return (i > 0 ? '<div style="page-break-before:always;"></div>' : '') + this._buildPrintHTML(n);
+    }).join('');
+    this._openPrintWindow(body, 'KnowledgeNode — All Notes');
+  },
+
+  _openPrintWindow(bodyHTML, title) {
+    const html = `<!DOCTYPE html><html lang="en"><head>
+      <meta charset="UTF-8">
+      <title>${this._esc(title)} — KnowledgeNode</title>
+      <link href="https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;0,500;1,400&family=DM+Mono:wght@300;400;500&display=swap" rel="stylesheet">
+      <style>
+        *{box-sizing:border-box;margin:0;padding:0;}
+        body{font-family:'Lora',Georgia,serif;font-size:11pt;line-height:1.65;color:#111;background:#fff;padding:2.2cm 2.5cm;}
+        h1{font-size:19pt;font-weight:bold;margin-bottom:5pt;letter-spacing:-0.3pt;}
+        h2{font-size:10pt;font-weight:700;text-transform:uppercase;letter-spacing:1.2pt;
+           border-bottom:1.5pt solid #222;padding-bottom:4pt;margin:20pt 0 10pt;color:#222;}
+        .meta{font-family:'DM Mono','Courier New',monospace;font-size:9pt;color:#555;
+              margin-bottom:18pt;padding-bottom:10pt;border-bottom:2pt solid #111;}
+        .def{display:grid;grid-template-columns:155pt 1fr;gap:0;border-bottom:0.5pt solid #ddd;padding:7pt 0;font-size:10pt;}
+        .def-term{font-family:'DM Mono',monospace;font-weight:500;color:#222;padding-right:12pt;}
+        .formula{background:#f7f7f7;border-left:3pt solid #444;padding:9pt 13pt;margin-bottom:9pt;page-break-inside:avoid;}
+        .formula-expr{font-family:'DM Mono',monospace;font-size:11pt;margin-bottom:4pt;}
+        .formula-desc{font-size:9.5pt;color:#444;font-style:italic;}
+        .formula-con{font-size:9pt;color:#666;margin-top:3pt;font-family:'DM Mono',monospace;}
+        .step{display:flex;gap:10pt;margin-bottom:6pt;font-size:10pt;page-break-inside:avoid;}
+        .step-num{font-weight:700;min-width:16pt;color:#333;}
+        .mistake{border:0.5pt solid #ddd;background:#fefefe;padding:7pt 11pt;margin-bottom:7pt;font-size:10pt;page-break-inside:avoid;}
+        .mistake::before{content:'⚠  ';}
+        .summary{background:#f9f9f9;border:0.5pt solid #ccc;border-left:3pt solid #888;padding:13pt;font-size:10.5pt;line-height:1.75;}
+        .user-notes{background:#f5f8ff;border:0.5pt solid #b8cce4;border-left:3pt solid #4472c4;padding:13pt;font-size:10.5pt;white-space:pre-wrap;line-height:1.7;}
+        .question{border:0.5pt solid #ccc;padding:9pt 13pt;margin-bottom:9pt;page-break-inside:avoid;font-size:10pt;}
+        .q-label{font-family:'DM Mono',monospace;font-size:8pt;text-transform:uppercase;letter-spacing:0.5pt;color:#888;margin-bottom:4pt;}
+        .q-answer{color:#555;font-style:italic;border-top:0.5pt solid #ddd;padding-top:7pt;margin-top:7pt;}
+        @media print{body{padding:0;}@page{margin:2cm;size:A4;}}
+      </style>
+    </head><body>
+      ${bodyHTML}
+      <script>window.onload=()=>{setTimeout(()=>{try{window.print();}catch(e){}},400);}<\/script>
+    </body></html>`;
+
+    // On Android the native print dialog (with proper system-back support) opens
+    // via KNFiles.print; window.open() would trap the user in a chrome-less WebView.
+    if (window.KNFiles) { KNFiles.print(html, title); return; }
+
+    const win = window.open('', '_blank');
+    if (!win) { Toast.error('Pop-up blocked. Allow pop-ups for this site and try again.'); return; }
+    win.document.write(html);
+    win.document.close();
+  },
+
+  // ─── Word (.docx) ─────────────────────────────────────
+  // Pure JS docx — uses the Open XML format directly (no library needed)
+  // Generates a proper .docx with headings, tables, paragraphs.
+
+  exportWord(node) {
+    const xml = this._buildDocxXML([node]);
+    this._downloadDocx(xml, this._safeFilename(node.title));
+    Toast.success(`"${node.title}" exported as Word document.`);
+  },
+
+  exportAllWord(nodes) {
+    const xml = this._buildDocxXML(nodes);
+    this._downloadDocx(xml, 'KnowledgeNode_All_Notes');
+    Toast.success(`${nodes.length} nodes exported as Word document.`);
+  },
+
+  _buildDocxXML(nodes) {
+    const esc = s => String(s || '')
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;').replace(/'/g, '&apos;');
+
+    const para = (text, style = 'Normal', bold = false, color = '000000') => {
+      const run = bold
+        ? `<w:r><w:rPr><w:b/><w:color w:val="${color}"/></w:rPr><w:t xml:space="preserve">${esc(text)}</w:t></w:r>`
+        : `<w:r><w:rPr><w:color w:val="${color}"/></w:rPr><w:t xml:space="preserve">${esc(text)}</w:t></w:r>`;
+      return `<w:p><w:pPr><w:pStyle w:val="${style}"/></w:pPr>${run}</w:p>`;
+    };
+
+    const heading1 = t => para(t, 'Heading1');
+    const heading2 = t => para(t, 'Heading2');
+    const heading3 = t => para(t, 'Heading3');
+    const normal   = t => para(t, 'Normal');
+    const mono     = t => `<w:p><w:pPr><w:pStyle w:val="Normal"/><w:shd w:val="clear" w:color="auto" w:fill="F5F5F5"/></w:pPr><w:r><w:rPr><w:rFonts w:ascii="Courier New" w:hAnsi="Courier New"/><w:sz w:val="20"/></w:rPr><w:t xml:space="preserve">${esc(t)}</w:t></w:r></w:p>`;
+    const spacer   = () => `<w:p><w:pPr><w:spacing w:after="120"/></w:pPr></w:p>`;
+    const pageBreak= () => `<w:p><w:r><w:br w:type="page"/></w:r></w:p>`;
+
+    const defTable = defs => {
+      if (!defs.length) return '';
+      const rows = defs.map(d => `
+        <w:tr>
+          <w:td><w:tcPr><w:tcW w:w="2800" w:type="dxa"/><w:shd w:val="clear" w:color="auto" w:fill="F5F5F5"/></w:tcPr>
+            <w:p><w:r><w:rPr><w:b/><w:rFonts w:ascii="Courier New" w:hAnsi="Courier New"/><w:sz w:val="20"/></w:rPr><w:t>${esc(d.term)}</w:t></w:r></w:p>
+          </w:td>
+          <w:td><w:tcPr><w:tcW w:w="5400" w:type="dxa"/></w:tcPr>
+            <w:p><w:r><w:t xml:space="preserve">${esc(d.description)}</w:t></w:r></w:p>
+          </w:td>
+        </w:tr>`).join('');
+      return `<w:tbl>
+        <w:tblPr><w:tblStyle w:val="TableGrid"/><w:tblW w:w="0" w:type="auto"/>
+          <w:tblBorders>
+            <w:top w:val="single" w:sz="4" w:space="0" w:color="CCCCCC"/>
+            <w:left w:val="none"/><w:bottom w:val="single" w:sz="4" w:space="0" w:color="CCCCCC"/>
+            <w:right w:val="none"/>
+            <w:insideH w:val="single" w:sz="4" w:space="0" w:color="DDDDDD"/>
+            <w:insideV w:val="none"/>
+          </w:tblBorders>
+        </w:tblPr>
+        <w:tblGrid><w:gridCol w:w="2800"/><w:gridCol w:w="5400"/></w:tblGrid>
+        ${rows}
+      </w:tbl>`;
+    };
+
+    const body = nodes.map((node, ni) => {
+      const date = new Date(node.createdAt || Date.now()).toLocaleDateString('en-GB', { day:'numeric', month:'long', year:'numeric' });
+      const meta = [node.subject, node.chapter, date].filter(Boolean).join('  ·  ');
+
+      let parts = (ni > 0 ? pageBreak() : '') + heading1(node.title) + normal(meta) + spacer();
+
+      if (node.blocks?.length) {
+        // ── Modern blocks format ──────────────────────
+        node.blocks.forEach(b => {
+          switch (b.type) {
+            case 'prose':
+              if (b.title) parts += heading3(b.title);
+              parts += normal((b.html || '').replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim());
+              parts += spacer();
+              break;
+            case 'callout':
+              if (b.title) parts += heading3(b.title);
+              parts += `<w:p><w:pPr><w:shd w:val="clear" w:color="auto" w:fill="FEF9EC"/><w:pBdr><w:left w:val="single" w:sz="12" w:space="4" w:color="F0A500"/></w:pBdr></w:pPr><w:r><w:t xml:space="preserve">${esc((b.html || '').replace(/<[^>]+>/g, ' ').trim())}</w:t></w:r></w:p>`;
+              parts += spacer();
+              break;
+            case 'definition':
+              parts += heading2(b.title || 'Definitions');
+              if (b.items?.length) parts += defTable(b.items);
+              parts += spacer();
+              break;
+            case 'formula':
+              parts += heading2(b.title || 'Formulas');
+              (b.items || []).forEach(f => {
+                parts += mono(f.expression);
+                if (f.description) parts += normal(f.description);
+                if (f.constraints) parts += normal('Constraints: ' + f.constraints);
+                parts += spacer();
+              });
+              break;
+            case 'table':
+              parts += heading2(b.title || 'Table');
+              if (b.columns?.length && b.rows?.length) {
+                const cols = b.columns;
+                const colWidth = Math.floor(8200 / cols.length);
+                const headerRow = '<w:tr>' + cols.map(c =>
+                  `<w:td><w:tcPr><w:tcW w:w="${colWidth}" w:type="dxa"/><w:shd w:val="clear" w:color="auto" w:fill="F5F5F5"/></w:tcPr><w:p><w:r><w:rPr><w:b/></w:rPr><w:t xml:space="preserve">${esc(c)}</w:t></w:r></w:p></w:td>`
+                ).join('') + '</w:tr>';
+                const dataRows = (b.rows || []).map(row =>
+                  '<w:tr>' + cols.map((_, ci) =>
+                    `<w:td><w:tcPr><w:tcW w:w="${colWidth}" w:type="dxa"/></w:tcPr><w:p><w:r><w:t xml:space="preserve">${esc(row[ci] || '')}</w:t></w:r></w:p></w:td>`
+                  ).join('') + '</w:tr>'
+                ).join('');
+                parts += `<w:tbl><w:tblPr><w:tblStyle w:val="TableGrid"/><w:tblW w:w="0" w:type="auto"/></w:tblPr><w:tblGrid>${cols.map(() => `<w:gridCol w:w="${colWidth}"/>`).join('')}</w:tblGrid>${headerRow}${dataRows}</w:tbl>`;
+              }
+              parts += spacer();
+              break;
+            case 'procedure':
+              parts += heading2(b.title || 'Procedure');
+              if (b.appliesTo) parts += normal('Applies to: ' + b.appliesTo);
+              (b.steps || []).forEach((s, i) => {
+                parts += `<w:p><w:r><w:rPr><w:b/></w:rPr><w:t xml:space="preserve">${i+1}.  </w:t></w:r><w:r><w:t xml:space="preserve">${esc(s)}</w:t></w:r></w:p>`;
+              });
+              if (b.notes) parts += normal('Note: ' + b.notes);
+              parts += spacer();
+              break;
+            case 'flashcards':
+              parts += heading2(b.title || 'Flashcards');
+              (b.cards || []).forEach(c => {
+                parts += `<w:p><w:r><w:rPr><w:b/></w:rPr><w:t xml:space="preserve">${esc(c.front)}</w:t></w:r></w:p>`;
+                parts += `<w:p><w:r><w:rPr><w:color w:val="444444"/></w:rPr><w:t xml:space="preserve">→ ${esc(c.back)}</w:t></w:r></w:p>`;
+                parts += spacer();
+              });
+              break;
+            case 'quiz':
+              parts += `<w:p><w:r><w:rPr><w:b/></w:rPr><w:t xml:space="preserve">❓ ${esc(b.q || '')}</w:t></w:r></w:p>`;
+              (b.options || []).forEach((o, i) => {
+                const isAnswer = i === b.answer;
+                parts += `<w:p><w:r><w:rPr>${isAnswer ? '<w:color w:val="1E8C45"/>' : '<w:color w:val="555555"/>'}</w:rPr><w:t xml:space="preserve">${isAnswer ? '✓' : '○'} ${esc(o)}</w:t></w:r></w:p>`;
+              });
+              parts += spacer();
+              break;
+            default:
+              if (b.title) parts += normal('[Interactive: ' + b.title + ']');
+          }
+        });
+      } else {
+        // ── Legacy fields fallback ────────────────────
+        if (node.definitions?.length) {
+          parts += heading2('Key Definitions') + defTable(node.definitions) + spacer();
+        }
+        if (node.formulas?.length) {
+          parts += heading2('Formulas & Equations');
+          node.formulas.forEach(f => {
+            parts += mono(f.expression);
+            if (f.description)  parts += normal(f.description);
+            if (f.constraints)  parts += normal('Constraints: ' + f.constraints);
+            parts += spacer();
+          });
+        }
+        if (node.procedures?.length) {
+          parts += heading2('Procedures');
+          node.procedures.forEach(proc => {
+            if (proc.title) parts += heading3(proc.title);
+            if (proc.appliesTo) parts += normal('Applies to: ' + proc.appliesTo);
+            (proc.steps || []).forEach((s, i) => {
+              parts += `<w:p><w:r><w:rPr><w:b/></w:rPr><w:t xml:space="preserve">${i+1}.  </w:t></w:r><w:r><w:t xml:space="preserve">${esc(s)}</w:t></w:r></w:p>`;
+            });
+            if (proc.notes) parts += normal('Note: ' + proc.notes);
+            parts += spacer();
+          });
+        }
+        if (node.tables?.length) {
+          parts += heading2('Tables');
+          node.tables.forEach(tbl => {
+            if (tbl.title) parts += heading3(tbl.title);
+            if (tbl.columns?.length && tbl.rows?.length) {
+              const cols = tbl.columns;
+              const colWidth = Math.floor(8200 / cols.length);
+              const headerRow = '<w:tr>' + cols.map(c =>
+                `<w:td><w:tcPr><w:tcW w:w="${colWidth}" w:type="dxa"/><w:shd w:val="clear" w:color="auto" w:fill="F5F5F5"/></w:tcPr><w:p><w:r><w:rPr><w:b/></w:rPr><w:t xml:space="preserve">${esc(c)}</w:t></w:r></w:p></w:td>`
+              ).join('') + '</w:tr>';
+              const dataRows = (tbl.rows || []).map(row =>
+                '<w:tr>' + cols.map((_, ci) =>
+                  `<w:td><w:tcPr><w:tcW w:w="${colWidth}" w:type="dxa"/></w:tcPr><w:p><w:r><w:t xml:space="preserve">${esc(row[ci] || '')}</w:t></w:r></w:p></w:td>`
+                ).join('') + '</w:tr>'
+              ).join('');
+              parts += `<w:tbl><w:tblPr><w:tblStyle w:val="TableGrid"/><w:tblW w:w="0" w:type="auto"/></w:tblPr><w:tblGrid>${cols.map(() => `<w:gridCol w:w="${colWidth}"/>`).join('')}</w:tblGrid>${headerRow}${dataRows}</w:tbl>`;
+            }
+            parts += spacer();
+          });
+        }
+        if (node.commonMistakes?.length) {
+          parts += heading2('Common Mistakes');
+          node.commonMistakes.forEach(m => {
+            parts += `<w:p><w:r><w:rPr><w:color w:val="C0392B"/></w:rPr><w:t xml:space="preserve">⚠  ${esc(m)}</w:t></w:r></w:p>`;
+          });
+          parts += spacer();
+        }
+        if (node.summary) parts += heading2('Summary') + normal(node.summary) + spacer();
+      }
+
+      if (node.userNotes) {
+        parts += heading2('My Notes') + `<w:p><w:pPr><w:shd w:val="clear" w:color="auto" w:fill="EEF4FB"/></w:pPr><w:r><w:t xml:space="preserve">${esc(node.userNotes)}</w:t></w:r></w:p>` + spacer();
+      }
+
+      const recall = node.questions?.filter(q => q.type === 'recall')      || [];
+      const apply  = node.questions?.filter(q => q.type === 'application') || [];
+      if (recall.length || apply.length) {
+        parts += pageBreak() + heading2('Questions');
+        if (recall.length) {
+          parts += heading3('Recall Questions');
+          recall.forEach((q, i) => {
+            parts += `<w:p><w:r><w:rPr><w:b/></w:rPr><w:t xml:space="preserve">Q${i+1}: ${esc(q.question)}</w:t></w:r></w:p>`;
+            parts += `<w:p><w:r><w:rPr><w:i/><w:color w:val="555555"/></w:rPr><w:t xml:space="preserve">Answer: ${esc(q.answer)}</w:t></w:r></w:p>`;
+            parts += spacer();
+          });
+        }
+        if (apply.length) {
+          parts += heading3('Application Questions');
+          apply.forEach((q, i) => {
+            parts += `<w:p><w:r><w:rPr><w:b/></w:rPr><w:t xml:space="preserve">Q${i+1}: ${esc(q.question)}</w:t></w:r></w:p>`;
+            parts += `<w:p><w:r><w:rPr><w:i/><w:color w:val="555555"/></w:rPr><w:t xml:space="preserve">Answer: ${esc(q.answer)}</w:t></w:r></w:p>`;
+            parts += spacer();
+          });
+        }
+      }
+      return parts;
+    }).join('');
+
+    return body;
+  },
+
+  _downloadDocx(bodyXML, filename) {
+    // Minimal valid .docx (Office Open XML) built entirely in browser
+    const docXML = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+  xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    ${bodyXML}
+    <w:sectPr>
+      <w:pgSz w:w="11906" w:h="16838"/>
+      <w:pgMar w:top="1134" w:right="1134" w:bottom="1134" w:left="1134" w:header="709" w:footer="709" w:gutter="0"/>
+    </w:sectPr>
+  </w:body>
+</w:document>`;
+
+    const stylesXML = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+          xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:docDefaults>
+    <w:rPrDefault><w:rPr>
+      <w:rFonts w:ascii="Calibri" w:hAnsi="Calibri" w:cs="Calibri"/>
+      <w:sz w:val="22"/><w:szCs w:val="22"/>
+    </w:rPr></w:rPrDefault>
+  </w:docDefaults>
+  <w:style w:type="paragraph" w:styleId="Normal"><w:name w:val="Normal"/>
+    <w:rPr><w:sz w:val="22"/></w:rPr>
+    <w:pPr><w:spacing w:after="160" w:line="276" w:lineRule="auto"/></w:pPr>
+  </w:style>
+  <w:style w:type="paragraph" w:styleId="Heading1"><w:name w:val="heading 1"/>
+    <w:basedOn w:val="Normal"/>
+    <w:pPr><w:spacing w:before="240" w:after="120"/>
+      <w:pBdr><w:bottom w:val="single" w:sz="6" w:space="4" w:color="F0A500"/></w:pBdr>
+    </w:pPr>
+    <w:rPr><w:b/><w:sz w:val="36"/><w:color w:val="111111"/></w:rPr>
+  </w:style>
+  <w:style w:type="paragraph" w:styleId="Heading2"><w:name w:val="heading 2"/>
+    <w:basedOn w:val="Normal"/>
+    <w:pPr><w:spacing w:before="200" w:after="80"/></w:pPr>
+    <w:rPr><w:b/><w:sz w:val="24"/><w:color w:val="333333"/><w:caps/></w:rPr>
+  </w:style>
+  <w:style w:type="paragraph" w:styleId="Heading3"><w:name w:val="heading 3"/>
+    <w:basedOn w:val="Normal"/>
+    <w:pPr><w:spacing w:before="160" w:after="60"/></w:pPr>
+    <w:rPr><w:b/><w:sz w:val="22"/><w:color w:val="555555"/></w:rPr>
+  </w:style>
+  <w:style w:type="table" w:styleId="TableGrid"><w:name w:val="Table Grid"/>
+    <w:tblPr><w:tblBorders>
+      <w:top w:val="single" w:sz="4" w:space="0" w:color="auto"/>
+      <w:left w:val="single" w:sz="4" w:space="0" w:color="auto"/>
+      <w:bottom w:val="single" w:sz="4" w:space="0" w:color="auto"/>
+      <w:right w:val="single" w:sz="4" w:space="0" w:color="auto"/>
+      <w:insideH w:val="single" w:sz="4" w:space="0" w:color="auto"/>
+      <w:insideV w:val="single" w:sz="4" w:space="0" w:color="auto"/>
+    </w:tblBorders></w:tblPr>
+  </w:style>
+</w:styles>`;
+
+    const relsXML = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>
+</Relationships>`;
+
+    const appRelsXML = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>`;
+
+    const contentTypes = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+  <Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml"/>
+</Types>`;
+
+    // Build zip using a minimal zip writer (pure JS, no dependencies)
+    const zip = this._buildZip({
+      '[Content_Types].xml':      contentTypes,
+      '_rels/.rels':              appRelsXML,
+      'word/document.xml':        docXML,
+      'word/styles.xml':          stylesXML,
+      'word/_rels/document.xml.rels': relsXML,
+    });
+
+    this._download(`${filename}.docx`, zip, 'application/vnd.openxmlformats-officedocument.wordprocessingml.document');
+  },
+
+  // ─── HTML Export ──────────────────────────────────────
+
+  exportHTML(node) {
+    const body = this._buildPrintHTML(node);
+    const full = `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8">
+<title>${this._esc(node.title)}</title>
+<link href="https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;1,400&family=DM+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>body{font-family:'Lora',Georgia,serif;font-size:12pt;line-height:1.7;max-width:820px;margin:48px auto;padding:0 24px;color:#111;}</style>
+</head><body>${body}</body></html>`;
+    this._download(`${this._safeFilename(node.title)}.html`, full, 'text/html');
+    Toast.success('Node exported as HTML.');
+  },
+
+  // ─── JSON Export ──────────────────────────────────────
+
+  exportJSON(node) {
+    this._download(`${this._safeFilename(node.title)}.json`, JSON.stringify(node.toJSON(), null, 2), 'application/json');
+    Toast.success('Node exported as JSON backup.');
+  },
+
+  exportAllJSON(nodes) {
+    const data = JSON.stringify(nodes.map(n => n.toJSON()), null, 2);
+    this._download('KnowledgeNode_backup.json', data, 'application/json');
+    if (typeof BackupVault !== 'undefined') BackupVault.markFileBackup();
+    Toast.success(`${nodes.length} nodes exported as JSON backup.`);
+  },
+
+  // ─── Shared HTML builder ──────────────────────────────
+
+  _buildPrintHTML(node) {
+    const esc  = s => String(s || '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+    const date = new Date(node.createdAt || Date.now()).toLocaleDateString('en-GB', { day:'numeric', month:'long', year:'numeric' });
+
+    let contentHTML = '';
+
+    // ── Prefer blocks (modern format) ────────────────────
+    if (node.blocks?.length) {
+      node.blocks.forEach(b => {
+        switch (b.type) {
+          case 'prose':
+            contentHTML += '<div style="margin-bottom:14pt;">'
+              + (b.title ? '<h3 style="font-size:11pt;font-weight:700;margin-bottom:6pt;">' + esc(b.title) + '</h3>' : '')
+              + '<div style="font-size:10.5pt;line-height:1.7;">' + (b.html || '').replace(/<[^>]+>/g,' ').trim() + '</div></div>';
+            break;
+          case 'callout':
+            contentHTML += '<div style="border-left:3pt solid #f0a500;background:#fef9ec;padding:10pt 14pt;margin-bottom:12pt;font-size:10pt;line-height:1.6;">'
+              + (b.title ? '<strong>' + esc(b.title) + '</strong><br>' : '')
+              + (b.html || '').replace(/<[^>]+>/g,' ').trim() + '</div>';
+            break;
+          case 'definition':
+            contentHTML += '<h2>' + esc(b.title || 'Definitions') + '</h2>'
+              + (b.items || []).map(d =>
+                  '<div class="def"><div class="def-term">' + esc(d.term) + '</div>'
+                  + '<div>'
+                  + (d.examples ? '<div style="font-style:italic;color:#666;font-size:9.5pt;">Examples: ' + esc(d.examples) + '</div>' : '')
+                  + esc(d.description) + '</div></div>'
+                ).join('');
+            break;
+          case 'formula':
+            contentHTML += '<h2>' + esc(b.title || 'Formulas') + '</h2>'
+              + (b.items || []).map(f =>
+                  '<div class="formula"><div class="formula-expr">' + esc(f.expression) + '</div>'
+                  + (f.description ? '<div class="formula-desc">' + esc(f.description) + '</div>' : '')
+                  + (f.constraints ? '<div class="formula-con">Constraints: ' + esc(f.constraints) + '</div>' : '')
+                  + '</div>'
+                ).join('');
+            break;
+          case 'table':
+            contentHTML += '<h2>' + esc(b.title || 'Table') + '</h2>'
+              + '<div style="margin-bottom:16pt;">'
+              + '<table style="width:100%;border-collapse:collapse;font-size:10pt;">'
+              + (b.columns?.length ? '<thead><tr>' + b.columns.map(c => '<th style="border:1pt solid #ccc;background:#f5f5f5;padding:5pt 8pt;text-align:left;font-weight:700;">' + esc(c) + '</th>').join('') + '</tr></thead>' : '')
+              + '<tbody>' + (b.rows || []).map(row => '<tr>' + (b.columns || []).map((_, ci) => '<td style="border:1pt solid #ddd;padding:5pt 8pt;">' + esc(row[ci] || '') + '</td>').join('') + '</tr>').join('') + '</tbody>'
+              + '</table></div>';
+            break;
+          case 'procedure':
+            contentHTML += '<h2>' + esc(b.title || 'Procedure') + '</h2>'
+              + '<div style="margin-bottom:16pt;">'
+              + (b.appliesTo ? '<div style="font-size:9pt;color:#666;margin-bottom:6pt;">Applies to: ' + esc(b.appliesTo) + '</div>' : '')
+              + (b.steps || []).map((s, i) => '<div class="step"><span class="step-num">' + (i+1) + '.</span><span>' + esc(s) + '</span></div>').join('')
+              + (b.notes ? '<div style="font-size:9.5pt;color:#555;margin-top:5pt;font-style:italic;">Note: ' + esc(b.notes) + '</div>' : '')
+              + '</div>';
+            break;
+          case 'flashcards':
+            contentHTML += '<h2>' + esc(b.title || 'Flashcards') + '</h2>'
+              + (b.cards || []).map(c =>
+                  '<div style="border:1pt solid #ddd;border-radius:4pt;padding:8pt 12pt;margin-bottom:8pt;">'
+                  + '<div style="font-weight:700;font-size:10pt;margin-bottom:4pt;">' + esc(c.front) + '</div>'
+                  + '<div style="font-size:10pt;color:#444;border-top:0.5pt solid #eee;padding-top:4pt;">' + esc(c.back) + '</div>'
+                  + '</div>'
+                ).join('');
+            break;
+          case 'quiz':
+            contentHTML += '<div style="border:1pt solid #ddd;padding:10pt 14pt;margin-bottom:10pt;">'
+              + '<div style="font-weight:700;font-size:10pt;margin-bottom:6pt;">❓ ' + esc(b.q || '') + '</div>'
+              + (b.options || []).map((o, i) =>
+                  '<div style="font-size:10pt;padding:3pt 0;' + (i === b.answer ? 'color:#1a7a3c;font-weight:700;' : 'color:#555;') + '">'
+                  + (i === b.answer ? '✓ ' : '○ ') + esc(o) + '</div>'
+                ).join('')
+              + (b.fb ? '<div style="font-size:9.5pt;color:#666;margin-top:5pt;font-style:italic;">' + esc(b.fb) + '</div>' : '')
+              + '</div>';
+            break;
+          // code, calc, webpreview, match, diagram — print as description only
+          default:
+            if (b.title) contentHTML += '<div style="border:1pt solid #eee;border-radius:4pt;padding:8pt 12pt;margin-bottom:10pt;color:#888;font-size:9.5pt;font-style:italic;">[Interactive block: ' + esc(b.title) + ']</div>';
+        }
+      });
+    } else {
+      // ── Fallback: legacy fields ───────────────────────
+      contentHTML += node.definitions?.length ? '<h2>Key Definitions</h2>'
+        + node.definitions.map(d =>
+            '<div class="def"><div class="def-term">' + esc(d.term) + '</div>'
+            + '<div>' + (d.examples ? '<div style="font-style:italic;color:#666;font-size:9.5pt;">Examples: ' + esc(d.examples) + '</div>' : '') + esc(d.description) + '</div></div>'
+          ).join('') : '';
+      contentHTML += node.formulas?.length ? '<h2>Formulas &amp; Equations</h2>'
+        + node.formulas.map(f =>
+            '<div class="formula"><div class="formula-expr">' + esc(f.expression) + '</div>'
+            + (f.description ? '<div class="formula-desc">' + esc(f.description) + '</div>' : '')
+            + (f.constraints ? '<div class="formula-con">Constraints: ' + esc(f.constraints) + '</div>' : '')
+            + '</div>'
+          ).join('') : '';
+      contentHTML += node.procedures?.length ? '<h2>Procedures</h2>'
+        + node.procedures.map(proc =>
+            '<div style="margin-bottom:16pt;">'
+            + '<div style="font-weight:700;font-size:11pt;margin-bottom:4pt;">' + esc(proc.title || '') + '</div>'
+            + (proc.appliesTo ? '<div style="font-size:9pt;color:#666;margin-bottom:6pt;">Applies to: ' + esc(proc.appliesTo) + '</div>' : '')
+            + (proc.steps || []).map((s, i) => '<div class="step"><span class="step-num">' + (i+1) + '.</span><span>' + esc(s) + '</span></div>').join('')
+            + '</div>'
+          ).join('') : '';
+      contentHTML += node.tables?.length ? '<h2>Tables</h2>'
+        + node.tables.map(tbl =>
+            '<div style="margin-bottom:16pt;">'
+            + (tbl.title ? '<div style="font-weight:700;font-size:10.5pt;margin-bottom:6pt;">' + esc(tbl.title) + '</div>' : '')
+            + '<table style="width:100%;border-collapse:collapse;font-size:10pt;">'
+            + (tbl.columns?.length ? '<thead><tr>' + tbl.columns.map(c => '<th style="border:1pt solid #ccc;background:#f5f5f5;padding:5pt 8pt;text-align:left;font-weight:700;">' + esc(c) + '</th>').join('') + '</tr></thead>' : '')
+            + '<tbody>' + (tbl.rows || []).map(row => '<tr>' + (tbl.columns || []).map((_, ci) => '<td style="border:1pt solid #ddd;padding:5pt 8pt;">' + esc(row[ci] || '') + '</td>').join('') + '</tr>').join('') + '</tbody>'
+            + '</table></div>'
+          ).join('') : '';
+      contentHTML += node.commonMistakes?.length ? '<h2>Common Mistakes</h2>' + node.commonMistakes.map(m => '<div class="mistake">' + esc(m) + '</div>').join('') : '';
+      contentHTML += node.summary ? '<h2>Summary</h2><div class="summary">' + esc(node.summary) + '</div>' : '';
+    }
+
+    contentHTML += node.userNotes ? '<h2>My Notes</h2><div class="user-notes">' + esc(node.userNotes) + '</div>' : '';
+
+    const recall = node.questions?.filter(q => q.type === 'recall')      || [];
+    const apply  = node.questions?.filter(q => q.type === 'application') || [];
+    const questions = (recall.length || apply.length) ?
+      '<div style="page-break-before:always;"></div><h2>Questions</h2>'
+      + (recall.length ? '<h3 style="font-size:11pt;margin:14pt 0 8pt;">Recall Questions</h3>'
+          + recall.map((q, i) => '<div class="question"><div class="q-label">Recall ' + (i+1) + '</div><div>' + esc(q.question) + '</div><div class="q-answer"><strong>Answer:</strong> ' + esc(q.answer) + '</div></div>').join('') : '')
+      + (apply.length ? '<h3 style="font-size:11pt;margin:14pt 0 8pt;">Application Questions</h3>'
+          + apply.map((q, i) => '<div class="question"><div class="q-label">Application ' + (i+1) + '</div><div>' + esc(q.question) + '</div><div class="q-answer"><strong>Answer:</strong> ' + esc(q.answer) + '</div></div>').join('') : '') : '';
+
+    return '<h1>' + esc(node.title) + '</h1>'
+      + '<div class="meta">' + [node.subject, node.chapter, date, 'Mastery: ' + (node.masteryScore || 0) + '%'].filter(Boolean).join('  \xb7  ') + '</div>'
+      + contentHTML + questions;
+  },
+  // ─── Minimal ZIP writer (pure JS, no deps) ────────────
+
+  _buildZip(files) {
+    const enc   = new TextEncoder();
+    const parts = [];
+    const centralDir = [];
+    let offset = 0;
+
+    for (const [name, content] of Object.entries(files)) {
+      const nameBytes    = enc.encode(name);
+      const contentBytes = enc.encode(content);
+      const crc          = this._crc32(contentBytes);
+      const size         = contentBytes.length;
+
+      // Local file header
+      const local = new Uint8Array(30 + nameBytes.length + size);
+      const lv = new DataView(local.buffer);
+      lv.setUint32(0,  0x04034b50, true); // signature
+      lv.setUint16(4,  20,         true); // version needed
+      lv.setUint16(6,  0,          true); // flags
+      lv.setUint16(8,  0,          true); // compression (stored)
+      lv.setUint16(10, 0,          true); // mod time
+      lv.setUint16(12, 0,          true); // mod date
+      lv.setUint32(14, crc,        true); // crc32
+      lv.setUint32(18, size,       true); // compressed size
+      lv.setUint32(22, size,       true); // uncompressed size
+      lv.setUint16(26, nameBytes.length, true);
+      lv.setUint16(28, 0,          true); // extra length
+      local.set(nameBytes, 30);
+      local.set(contentBytes, 30 + nameBytes.length);
+      parts.push(local);
+
+      // Central directory entry
+      const cd = new Uint8Array(46 + nameBytes.length);
+      const cv = new DataView(cd.buffer);
+      cv.setUint32(0,  0x02014b50, true);
+      cv.setUint16(4,  20,         true);
+      cv.setUint16(6,  20,         true);
+      cv.setUint16(8,  0,          true);
+      cv.setUint16(10, 0,          true);
+      cv.setUint16(12, 0,          true);
+      cv.setUint16(14, 0,          true);
+      cv.setUint32(16, crc,        true);
+      cv.setUint32(20, size,       true);
+      cv.setUint32(24, size,       true);
+      cv.setUint16(28, nameBytes.length, true);
+      cv.setUint16(30, 0,          true);
+      cv.setUint16(32, 0,          true);
+      cv.setUint16(34, 0,          true);
+      cv.setUint16(36, 0,          true);
+      cv.setUint32(38, 0,          true);
+      cv.setUint32(42, offset,     true);
+      cd.set(nameBytes, 46);
+      centralDir.push(cd);
+
+      offset += local.length;
+    }
+
+    const cdBytes  = this._concat(centralDir);
+    const eocd     = new Uint8Array(22);
+    const ev       = new DataView(eocd.buffer);
+    ev.setUint32(0,  0x06054b50,      true);
+    ev.setUint16(4,  0,               true);
+    ev.setUint16(6,  0,               true);
+    ev.setUint16(8,  centralDir.length, true);
+    ev.setUint16(10, centralDir.length, true);
+    ev.setUint32(12, cdBytes.length,  true);
+    ev.setUint32(16, offset,          true);
+    ev.setUint16(20, 0,               true);
+
+    return this._concat([...parts, cdBytes, eocd]);
+  },
+
+  _crc32(data) {
+    const table = this._crc32Table || (this._crc32Table = (() => {
+      const t = new Uint32Array(256);
+      for (let i = 0; i < 256; i++) {
+        let c = i;
+        for (let j = 0; j < 8; j++) c = (c & 1) ? (0xedb88320 ^ (c >>> 1)) : (c >>> 1);
+        t[i] = c;
+      }
+      return t;
+    })());
+    let crc = 0xffffffff;
+    for (const b of data) crc = table[(crc ^ b) & 0xff] ^ (crc >>> 8);
+    return (crc ^ 0xffffffff) >>> 0;
+  },
+
+  _concat(arrays) {
+    const total  = arrays.reduce((s, a) => s + a.length, 0);
+    const result = new Uint8Array(total);
+    let offset   = 0;
+    for (const a of arrays) { result.set(a, offset); offset += a.length; }
+    return result;
+  },
+
+  // ─── Helpers ──────────────────────────────────────────
+
+  _download(filename, content, type) {
+    const blob = new Blob([content], { type });
+    // Native save on Android (where <a download>/navigator.share don't work),
+    // browser link download otherwise — both handled by KNFiles.
+    if (window.KNFiles) { KNFiles.save(filename, type, blob); return; }
+
+    const url = URL.createObjectURL(blob);
+    const a   = Object.assign(document.createElement('a'), { href: url, download: filename, style: 'display:none' });
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
+  },
+
+  _safeFilename: name => String(name || 'export').replace(/[^a-z0-9_\-]/gi, '_').slice(0, 60),
+  _esc: s => String(s || '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'),
+};

--- a/knowledgenode/www/js/ui/ReactiveReshaper.js
+++ b/knowledgenode/www/js/ui/ReactiveReshaper.js
@@ -1,0 +1,134 @@
+/**
+ * ReactiveReshaper.js — Adaptation as a consequence of studying.
+ *
+ * The canvas reshapes itself in response to performance, with no
+ * "regenerate" button. When a learner struggles with a question during
+ * review or practice, the node grows a scaffold block (a simpler
+ * breakdown + an easier follow-up question) right where they're stuck.
+ * When they master it, the scaffold collapses away.
+ *
+ * A persistent, pulsing "reshaping" bar shows what the AI is doing in
+ * real time, so the adaptation is visible and felt.
+ *
+ * Hooks: ReviewView._rate() calls ReactiveReshaper.onRating(node, question, rating).
+ */
+const ReactiveReshaper = {
+  _bar: null,
+  _busy: false,
+
+  /* ─── Live reshaping bar ─────────────────────────── */
+  _ensureBar() {
+    if (this._bar && document.body.contains(this._bar)) return this._bar;
+    const bar = document.createElement('div');
+    bar.id = 'reshaping-bar';
+    bar.className = 'reshaping-bar hidden';
+    bar.innerHTML = '<span class="reshaping-orb">⬡</span><span class="reshaping-msg"></span>';
+    document.body.appendChild(bar);
+    this._bar = bar;
+    return bar;
+  },
+  show(msg) {
+    const bar = this._ensureBar();
+    bar.querySelector('.reshaping-msg').textContent = msg;
+    bar.classList.remove('hidden');
+  },
+  hide(delay = 0) {
+    if (!this._bar) return;
+    const doHide = () => this._bar && this._bar.classList.add('hidden');
+    if (delay) setTimeout(doHide, delay); else doHide();
+  },
+
+  /* ─── The reactive loop ──────────────────────────── */
+  /**
+   * Called after every rating. Decides whether to reshape.
+   * rating: 1=again 2=hard 3=good 4=easy
+   */
+  async onRating(node, question, rating) {
+    if (!node || !question) return;
+
+    // Track per-question performance so repeated struggle escalates.
+    question._perf = question._perf || { attempts: [], scaffolded: false };
+    question._perf.attempts.push(rating);
+    const recent = question._perf.attempts.slice(-3);
+    const avg = recent.reduce((a, b) => a + b, 0) / recent.length;
+
+    // MASTERED — collapse any scaffold that was added to help.
+    if (rating === 4 && question._perf.scaffoldBlockId) {
+      this._collapseScaffold(node, question);
+      this.show('Collapsing help for "' + this._short(question.question) + '" — mastered ✓');
+      nodeStore.save(node);
+      this.hide(1300);
+      return;
+    }
+
+    // STRUGGLING — only reshape on a clear struggle signal, and only once
+    // per question until they've moved on, to avoid spamming the AI.
+    const struggling = rating <= 2 && avg <= 2.2;
+    if (!struggling || question._perf.scaffolded || this._busy) return;
+
+    if (!AIService.hasApiKey()) {
+      // Without AI we can still flag the topic visually.
+      question._perf.flagged = true;
+      nodeStore.save(node);
+      this.show('Flagged "' + this._short(question.question) + '" as a focus area');
+      this.hide(1400);
+      return;
+    }
+
+    this._busy = true;
+    this.show('Expanding "' + this._short(question.question) + '" — you found this tricky');
+    try {
+      const res = await AIService.generateScaffold(node, question);
+      const scaffoldBlock = node.addBlock('callout', {
+        title: '✦ Simpler breakdown — added to help',
+        tone: 'tip',
+        html: this._esc(res.scaffold || '') + this._renderEasierQ(res.easierQuestion),
+        _scaffoldFor: question.id,
+      });
+      question._perf.scaffolded = true;
+      question._perf.scaffoldBlockId = scaffoldBlock.id;
+
+      // Also add the easier question to the node so it surfaces in review.
+      if (res.easierQuestion?.question) {
+        const eq = {
+          id: KnowledgeNode._generateQuestionId(),
+          type: 'recall',
+          question: res.easierQuestion.question,
+          answer: res.easierQuestion.answer || '',
+          _scaffoldFor: question.id,
+        };
+        node.questions.push(eq);
+      }
+      nodeStore.save(node);
+      this.show('Added a simpler breakdown for "' + this._short(question.question) + '"');
+      this.hide(1600);
+      Toast.success('The canvas reshaped — a simpler breakdown was added to this node.');
+    } catch (e) {
+      this.show('Couldn\'t reshape — ' + (e.message || 'try again'));
+      this.hide(1800);
+    } finally {
+      this._busy = false;
+    }
+  },
+
+  _collapseScaffold(node, question) {
+    const bid = question._perf.scaffoldBlockId;
+    if (bid) node.removeBlock(bid);
+    // remove the easier auto-question too
+    node.questions = node.questions.filter(q => q._scaffoldFor !== question.id || q.id === question.id);
+    question._perf.scaffolded = false;
+    question._perf.scaffoldBlockId = null;
+  },
+
+  _renderEasierQ(eq) {
+    if (!eq?.question) return '';
+    return '<div style="margin-top:10px;padding-top:10px;border-top:1px dashed var(--border);">'
+      + '<div style="font-size:12px;color:var(--accent);font-weight:600;margin-bottom:4px;">Try this easier one:</div>'
+      + '<div style="font-size:13.5px;">' + this._esc(eq.question) + '</div>'
+      + '<details style="margin-top:6px;"><summary style="font-size:12px;color:var(--text-muted);cursor:pointer;">Show answer</summary>'
+      + '<div style="font-size:13px;color:var(--text-secondary);margin-top:4px;">' + this._esc(eq.answer || '') + '</div></details></div>';
+  },
+
+  _short(s) { s = String(s || ''); return s.length > 42 ? s.slice(0, 40) + '…' : s; },
+  _esc(s) { return String(s ?? '').replace(/[&<>"]/g, c => ({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;' }[c])); },
+};

--- a/knowledgenode/www/js/ui/ReviewView.js
+++ b/knowledgenode/www/js/ui/ReviewView.js
@@ -1,0 +1,649 @@
+/**
+ * ReviewView.js — Final AI-powered study session
+ *
+ * Every card has:
+ *  - "Get a hint"       → AI gives a nudge without revealing the answer
+ *  - "Explain this"     → AI explains the concept after reveal
+ *  - "Follow-up Q"      → AI generates a fresh related question on the fly
+ *  - "I don't get it"   → AI tries a completely different explanation angle
+ *
+ * The session feels like studying with a teacher, not flipping flashcards.
+ */
+const ReviewView = {
+  _session:    [],
+  _index:      0,
+  _inSession:  false,
+  _revealed:   false,
+  _stats:      { again:0, hard:0, good:0, easy:0 },
+  _aiPending:  false,
+
+  init() {
+    document.getElementById('reveal-btn')
+      .addEventListener('click', () => this._reveal());
+    document.getElementById('skip-btn')
+      .addEventListener('click', () => this._skip());
+    document.querySelectorAll('.rating-btn').forEach(btn =>
+      btn.addEventListener('click', () => this._rate(parseInt(btn.dataset.rating))));
+    document.getElementById('review-again-btn')
+      .addEventListener('click', () => { this._inSession = false; this.refresh(); });
+  },
+
+  refresh() {
+    // A nodeStore "change" event fires on every rating (we save the node to
+    // record it). Do NOT tear down an active review session when that happens —
+    // only (re)build the filter UI when no session is running.
+    if (this._inSession) return;
+    this._hideAll();
+    this._renderFilterUI();
+  },
+
+  _hideAll() {
+    ['review-container','review-complete','review-empty'].forEach(id =>
+      document.getElementById(id).classList.add('hidden'));
+  },
+
+  /* ─── FILTER UI ─────────────────────────────────── */
+  _renderFilterUI() {
+    const allNodes = nodeStore.getAll().filter(n => n.processingStatus === 'ready');
+    const filterEl = document.getElementById('review-filter-panel');
+
+    if (!allNodes.length) {
+      filterEl.style.display = 'none';
+      const emptyEl = document.getElementById('review-empty');
+      if (emptyEl) emptyEl.style.display = 'flex';
+      return;
+    }
+
+    const emptyEl2 = document.getElementById('review-empty');
+    if (emptyEl2) emptyEl2.style.display = 'none';
+    // Single pass — avoids 5 separate loops (4 reduce + 1 map) and multiple
+    // dueQuestions() SRS scans. Inline the due check to avoid creating arrays.
+    let totalQs = 0, dueQs = 0, newQs = 0, weakCount = 0;
+    const now = Date.now(), subjectSet = new Set();
+    for (const n of allNodes) {
+      totalQs  += n.questions.length;
+      weakCount += n.weakQuestions?.length || 0;
+      if (n.subject) subjectSet.add(n.subject);
+      for (const q of n.questions) {
+        const srs = n.srsState[q.id];
+        if (!srs || srs.repetitions === 0) newQs++;
+        else if (srs.nextReview <= now)     dueQs++;
+      }
+    }
+    const subjects = Array.from(subjectSet);
+    // How many NEW cards today's Due session will actually introduce (paced).
+    const newToday = this._newTodayCount(allNodes);
+    const dueLabel = (d, n) => {
+      const parts = [];
+      if (d > 0) parts.push(d + ' due');
+      if (n > 0) parts.push(n + ' new');
+      return parts.length ? 'Start Session — ' + parts.join(' + ') : 'Start Session';
+    };
+
+    filterEl.style.display = 'block';
+    filterEl.innerHTML = `
+      <div class="review-filter-card">
+        <div class="notes-section-title" style="margin-bottom:16px;">Study Session</div>
+        <div class="review-stats-row">
+          <div class="review-stat"><span class="review-stat-val">${totalQs}</span><span class="review-stat-key">Cards</span></div>
+          <div class="review-stat accent"><span class="review-stat-val">${dueQs}</span><span class="review-stat-key">Due</span></div>
+          <div class="review-stat" style="color:var(--blue,#4f9cf9);"><span class="review-stat-val">${newQs}</span><span class="review-stat-key">New</span></div>
+          <div class="review-stat"><span class="review-stat-val">${allNodes.length}</span><span class="review-stat-key">Nodes</span></div>
+        </div>
+
+        <div style="margin-bottom:16px;">
+          <label class="config-label">Mode</label>
+          <div class="review-mode-toggle">
+            <button class="mode-btn active" id="mode-due">Today ${(dueQs+newToday)>0?`(${dueQs+newToday})`:''}</button>
+            <button class="mode-btn" id="mode-all">All Cards (${totalQs})</button>
+            <button class="mode-btn" id="mode-weak">🎯 Weak Spots${weakCount>0?` (${weakCount})`:''}</button>
+          </div>
+          ${newToday>0?`<p style="font-family:var(--font-mono);font-size:10px;color:var(--text-muted);margin:8px 2px 0;">Today mixes ${dueQs>0?`${dueQs} review${dueQs===1?'':'s'} with `:''}${newToday} new card${newToday===1?'':''} — paced so new material never floods you.</p>`:''}
+        </div>
+
+        ${subjects.length > 1 ? `
+        <div style="margin-bottom:16px;">
+          <label class="config-label">Subject</label>
+          <select id="review-subject-filter" class="config-select">
+            <option value="">All subjects</option>
+            ${subjects.map(s=>`<option value="${s}">${s}</option>`).join('')}
+          </select>
+        </div>` : ''}
+
+        <!-- AI session settings -->
+        <div style="margin-bottom:20px;padding:14px 16px;background:var(--accent-soft);border:1px solid var(--accent-dim);border-radius:var(--radius-md);">
+          <div style="font-family:var(--font-ui);font-size:12px;font-weight:700;color:var(--accent);margin-bottom:8px;">⬡ AI Study Mode</div>
+          <label style="display:flex;align-items:center;gap:10px;cursor:pointer;">
+            <input type="checkbox" id="ai-mode-toggle" ${AIService.hasApiKey()?'checked':''} style="accent-color:var(--accent);width:16px;height:16px;" ${!AIService.hasApiKey()?'disabled':''}>
+            <span style="font-family:var(--font-body);font-size:13px;color:var(--text-secondary);">
+              ${AIService.hasApiKey()
+                ? 'AI hints, explanations &amp; follow-up questions enabled'
+                : 'Configure AI in Settings to enable AI study mode'}
+            </span>
+          </label>
+        </div>
+
+        <button class="btn-primary" id="start-review-btn" style="width:100%;justify-content:center;padding:14px;" ${!totalQs?'disabled':''}>
+          ${(dueQs + newToday) > 0 ? dueLabel(dueQs, newToday) : `Start Session — ${totalQs} Cards`}
+        </button>
+      </div>`;
+
+    let mode = (dueQs + newToday) > 0 ? 'due' : 'all';
+    document.getElementById('mode-due').addEventListener('click', () => {
+      mode = 'due';
+      document.getElementById('mode-due').classList.add('active');
+      document.getElementById('mode-all').classList.remove('active');
+      document.getElementById('mode-weak').classList.remove('active');
+      document.getElementById('start-review-btn').textContent =
+        (dueQs + newToday) > 0 ? dueLabel(dueQs, newToday) : 'All caught up — switch to All to keep going';
+    });
+    document.getElementById('mode-all').addEventListener('click', () => {
+      mode = 'all';
+      document.getElementById('mode-all').classList.add('active');
+      document.getElementById('mode-due').classList.remove('active');
+      document.getElementById('mode-weak').classList.remove('active');
+      document.getElementById('start-review-btn').textContent = `Start Session — ${totalQs} Cards`;
+    });
+    document.getElementById('mode-weak').addEventListener('click', () => {
+      mode = 'weak';
+      document.getElementById('mode-weak').classList.add('active');
+      document.getElementById('mode-due').classList.remove('active');
+      document.getElementById('mode-all').classList.remove('active');
+      document.getElementById('start-review-btn').textContent =
+        weakCount > 0 ? `Start Session — ${weakCount} Weak Spots` : 'No weak spots yet — keep studying';
+    });
+    document.getElementById('start-review-btn').addEventListener('click', () => {
+      const subject = document.getElementById('review-subject-filter')?.value || '';
+      const aiMode  = document.getElementById('ai-mode-toggle')?.checked ?? false;
+      const filtered = subject ? allNodes.filter(n=>n.subject===subject) : allNodes;
+      this._startSession(filtered, mode, aiMode);
+    });
+  },
+
+  /* ─── SESSION ───────────────────────────────────── */
+  _startSession(nodes, mode, aiMode) {
+    const session = mode === 'weak'
+      ? this._buildWeakSession(nodes)
+      : (mode === 'due' && (nodes.some(n=>n.dueQuestions().length) || this._newTodayCount(nodes) > 0)
+        ? this._buildDueSession(nodes)
+        : this._buildAllSession(nodes));
+
+    if (!session.length) {
+      Toast.info('No questions found. Add notes and generate questions first.');
+      return;
+    }
+
+    this._session  = session;
+    this._index    = 0;
+    this._revealed = false;
+    this._aiMode   = aiMode;
+    this._stats    = { again:0, hard:0, good:0, easy:0 };
+    this._inSession = true;
+
+    document.getElementById('review-filter-panel').style.display = 'none';
+    document.getElementById('review-container').classList.remove('hidden');
+    this._renderCard();
+  },
+
+  /**
+   * Scale a built session by the student's current load lever and, on light
+   * days, prepend any deferred review items so backlog resurfaces. On deep
+   * days the full set plays (multiplier > 1 just means "don't trim").
+   *
+   * Review cards are SRS-backed: an unserved due card stays due and returns
+   * tomorrow on its own, so "deferring" here only controls how many you face
+   * in THIS sitting — nothing is lost.
+   */
+  _applyLoad(items) {
+    if (!items.length) return items;
+    let load = { level: 'normal' }, mult = 1;
+    try {
+      if (typeof LearnerState !== 'undefined') {
+        load = LearnerState.getSessionLoad();
+        mult = LearnerState.loadMultiplier();
+      }
+    } catch (_) {}
+
+    // Deep day: surface everything (the queue is the cap). Normal: as-is.
+    if (load.level !== 'light') return items;
+
+    // Light day: keep a focused slice; the rest simply stays due for next time.
+    const keep = Math.max(3, Math.round(items.length * mult)); // never below 3
+    if (keep >= items.length) return items;
+    return items.slice(0, keep);
+  },
+
+  _buildDueSession(nodes) {
+    const items = [];
+    nodes.forEach(node => {
+      node.dueQuestions().forEach(q => items.push({ node, question:q, state:node.srsState[q.id]||null }));
+    });
+    const due = this._applyLoad(this._shuffle(items));
+    // Blend in a capped batch of NEW cards so a fresh upload becomes a
+    // sustainable daily drip instead of a wall (cognitive-load management).
+    const fresh = this._pickNewCards(nodes);
+    if (fresh.length) return this._shuffle([...due, ...fresh]);
+    return due;
+  },
+
+  /** Up to today's remaining new-card budget, drawn from cards never rated. */
+  _pickNewCards(nodes) {
+    if (typeof NewCardPacer === 'undefined') return [];
+    const level = (typeof LearnerState !== 'undefined') ? (LearnerState.getSessionLoad().level || 'normal') : 'normal';
+    let budget = NewCardPacer.remainingToday(level);
+    if (budget <= 0) return [];
+    const fresh = [];
+    for (const node of this._shuffle([...nodes])) {
+      for (const q of node.questions) {
+        const s = node.srsState[q.id];
+        if (!s || (s.repetitions || 0) === 0) {
+          fresh.push({ node, question: q, state: s || null, _new: true });
+          if (fresh.length >= budget) return fresh;
+        }
+      }
+    }
+    return fresh;
+  },
+
+  /** How many new cards today's Due session would introduce (for labels). */
+  _newTodayCount(nodes) {
+    return this._pickNewCards(nodes).length;
+  },
+
+  /** Build a session from the questions the learner keeps getting wrong,
+   *  most-struggled first (highest struggle count, then lowest rating). */
+  _buildWeakSession(nodes) {
+    const items = [];
+    nodes.forEach(node => {
+      (node.weakQuestions || []).forEach(w => {
+        const q = node.questions.find(q => q.id === w.id);
+        if (q) items.push({ node, question: q, state: node.srsState[q.id] || null, _struggle: w });
+      });
+    });
+    // Hardest first: more misses and lower ratings come first
+    items.sort((a, b) => {
+      const countCmp = (b._struggle.count || 1) - (a._struggle.count || 1);
+      if (countCmp !== 0) return countCmp;
+      return (a._struggle.rating || 0) - (b._struggle.rating || 0);
+    });
+    return this._applyLoad(items);
+  },
+
+  _buildAllSession(nodes) {
+    const dueItems = [];
+    const newItems = [];
+
+    // Sort nodes by subject then chapter so new questions are grouped logically
+    const sorted = [...nodes].sort((a, b) => {
+      const subjectCmp = (a.subject || '').localeCompare(b.subject || '');
+      if (subjectCmp !== 0) return subjectCmp;
+      return (a.title || '').localeCompare(b.title || '', undefined, { numeric: true });
+    });
+
+    sorted.forEach(node => {
+      node.questions.forEach(q => {
+        const s = node.srsState[q.id];
+        const isNew = !s || s.repetitions === 0;
+        const item  = { node, question: q, state: s || null };
+        if (isNew) newItems.push(item);
+        else       dueItems.push(item);
+      });
+    });
+
+    // Due cards shuffled (spaced repetition order), new cards in chapter order
+    return this._applyLoad([...this._shuffle(dueItems), ...newItems]);
+  },
+
+  _shuffle(arr) {
+    for (let i=arr.length-1; i>0; i--) {
+      const j = Math.floor(Math.random()*(i+1));
+      [arr[i],arr[j]] = [arr[j],arr[i]];
+    }
+    return arr;
+  },
+
+  /* ─── CARD RENDER ───────────────────────────────── */
+  _renderCard() {
+    document.getElementById('review-leech')?.remove(); // clear any leech prompt
+    const item = this._session[this._index];
+    if (!item) { this._showComplete(); return; }
+    const { node, question } = item;
+
+    let _loadTag = '';
+    try {
+      if (typeof LearnerState !== 'undefined') {
+        const lvl = LearnerState.getSessionLoad().level;
+        if (lvl === 'light') _loadTag = '  ·  light session';
+        else if (lvl === 'deep') _loadTag = '  ·  deep session';
+      }
+    } catch (_) {}
+    document.getElementById('review-counter').textContent  = `Card ${this._index+1} of ${this._session.length}${_loadTag}`;
+    document.getElementById('review-node-tag').textContent = node.title;
+    document.getElementById('card-type-label').textContent = question.type==='recall' ? '🔁 Recall' : '🧩 Application';
+    document.getElementById('card-question').textContent   = window.KNText ? KNText.split(question.question) : question.question;
+    document.getElementById('card-answer').textContent     = window.KNText ? KNText.split(question.answer) : question.answer;
+    document.getElementById('flashcard-back').classList.add('hidden');
+    document.getElementById('reveal-btn').classList.remove('hidden');
+    document.getElementById('skip-btn').classList.remove('hidden');
+    this._revealed = false;
+
+    // Inject AI toolbar below question
+    this._renderAIToolbar(node, question);
+  },
+
+  _renderAIToolbar(node, question) {
+    // Remove old toolbar if exists
+    document.getElementById('review-ai-toolbar')?.remove();
+    document.getElementById('review-ai-panel')?.remove();
+
+    if (!this._aiMode) return;
+
+    const toolbar = document.createElement('div');
+    toolbar.id = 'review-ai-toolbar';
+    toolbar.style.cssText = 'display:flex;gap:6px;flex-wrap:wrap;margin:12px 0 0;';
+    toolbar.innerHTML =
+      '<button class="rai-btn" id="rai-hint">💡 Hint</button>'
+      + '<button class="rai-btn" id="rai-explain">📖 Explain</button>'
+      + '<button class="rai-btn" id="rai-followup">🔀 New Q</button>'
+      + '<button class="rai-btn" id="rai-struggle">🤔 I don\'t get it</button>';
+
+    // Insert after question
+    const qEl = document.getElementById('card-question');
+    qEl.parentNode.insertBefore(toolbar, qEl.nextSibling);
+
+    // AI response panel
+    const panel = document.createElement('div');
+    panel.id = 'review-ai-panel';
+    panel.style.cssText = 'display:none;margin-top:10px;background:var(--bg-raised);border:1px solid var(--border);border-left:3px solid var(--accent);border-radius:var(--radius-md);padding:14px 16px;';
+    toolbar.parentNode.insertBefore(panel, toolbar.nextSibling);
+
+    const showAI = async (promptFn, label) => {
+      if (this._aiPending) return;
+      this._aiPending = true;
+      // Dim all buttons
+      toolbar.querySelectorAll('.rai-btn').forEach(b => { b.disabled=true; b.style.opacity='0.5'; });
+      panel.style.display = 'block';
+      panel.innerHTML = '<div class="aif-loading"><div class="aif-dot"></div><div class="aif-dot"></div><div class="aif-dot"></div></div>';
+
+      try {
+        const ctx = LearnerContext.forReviewCard(node, question);
+        const response = await AIService._callWithFunction('chat',
+          [{ role:'user', content: ctx + '\n\n' + promptFn(question, node) }], 600);
+        panel.innerHTML =
+          '<div style="font-family:var(--font-mono);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:0.08em;color:var(--accent);margin-bottom:8px;">' + label + '</div>'
+          + response.split('\n').filter(l=>l.trim())
+              .map(l=>'<p style="font-family:var(--font-body);font-size:13px;line-height:1.7;color:var(--text-primary);margin:0 0 8px;">' + this._esc(l) + '</p>')
+              .join('');
+      } catch(e) {
+        panel.innerHTML = '<p style="font-family:var(--font-mono);font-size:12px;color:var(--red);">' + this._esc(e.message) + '</p>';
+      }
+      this._aiPending = false;
+      toolbar.querySelectorAll('.rai-btn').forEach(b => { b.disabled=false; b.style.opacity='1'; });
+    };
+
+    // Hint — nudge without giving away answer
+    document.getElementById('rai-hint')?.addEventListener('click', () => showAI(
+      (q, n) => `Give a helpful hint for this question WITHOUT revealing the answer. A hint should activate memory, not replace it. Be brief — 1-2 sentences max.\n\nQuestion: "${q.question}"`,
+      '💡 Hint'
+    ));
+
+    // Explain — full explanation after reveal
+    document.getElementById('rai-explain')?.addEventListener('click', () => showAI(
+      (q, n) => `Explain this concept thoroughly:\n- What is the core idea behind the answer?\n- Why does it work this way?\n- Give a short real-world accounting/tax example that makes it concrete.\n\nKeep it to 3-4 short paragraphs.`,
+      '📖 Explanation'
+    ));
+
+    // Follow-up — generate a fresh related question
+    document.getElementById('rai-followup')?.addEventListener('click', async () => {
+      if (this._aiPending) return;
+      this._aiPending = true;
+      toolbar.querySelectorAll('.rai-btn').forEach(b=>{b.disabled=true;b.style.opacity='0.5';});
+      panel.style.display='block';
+      panel.innerHTML='<div class="aif-loading"><div class="aif-dot"></div><div class="aif-dot"></div><div class="aif-dot"></div></div>';
+      try {
+        const ctx = LearnerContext.forReviewCard(node, question);
+        const prompt = ctx + '\n\nGenerate ONE follow-up question that tests the same concept from a different angle — make it harder or more applied than the original. Output ONLY valid JSON: {"question":"","answer":""}';
+        const raw  = await AIService._callWithFunction('questionGen', [{role:'user',content:prompt}], 400);
+        const data = AIService._parseJSON(raw);
+        panel.innerHTML =
+          '<div style="font-family:var(--font-mono);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:0.08em;color:var(--accent);margin-bottom:10px;">🔀 Follow-up Question</div>'
+          + '<div style="font-family:var(--font-body);font-size:14px;color:var(--text-primary);margin-bottom:12px;line-height:1.65;">' + this._esc(data.question||'') + '</div>'
+          + '<div id="rai-fu-answer" style="display:none;background:var(--bg-surface);border:1px solid var(--border);border-radius:var(--radius-sm);padding:10px 12px;font-family:var(--font-body);font-size:13px;color:var(--text-secondary);line-height:1.65;">' + this._esc(data.answer||'') + '</div>'
+          + '<div style="display:flex;gap:8px;flex-wrap:wrap;margin-top:10px;">'
+          + '<button class="rai-btn" id="rai-fu-reveal">Show Answer</button>'
+          + '<button class="rai-btn" id="rai-fu-save">+ Save to node</button>'
+          + '</div>';
+        document.getElementById('rai-fu-reveal')?.addEventListener('click', () => {
+          document.getElementById('rai-fu-answer').style.display='block';
+          document.getElementById('rai-fu-reveal').textContent='Answer shown';
+          document.getElementById('rai-fu-reveal').disabled=true;
+        });
+        document.getElementById('rai-fu-save')?.addEventListener('click', () => {
+          node.questions.push({ id:KnowledgeNode._generateQuestionId(), type:'application', question:data.question, answer:data.answer });
+          nodeStore.save(node);
+          Toast.success('Question saved to node!');
+          document.getElementById('rai-fu-save').disabled=true;
+          document.getElementById('rai-fu-save').textContent='✓ Saved';
+        });
+      } catch(e) {
+        panel.innerHTML='<p style="font-family:var(--font-mono);font-size:12px;color:var(--red);">' + this._esc(e.message) + '</p>';
+      }
+      this._aiPending=false;
+      toolbar.querySelectorAll('.rai-btn').forEach(b=>{b.disabled=false;b.style.opacity='1';});
+    });
+
+    // I don't get it — completely different angle
+    document.getElementById('rai-struggle')?.addEventListener('click', () => showAI(
+      (q, n) => `A student is struggling with this concept. Explain it from a completely different angle:\n1. Use a simple everyday analogy (nothing accounting-related)\n2. Then show how that analogy maps to the actual concept\n3. End with the simplest possible version of the rule to remember\n\nQuestion context: "${q.question}"`,
+      '🤔 Different Angle'
+    ));
+  },
+
+  /* ─── REVEAL & RATE ─────────────────────────────── */
+  _reveal() {
+    document.getElementById('reveal-btn').classList.add('hidden');
+    document.getElementById('skip-btn').classList.add('hidden');
+    document.getElementById('flashcard-back').classList.remove('hidden');
+    this._revealed = true;
+    // Show scheduling hints so the student knows the consequence of each rating
+    this._updateRatingHints();
+  },
+
+  /** Adds scheduling hints to rating buttons after answer is revealed.
+   *  Computes actual next-review intervals from the SRS state where available. */
+  _updateRatingHints() {
+    const item  = this._session?.[this._index];
+    const hints = { 1: 'Right now', 2: 'Tomorrow', 3: '~3 days', 4: '~1 week' };
+    if (item && typeof SpacedRepetition !== 'undefined') {
+      try {
+        const state = item.node.srsState?.[item.question?.id] || {};
+        [1,2,3,4].forEach(r => {
+          const next = SpacedRepetition.update({ ...state }, r);
+          const days = Math.round((next.nextReview - Date.now()) / 86400000);
+          hints[r] = days <= 0 ? 'Right now'
+            : days === 1 ? 'Tomorrow'
+            : days < 7   ? days + ' days'
+            : days < 14  ? '~1 week'
+            : Math.round(days / 7) + ' weeks';
+        });
+      } catch(e) { /* fallback to static hints */ }
+    }
+    document.querySelectorAll('.rating-btn').forEach(btn => {
+      const r = parseInt(btn.dataset.rating);
+      if (!r) return;
+      btn.querySelector('.rating-hint')?.remove();
+      const hint = document.createElement('span');
+      hint.className = 'rating-hint';
+      hint.textContent = hints[r] || '';
+      btn.appendChild(hint);
+    });
+  },
+
+  /** Skip the current card without rating it.
+   *  The card is re-queued at the end so it isn't lost — you'll see it
+   *  again before the session finishes. No SRS rating is recorded. */
+  _skip() {
+    const item = this._session[this._index];
+    if (!item) return;
+    // Re-queue a copy at the end of the session (skip last card → no-op re-add still works)
+    this._session.push({ ...item });
+    this._index++;
+    document.getElementById('review-ai-toolbar')?.remove();
+    document.getElementById('review-ai-panel')?.remove();
+    this._renderCard();
+  },
+
+  _rate(rating) {
+    if (!this._revealed) return;
+    const item = this._session[this._index];
+    if (!item) return;
+    const { node, question } = item;
+
+    // Count a first-ever rating toward today's new-card budget (before the
+    // rating mutates repetitions), so paced introduction holds across sessions.
+    try {
+      const prev = node.srsState[question.id];
+      if ((!prev || (prev.repetitions || 0) === 0) && typeof NewCardPacer !== 'undefined') NewCardPacer.recordIntroduced(1);
+    } catch (e) { /* non-critical */ }
+
+    // Record the rating and learner signals — but never let a writeback error
+    // stop the session from advancing to the next card.
+    try { node.recordRating(question.id, rating); nodeStore.save(node); } catch(e) { console.warn('[Review] recordRating failed', e); }
+    try { LearnerMemory.recordStruggle(node, question, rating); } catch(e) { console.warn('[Review] recordStruggle failed', e); }
+    if (!this._ratingMap) this._ratingMap = {};
+    this._ratingMap[question.id] = rating;
+    // Fire-and-forget: don't await (review must advance immediately).
+    // .catch() surfaces errors without breaking the session flow.
+    ReactiveReshaper.onRating(node, question, rating)
+      .catch(e => console.warn('[ReviewView] onRating background error:', e));
+
+    const labels = { 1:'again', 2:'hard', 3:'good', 4:'easy' };
+    this._stats[labels[rating]]++;
+
+    // Leech intervention: if this card has now been failed too many times,
+    // stop re-queuing it (grinding a blank wastes time) and offer to actually
+    // learn the concept instead. Shown once per card per session.
+    if (rating === 1 && typeof LeechDetector !== 'undefined'
+        && LeechDetector.isLeechCard(node, question.id)) {
+      if (!this._leechShown) this._leechShown = new Set();
+      if (!this._leechShown.has(question.id)) {
+        this._leechShown.add(question.id);
+        document.getElementById('review-ai-toolbar')?.remove();
+        document.getElementById('review-ai-panel')?.remove();
+        this._showLeechIntervention(node, question, LeechDetector.countFor(node, question.id));
+        return; // don't re-queue or advance — the intervention drives what's next
+      }
+    }
+
+    if (rating === 1) this._session.push({ ...item }); // re-queue
+    this._index++;
+    // Clear AI panel
+    document.getElementById('review-ai-toolbar')?.remove();
+    document.getElementById('review-ai-panel')?.remove();
+    this._renderCard();
+  },
+
+  /** Break the grind on a repeatedly-failed card: instead of flashcarding it
+   *  yet again, offer to understand the concept. Rendered over the flashcard. */
+  _showLeechIntervention(node, question, count) {
+    const back = document.getElementById('flashcard-back');
+    if (back) back.classList.add('hidden');
+    document.getElementById('reveal-btn')?.classList.add('hidden');
+    document.getElementById('skip-btn')?.classList.add('hidden');
+    document.getElementById('review-ai-toolbar')?.remove();
+    document.getElementById('review-ai-panel')?.remove();
+
+    let host = document.getElementById('review-leech');
+    if (host) host.remove();
+    host = document.createElement('div');
+    host.id = 'review-leech';
+    host.style.cssText = 'margin-top:16px;background:var(--bg-raised);border:1px solid rgba(240,86,74,0.35);border-left:3px solid var(--red,#f0564a);border-radius:var(--radius-md);padding:16px 18px;';
+    host.innerHTML =
+      '<div style="font-family:var(--font-mono);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--red,#f0564a);margin-bottom:8px;">⚠ Sticking point — missed ' + count + '×</div>'
+      + '<p style="font-family:var(--font-body);font-size:14px;line-height:1.6;color:var(--text-primary);margin:0 0 14px;">Flashcarding this one isn\'t making it stick — that usually means the underlying idea needs a proper look, not more testing. Let\'s understand it instead of grinding it.</p>'
+      + '<div style="display:flex;gap:8px;flex-wrap:wrap;">'
+      + '<button class="btn-primary" id="leech-understand" style="font-size:13px;">📖 Understand this topic</button>'
+      + '<button class="btn-secondary" id="leech-continue" style="font-size:13px;">Keep drilling anyway</button>'
+      + '</div>';
+    const container = document.getElementById('review-container');
+    (container || document.body).appendChild(host);
+
+    document.getElementById('leech-understand').addEventListener('click', () => {
+      host.remove();
+      this._inSession = false;
+      if (typeof NodeDetailView !== 'undefined') NodeDetailView.open(node.id, 'notes');
+    });
+    document.getElementById('leech-continue').addEventListener('click', () => {
+      host.remove();
+      this._session.push({ node, question, state: node.srsState[question.id] || null }); // re-queue after all
+      this._index++;
+      this._renderCard();
+    });
+  },
+
+  /* ─── COMPLETE ──────────────────────────────────── */
+  _showComplete() {
+    this._inSession = false;
+    document.getElementById('review-container').classList.add('hidden');
+    const el = document.getElementById('review-complete');
+    el.classList.remove('hidden');
+    const { again, hard, good, easy } = this._stats;
+    const total = again + hard + good + easy;
+    const score = total ? Math.round(((good*0.7 + easy) / total) * 100) : 0;
+
+    document.getElementById('review-complete-stats').innerHTML =
+      `<div style="font-size:36px;font-weight:800;color:var(--accent);font-family:var(--font-mono);margin-bottom:4px;">${score}%</div>`
+      + `<div style="font-family:var(--font-mono);font-size:12px;color:var(--text-muted);margin-bottom:16px;">${total} cards — Easy: ${easy} · Good: ${good} · Hard: ${hard} · Again: ${again}</div>`
+      + (this._aiMode && AIService.hasApiKey() ? '<div id="complete-ai-insight" style="margin-top:8px;"><div class="aif-loading"><div class="aif-dot"></div><div class="aif-dot"></div><div class="aif-dot"></div></div></div>' : '');
+
+    Toast.success('Session complete!');
+    App.updateSidebarStats();
+    StreakTracker.recordActivity();
+    StreakTracker.render();
+
+    // Write session result back to every node that was reviewed
+    const reviewedNodes = [...new Set(this._session.map(i => i.node))];
+    reviewedNodes.forEach(n => {
+      const nodeItems  = this._session.filter(i => i.node === n);
+      const hardQIds   = nodeItems
+        .filter(i => (this._ratingMap?.[i.question.id] || 3) <= 2)
+        .map(i => i.question.id);
+      LearnerMemory.recordReview(n, { again, hard, good, easy, score }, hardQIds);
+    });
+
+    // AI session debrief — structured, cross-topic analysis via analyzeSessionGaps
+    if (this._aiMode && AIService.hasApiKey()) {
+      const hardList = this._session
+        .filter((_,i) => i < this._stats.again + this._stats.hard)
+        .map(item => item.question.question).slice(0, 5);
+      const sessionData = {
+        score, easy, good, hard, again,
+        reviewedTopics: reviewedNodes.map(n => n.title),
+        struggledQuestions: hardList,
+      };
+      AIService.analyzeSessionGaps(sessionData, nodeStore.getAll())
+        .then(r => {
+          const el = document.getElementById('complete-ai-insight');
+          if (!el || !r) return;
+          const chips = (arr, color) => (arr || []).filter(Boolean).slice(0,4)
+            .map(t => '<span style="display:inline-block;background:var(--bg-raised);border:1px solid ' + color + ';border-radius:999px;padding:3px 10px;margin:2px 4px 2px 0;font-family:var(--font-mono);font-size:11px;">' + this._esc(t) + '</span>').join('');
+          const block = (label, html) => html
+            ? '<div style="margin-top:10px;"><div style="font-family:var(--font-ui);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:0.06em;color:var(--text-muted);margin-bottom:4px;">' + label + '</div>' + html + '</div>'
+            : '';
+          el.innerHTML = '<div style="background:var(--accent-soft);border:1px solid var(--accent-dim);border-radius:var(--radius-md);padding:14px 16px;">'
+            + '<div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:8px;">'
+            +   '<span style="font-family:var(--font-mono);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:0.08em;color:var(--accent);">⬡ AI Session Debrief</span>'
+            +   (r.examReadiness ? '<span style="font-family:var(--font-mono);font-size:12px;font-weight:700;color:var(--accent);">Exam ready: ' + this._esc(String(r.examReadiness)) + '</span>' : '')
+            + '</div>'
+            + (r.sessionSummary ? '<p style="margin:0;font-family:var(--font-body);font-size:13px;color:var(--text-primary);line-height:1.7;">' + this._esc(r.sessionSummary) + '</p>' : '')
+            + block('Strong areas',      chips(r.strongAreas, 'var(--green)'))
+            + block('Focus next',        chips((r.weakAreas||[]).concat(r.nextSessionFocus||[]), 'var(--red)'))
+            + (r.dailyRecommendation ? block('Recommended', '<span style="font-family:var(--font-body);font-size:13px;color:var(--text-primary);">' + this._esc(r.dailyRecommendation) + '</span>') : '')
+            + '</div>';
+        })
+        .catch(() => { document.getElementById('complete-ai-insight')?.remove(); });
+    }
+  },
+
+  _esc: s => String(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'),
+};

--- a/knowledgenode/www/js/ui/ReviewView.js
+++ b/knowledgenode/www/js/ui/ReviewView.js
@@ -58,13 +58,17 @@ const ReviewView = {
     if (emptyEl2) emptyEl2.style.display = 'none';
     // Single pass — avoids 5 separate loops (4 reduce + 1 map) and multiple
     // dueQuestions() SRS scans. Inline the due check to avoid creating arrays.
-    let totalQs = 0, dueQs = 0, newQs = 0, weakCount = 0;
+    let totalQs = 0, dueQs = 0, newQs = 0, weakCount = 0, calcQs = 0;
     const now = Date.now(), subjectSet = new Set();
     for (const n of allNodes) {
-      totalQs  += n.questions.length;
       weakCount += n.weakQuestions?.length || 0;
       if (n.subject) subjectSet.add(n.subject);
-      for (const q of n.questions) {
+      // Count only what review can actually serve — full calculations are exam
+      // material, so counting them here would promise cards that never appear.
+      const reviewable = n.reviewableQuestions();
+      totalQs += reviewable.length;
+      calcQs  += n.questions.length - reviewable.length;
+      for (const q of reviewable) {
         const srs = n.srsState[q.id];
         if (!srs || srs.repetitions === 0) newQs++;
         else if (srs.nextReview <= now)     dueQs++;
@@ -90,6 +94,9 @@ const ReviewView = {
           <div class="review-stat" style="color:var(--blue,#4f9cf9);"><span class="review-stat-val">${newQs}</span><span class="review-stat-key">New</span></div>
           <div class="review-stat"><span class="review-stat-val">${allNodes.length}</span><span class="review-stat-key">Nodes</span></div>
         </div>
+
+        ${calcQs > 0 ? `<div style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);margin:-6px 0 14px;line-height:1.5;">
+          ${calcQs} full calculation${calcQs===1?' is':'s are'} kept out of review — work ${calcQs===1?'it':'them'} in the Exam tab, where you have time to lay the answer out.</div>` : ''}
 
         <div style="margin-bottom:16px;">
           <label class="config-label">Mode</label>
@@ -234,7 +241,7 @@ const ReviewView = {
     if (budget <= 0) return [];
     const fresh = [];
     for (const node of this._shuffle([...nodes])) {
-      for (const q of node.questions) {
+      for (const q of node.reviewableQuestions()) {
         const s = node.srsState[q.id];
         if (!s || (s.repetitions || 0) === 0) {
           fresh.push({ node, question: q, state: s || null, _new: true });
@@ -257,7 +264,11 @@ const ReviewView = {
     nodes.forEach(node => {
       (node.weakQuestions || []).forEach(w => {
         const q = node.questions.find(q => q.id === w.id);
-        if (q) items.push({ node, question: q, state: node.srsState[q.id] || null, _struggle: w });
+        // Skip calculations: they may carry old struggle records from before
+        // they were routed to the exam, and re-drilling them here is the very
+        // thing that made review unusable.
+        if (q && (typeof QuestionKind === 'undefined' || QuestionKind.isReviewable(q)))
+          items.push({ node, question: q, state: node.srsState[q.id] || null, _struggle: w });
       });
     });
     // Hardest first: more misses and lower ratings come first
@@ -281,7 +292,7 @@ const ReviewView = {
     });
 
     sorted.forEach(node => {
-      node.questions.forEach(q => {
+      node.reviewableQuestions().forEach(q => {
         const s = node.srsState[q.id];
         const isNew = !s || s.repetitions === 0;
         const item  = { node, question: q, state: s || null };

--- a/knowledgenode/www/js/ui/SelectToAction.js
+++ b/knowledgenode/www/js/ui/SelectToAction.js
@@ -1,0 +1,261 @@
+/**
+ * SelectToAction.js — Final
+ * Desktop: floating toolbar with Recall, Apply, Define, Highlight, + Question (quick add)
+ * Mobile: bottom bar (avoids Samsung conflict)
+ */
+
+const SelectToAction = {
+  _toolbar:     null,
+  _mobileBar:   null,
+  _currentNode: null,
+  _selectedText:'',
+  _isMobile:    false,
+
+  init() {
+    this._toolbar  = document.getElementById('select-toolbar');
+    this._isMobile = window.matchMedia('(pointer: coarse)').matches;
+    if (this._isMobile) this._initMobileBar();
+    else this._initDesktop();
+  },
+
+  setNode(node) { this._currentNode = node; },
+
+  _initDesktop() {
+    document.addEventListener('mouseup', e => {
+      if (this._toolbar?.contains(e.target)) return;
+      setTimeout(() => this._checkSelection(), 10);
+    });
+    document.addEventListener('mousedown', e => {
+      if (!this._toolbar?.contains(e.target)) this._hide();
+    });
+    this._bindButtons();
+  },
+
+  _checkSelection() {
+    const sel  = window.getSelection();
+    const text = sel?.toString().trim();
+    const inNotes = sel?.anchorNode?.parentElement?.closest(
+      '#notes-display,.step-content,.detail-body,.user-notes-block,.summary-block,.definition-desc,.procedure-text'
+    );
+    if (!text || text.length < 3 || !inNotes) { this._hide(); return; }
+    this._selectedText = text;
+    const rect = sel.getRangeAt(0).getBoundingClientRect();
+    this._showDesktop(rect);
+  },
+
+  _showDesktop(rect) {
+    if (!this._toolbar) return;
+    this._toolbar.classList.remove('hidden');
+    const top  = rect.top  + window.scrollY - this._toolbar.offsetHeight - 10;
+    const left = rect.left + window.scrollX + rect.width / 2 - 130;
+    this._toolbar.style.top  = Math.max(8, top) + 'px';
+    this._toolbar.style.left = Math.max(8, Math.min(window.innerWidth - 280, left)) + 'px';
+  },
+
+  _hide() {
+    this._toolbar?.classList.add('hidden');
+    this._mobileBar?.classList.add('hidden');
+    this._selectedText = '';
+  },
+
+  _bindButtons() {
+    document.getElementById('sel-recall')     ?.addEventListener('click', () => this._createItem('recall'));
+    document.getElementById('sel-apply')      ?.addEventListener('click', () => this._createItem('application'));
+    document.getElementById('sel-define')     ?.addEventListener('click', () => this._createItem('definition'));
+    document.getElementById('sel-highlight')  ?.addEventListener('click', () => this._highlightSelection());
+    document.getElementById('sel-question')   ?.addEventListener('click', () => this._quickQuestion());
+    document.getElementById('sel-correct')    ?.addEventListener('click', () => this._correctAI());
+  },
+
+  _correctAI() {
+    const text = this._selectedText;
+    this._hide();
+    if (!this._currentNode) { Toast.info('Open a node first.'); return; }
+    if (typeof AICorrections === 'undefined') { Toast.error('AI Corrections not loaded.'); return; }
+    AICorrections.promptUser(this._currentNode, 'content', text);
+  },
+
+  _initMobileBar() {
+    this._mobileBar = document.createElement('div');
+    this._mobileBar.id = 'mobile-select-bar';
+    this._mobileBar.className = 'mobile-select-bar hidden';
+    this._mobileBar.innerHTML = `
+      <div class="msb-title">With selected text:</div>
+      <div class="msb-btns">
+        <button class="msb-btn" id="msb-recall">🔁 Recall</button>
+        <button class="msb-btn" id="msb-apply">🧩 Apply</button>
+        <button class="msb-btn" id="msb-define">📖 Define</button>
+        <button class="msb-btn" id="msb-question">❓ Question</button>
+        <button class="msb-btn" id="msb-correct" title="Correct the AI on this text">✏️ Correct AI</button>
+        <button class="msb-btn" id="msb-close" style="flex:0;padding:10px 14px;">✕</button>
+      </div>`;
+    document.body.appendChild(this._mobileBar);
+    document.getElementById('msb-recall')   ?.addEventListener('click', () => this._createItem('recall'));
+    document.getElementById('msb-apply')    ?.addEventListener('click', () => this._createItem('application'));
+    document.getElementById('msb-define')   ?.addEventListener('click', () => this._createItem('definition'));
+    document.getElementById('msb-question') ?.addEventListener('click', () => this._quickQuestion());
+    document.getElementById('msb-correct')  ?.addEventListener('click', () => this._correctAI());
+    document.getElementById('msb-close')    ?.addEventListener('click', () => this._hide());
+
+    document.addEventListener('selectionchange', () => {
+      clearTimeout(this._selTimer);
+      this._selTimer = setTimeout(() => {
+        const sel  = window.getSelection();
+        const text = sel?.toString().trim();
+        const inNotes = sel?.anchorNode?.parentElement?.closest('#notes-display,.step-content,.detail-body');
+        if (text && text.length >= 3 && inNotes) {
+          this._selectedText = text;
+          this._mobileBar?.classList.remove('hidden');
+        } else if (!text) {
+          this._mobileBar?.classList.add('hidden');
+        }
+      }, 300);
+    });
+  },
+
+  /* ─── Quick Question — picks type automatically ─── */
+  _quickQuestion() {
+    const text = this._selectedText;
+    this._hide();
+    if (!this._currentNode || !text) { Toast.info('Open a node first.'); return; }
+
+    // Auto-detect type: if text contains numbers/formulas → application, otherwise recall
+    const hasNumbers = /\d|=|formula|calculate|compute|apply/i.test(text);
+    const type = hasNumbers ? 'application' : 'recall';
+
+    Modal.open(`
+      <h2 style="font-family:var(--font-ui);font-size:18px;font-weight:800;margin-bottom:16px;">Quick Question</h2>
+      <div style="background:var(--bg-raised);border-left:3px solid var(--accent);border-radius:var(--radius-sm);padding:10px 14px;margin-bottom:16px;font-family:var(--font-body);font-size:13px;color:var(--text-secondary);font-style:italic;">
+        "${this._esc(text.slice(0,100))}${text.length>100?'…':''}"
+      </div>
+      <div style="display:flex;gap:8px;margin-bottom:16px;">
+        <button class="mode-btn ${type==='recall'?'active':''}" id="qt-recall-btn">🔁 Recall</button>
+        <button class="mode-btn ${type==='application'?'active':''}" id="qt-apply-btn">🧩 Application</button>
+      </div>
+      <div class="config-row" style="margin-bottom:12px;">
+        <label class="config-label">Question</label>
+        <textarea id="qt-question" class="config-input" rows="2" style="resize:vertical;"
+          placeholder="What is…? Define…? How would you…?"></textarea>
+      </div>
+      <div class="config-row" style="margin-bottom:16px;">
+        <label class="config-label">Answer</label>
+        <textarea id="qt-answer" class="config-input" rows="3" style="resize:vertical;">${this._esc(text)}</textarea>
+      </div>
+      <div style="display:flex;gap:8px;">
+        <button class="btn-primary" id="qt-save-btn">Add Question</button>
+        <button class="btn-secondary" onclick="Modal.close()">Cancel</button>
+      </div>`);
+
+    setTimeout(() => {
+      let selectedType = type;
+      document.getElementById('qt-recall-btn')?.addEventListener('click', () => {
+        selectedType = 'recall';
+        document.getElementById('qt-recall-btn').classList.add('active');
+        document.getElementById('qt-apply-btn').classList.remove('active');
+      });
+      document.getElementById('qt-apply-btn')?.addEventListener('click', () => {
+        selectedType = 'application';
+        document.getElementById('qt-apply-btn').classList.add('active');
+        document.getElementById('qt-recall-btn').classList.remove('active');
+      });
+      document.getElementById('qt-question')?.focus();
+      document.getElementById('qt-save-btn')?.addEventListener('click', () => {
+        const question = document.getElementById('qt-question').value.trim();
+        const answer   = document.getElementById('qt-answer').value.trim();
+        if (!question||!answer) { Toast.error('Fill in both fields.'); return; }
+        this._currentNode.questions.push({ id:KnowledgeNode._generateQuestionId(), type:selectedType, question, answer });
+        nodeStore.save(this._currentNode);
+        Modal.close();
+        Toast.success('Question added!');
+        if (NodeDetailView._currentNode?.id === this._currentNode.id && NodeDetailView._currentSection === 'questions') NodeDetailView._renderSection();
+      });
+    }, 0);
+  },
+
+  /* ─── Create definition or typed question ─── */
+  _createItem(type) {
+    const text = this._selectedText;
+    this._hide();
+    if (!this._currentNode || !text) { Toast.info('Open a node first.'); return; }
+
+    if (type === 'definition') {
+      Modal.open(`
+        <h2 style="font-family:var(--font-ui);font-size:18px;font-weight:800;margin-bottom:16px;">Add Definition</h2>
+        <div class="config-row" style="margin-bottom:12px;">
+          <label class="config-label">Term</label>
+          <input type="text" id="sel-def-term" class="config-input" value="${this._esc(text.slice(0,60))}"/>
+        </div>
+        <div class="config-row" style="margin-bottom:16px;">
+          <label class="config-label">Description</label>
+          <textarea id="sel-def-desc" class="config-input" rows="3" placeholder="What does this mean?"></textarea>
+        </div>
+        <div style="display:flex;gap:8px;">
+          <button class="btn-primary" id="sel-def-save">Add Definition</button>
+          <button class="btn-secondary" onclick="Modal.close()">Cancel</button>
+        </div>`);
+      setTimeout(() => {
+        document.getElementById('sel-def-desc').focus();
+        document.getElementById('sel-def-save')?.addEventListener('click', () => {
+          const term = document.getElementById('sel-def-term').value.trim();
+          const desc = document.getElementById('sel-def-desc').value.trim();
+          if (!term||!desc) { Toast.error('Fill in both fields.'); return; }
+          this._currentNode.definitions.push({ term, description: desc });
+          nodeStore.save(this._currentNode);
+          Modal.close();
+          Toast.success('Definition added!');
+          if (NodeDetailView._currentNode?.id === this._currentNode.id) NodeDetailView._renderSection();
+        });
+      }, 0);
+      return;
+    }
+
+    const label = type === 'recall' ? 'Recall Question' : 'Application Question';
+    Modal.open(`
+      <h2 style="font-family:var(--font-ui);font-size:18px;font-weight:800;margin-bottom:16px;">Create ${label}</h2>
+      <div style="background:var(--bg-raised);border-left:3px solid var(--accent);border-radius:var(--radius-sm);padding:10px 14px;margin-bottom:16px;font-family:var(--font-body);font-size:13px;color:var(--text-secondary);font-style:italic;">
+        "${this._esc(text.slice(0,120))}${text.length>120?'…':''}"
+      </div>
+      <div class="config-row" style="margin-bottom:12px;">
+        <label class="config-label">Question</label>
+        <textarea id="sel-q-question" class="config-input" rows="2" style="resize:vertical;"
+          placeholder="${type==='recall'?'What is / Define / State…':'Given a scenario where…'}"></textarea>
+      </div>
+      <div class="config-row" style="margin-bottom:16px;">
+        <label class="config-label">Answer</label>
+        <textarea id="sel-q-answer" class="config-input" rows="3" style="resize:vertical;">${this._esc(text)}</textarea>
+      </div>
+      <div style="display:flex;gap:8px;">
+        <button class="btn-primary" id="sel-q-save">Add Question</button>
+        <button class="btn-secondary" onclick="Modal.close()">Cancel</button>
+      </div>`);
+    setTimeout(() => {
+      document.getElementById('sel-q-question')?.focus();
+      document.getElementById('sel-q-save')?.addEventListener('click', () => {
+        const question = document.getElementById('sel-q-question').value.trim();
+        const answer   = document.getElementById('sel-q-answer').value.trim();
+        if (!question||!answer) { Toast.error('Fill in both fields.'); return; }
+        this._currentNode.questions.push({ id:KnowledgeNode._generateQuestionId(), type, question, answer });
+        nodeStore.save(this._currentNode);
+        Modal.close();
+        Toast.success(`${label} added!`);
+        if (NodeDetailView._currentNode?.id === this._currentNode.id) NodeDetailView._renderSection();
+      });
+    }, 0);
+  },
+
+  _highlightSelection() {
+    if (this._isMobile) { Toast.info('Use browser highlighting on mobile.'); this._hide(); return; }
+    const sel = window.getSelection();
+    if (!sel?.rangeCount) return;
+    const range = sel.getRangeAt(0);
+    const mark  = document.createElement('mark');
+    mark.className = 'kn-highlight';
+    mark.title = 'Click to remove';
+    mark.addEventListener('click', () => { const p=mark.parentNode; while(mark.firstChild) p.insertBefore(mark.firstChild,mark); p.removeChild(mark); });
+    try { range.surroundContents(mark); } catch { Toast.info('Select within one paragraph to highlight.'); }
+    sel.removeAllRanges();
+    this._hide();
+  },
+
+  _esc: s => String(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'),
+};

--- a/knowledgenode/www/js/ui/SettingsPanel.js
+++ b/knowledgenode/www/js/ui/SettingsPanel.js
@@ -1,0 +1,382 @@
+/**
+ * SettingsPanel.js
+ * Full settings modal: AI config, reset data, onboarding replay, session prefs
+ */
+
+const SettingsPanel = {
+  open() {
+    const stats = nodeStore.getStats();
+    const streak = StreakTracker.getStats();
+
+    Modal.open(`
+      <h2 style="font-family:var(--font-ui);font-size:19px;font-weight:800;margin-bottom:20px;">⚙ Settings</h2>
+
+      <!-- AI Provider -->
+      <div class="settings-section">
+        <div class="settings-section-title">AI Provider</div>
+        <div style="display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:10px;">
+          <div>
+            <div style="font-family:var(--font-ui);font-size:13px;font-weight:600;color:var(--text-primary);">
+              ${AIService.hasApiKey() ? `✓ ${AIService.getActiveProvider()?.name || 'Configured'}` : '⚠ Not configured (demo mode)'}
+            </div>
+            <div style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);margin-top:2px;">
+              ${AIService.hasApiKey() ? 'Click to change provider or model' : 'Configure to enable AI processing'}
+            </div>
+          </div>
+          <button class="btn-secondary" style="font-size:12px;" id="settings-ai-btn">Configure AI</button>
+        </div>
+      </div>
+
+      <!-- Study Color (additive accent palettes — dark/light toggle is unchanged, in the sidebar) -->
+      <div class="settings-section">
+        <div class="settings-section-title">Study Color</div>
+        <p style="font-family:var(--font-body);font-size:12.5px;color:var(--text-secondary);margin-bottom:12px;line-height:1.55;">
+          Backed by learning-science color research: each accent is tuned for a different kind of studying. Purely visual — pick one, switch anytime, or leave it on the original.
+        </p>
+        <div class="study-color-grid" id="study-color-grid">${this._renderStudyColorSwatches()}</div>
+      </div>
+
+      <!-- AI Corrections -->
+      <div class="settings-section" id="settings-corrections-section">
+        <div class="settings-section-title">AI Corrections</div>
+        <p style="font-family:var(--font-body);font-size:13px;color:var(--text-secondary);margin-bottom:12px;">
+          Things you've told the AI it got wrong. These are sent with every future prompt for that node.
+        </p>
+        <div id="settings-corrections-list">${this._renderCorrectionsPanel()}</div>
+      </div>
+
+      <!-- Your Data -->
+      <div class="settings-section">
+        <div class="settings-section-title">Your Data</div>
+        <div style="display:grid;grid-template-columns:repeat(3,1fr);gap:10px;margin-bottom:14px;">
+          <div class="mastery-stat-card"><span class="mastery-stat-value">${stats.total}</span><span class="mastery-stat-label">Nodes</span></div>
+          <div class="mastery-stat-card"><span class="mastery-stat-value">${stats.mastery}%</span><span class="mastery-stat-label">Mastery</span></div>
+          <div class="mastery-stat-card"><span class="mastery-stat-value">${streak.streak}</span><span class="mastery-stat-label">Streak</span></div>
+        </div>
+
+        <div style="background:rgba(240,165,0,0.1);border:1px solid var(--accent-dim);border-radius:10px;padding:12px 14px;margin-bottom:14px;">
+          <div style="font-family:var(--font-ui);font-weight:700;font-size:13px;color:var(--accent-light);margin-bottom:4px;">⚠ Keep your data safe</div>
+          <div style="font-family:var(--font-body);font-size:13px;color:var(--text-secondary);line-height:1.6;">
+            Uninstalling this app <strong>permanently deletes all your nodes</strong>. Export your data to a file and keep it somewhere safe (Google Drive, email, cloud storage) — especially before any app update.
+          </div>
+        </div>
+
+        <div style="display:flex;gap:8px;flex-wrap:wrap;">
+          <button class="btn-secondary" style="font-size:12px;" id="settings-export-btn">⎙ Export All Nodes</button>
+          <button class="btn-secondary" style="font-size:12px;" id="settings-import-btn">↑ Import Backup</button>
+          <button class="btn-secondary" style="font-size:12px;" id="settings-copy-btn" title="Copy all data as JSON — paste into any text editor and save as .json">📋 Copy to clipboard</button>
+          <input type="file" id="import-file-input" accept=".json" hidden/>
+        </div>
+      </div>
+
+      <!-- Backups (in-app vault) -->
+      <div class="settings-section">
+        <div class="settings-section-title">Backups</div>
+        <p style="font-family:var(--font-body);font-size:13px;color:var(--text-secondary);margin-bottom:12px;">
+          Versioned snapshots kept inside the app — including your AI provider &amp; API&nbsp;key, so a restore brings back your setup too. The newest ${BackupVault.MAX_SNAPSHOTS} are kept automatically (once every 6&nbsp;hours). Restore any one, or download it as a file.
+        </p>
+        <p style="font-family:var(--font-body);font-size:12px;color:var(--text-muted);margin-bottom:12px;line-height:1.55;">
+          ⚠ These live in <em>this browser</em>. They survive an in-app purge, but clearing your browser's site data, uninstalling, or switching devices will remove them. For real safety, <strong>Download</strong> one occasionally and keep it somewhere off this device. Note a downloaded file contains your <strong>API key in plain text</strong> — store it somewhere private.
+        </p>
+        <div style="display:flex;gap:8px;flex-wrap:wrap;margin-bottom:12px;">
+          <button class="btn-secondary" style="font-size:12px;" id="settings-backup-now-btn">💾 Back up now</button>
+          <button class="btn-secondary" style="font-size:12px;color:var(--red);border-color:rgba(240,86,74,0.3);" id="settings-backup-clear-btn">Clear all backups</button>
+        </div>
+        <div id="settings-backup-list" style="display:flex;flex-direction:column;gap:8px;">
+          <div style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);">Loading backups…</div>
+        </div>
+      </div>
+
+      <!-- Onboarding -->
+      <div class="settings-section">
+        <div class="settings-section-title">Onboarding & Help</div>
+        <div style="display:flex;gap:8px;flex-wrap:wrap;">
+          <button class="btn-secondary" style="font-size:12px;" id="settings-guide-btn">📘 Full Guide</button>
+          <button class="btn-secondary" style="font-size:12px;" id="settings-tour-btn">📖 Replay Tour</button>
+          <button class="btn-secondary" style="font-size:12px;" id="settings-shortcuts-btn">⌨ Keyboard Shortcuts</button>
+        </div>
+      </div>
+
+      <!-- Danger Zone -->
+      <div class="settings-section" style="border-color:rgba(240,86,74,0.2);">
+        <div class="settings-section-title" style="color:var(--red);">⚠ Danger Zone</div>
+        <p style="font-family:var(--font-body);font-size:13px;color:var(--text-secondary);margin-bottom:14px;">
+          These actions cannot be undone. Export your data first if you want a backup.
+        </p>
+        <div style="display:flex;gap:8px;flex-wrap:wrap;">
+          <button class="btn-secondary" style="font-size:12px;border-color:rgba(240,86,74,0.3);color:var(--red);" id="reset-onboarding-btn">
+            Reset Onboarding
+          </button>
+          <button class="btn-danger" style="font-size:12px;" id="purge-all-btn">
+            🗑 Purge All Data
+          </button>
+        </div>
+      </div>
+
+      <div style="margin-top:8px;">
+        <button class="btn-secondary" onclick="Modal.close()" style="width:100%;justify-content:center;">Close</button>
+      </div>
+
+      <div style="margin-top:10px;text-align:center;font-family:var(--font-mono);font-size:11px;color:var(--text-muted);">
+        Build ${this._buildStamp()}
+      </div>
+
+    `);
+
+    setTimeout(() => {
+      this._bindStudyColorSwatches();
+      document.getElementById('settings-ai-btn')?.addEventListener('click', () => { Modal.close(); AISettingsModal.open(); });
+
+      document.getElementById('settings-guide-btn')?.addEventListener('click', () => { Modal.close(); Guide.open(); });
+
+      document.getElementById('settings-tour-btn')?.addEventListener('click', () => { Modal.close(); Onboarding.showTour(); });
+
+      // Corrections delete/clear
+      document.getElementById('settings-corrections-list')?.addEventListener('click', e => {
+        const delBtn   = e.target.closest('[data-cor-del]');
+        const clearBtn = e.target.closest('[data-node-clear]');
+        if (delBtn) {
+          const node = nodeStore.get(delBtn.dataset.corNode);
+          if (node) { AICorrections.delete(node, delBtn.dataset.corDel); }
+          document.getElementById('settings-corrections-list').innerHTML = this._renderCorrectionsPanel();
+        }
+        if (clearBtn) {
+          const node = nodeStore.get(clearBtn.dataset.nodeClear);
+          if (node) { AICorrections.clearAll(node); }
+          document.getElementById('settings-corrections-list').innerHTML = this._renderCorrectionsPanel();
+        }
+      });
+
+      document.getElementById('settings-export-btn')?.addEventListener('click', () => {
+        const nodes = nodeStore.getAll();
+        if (!nodes.length) { Toast.error('No nodes to export.'); return; }
+        try {
+          PrintExport.showAllExportMenu(nodes);
+          Toast.success('Export started — choose where to save the file when prompted.');
+        } catch(e) {
+          Toast.error('Export failed. Use "Copy to clipboard" instead.');
+        }
+      });
+
+      document.getElementById('settings-copy-btn')?.addEventListener('click', async () => {
+        const nodes = nodeStore.getAll();
+        if (!nodes.length) { Toast.error('No nodes to copy.'); return; }
+        const json = nodeStore.exportJSON();
+        try {
+          await navigator.clipboard.writeText(json);
+          Toast.success('All data copied to clipboard. Paste into a text file and save as .json — this is your backup.');
+        } catch(e) {
+          Toast.error('Clipboard failed. Try the Export button or Settings → Backups → Download.');
+        }
+      });
+
+      document.getElementById('settings-import-btn')?.addEventListener('click', () => {
+        document.getElementById('import-file-input').click();
+      });
+      document.getElementById('import-file-input')?.addEventListener('change', async e => {
+        const file = e.target.files[0];
+        if (!file) return;
+        try {
+          const text = await file.text();
+          try { await BackupVault.snapshot('pre-import'); } catch {}
+          nodeStore.importJSON(text);
+          Modal.close();
+          Toast.success('Nodes imported successfully!');
+          App.updateSidebarStats();
+        } catch(err) {
+          Toast.error('Import failed: ' + err.message);
+        }
+      });
+
+      // ── Backups (in-app vault) ──
+      const refreshBackups = () => { try { this._renderBackupList(); } catch {} };
+      refreshBackups();
+
+      document.getElementById('settings-backup-now-btn')?.addEventListener('click', async () => {
+        try {
+          const rec = await BackupVault.snapshot('manual');
+          Toast.success('Backup #' + rec.seq + ' saved');
+          refreshBackups();
+        } catch (err) { Toast.error('Backup failed: ' + err.message); }
+      });
+
+      document.getElementById('settings-backup-clear-btn')?.addEventListener('click', async () => {
+        if (!confirm('Delete ALL saved backups? This cannot be undone.')) return;
+        try { await BackupVault.clearAll(); Toast.success('All backups cleared'); refreshBackups(); }
+        catch (err) { Toast.error('Failed: ' + err.message); }
+      });
+
+      document.getElementById('settings-backup-list')?.addEventListener('click', async e => {
+        const restoreBtn = e.target.closest('[data-bk-restore]');
+        const dlBtn      = e.target.closest('[data-bk-dl]');
+        const delBtn     = e.target.closest('[data-bk-del]');
+
+        if (restoreBtn) {
+          const seq = Number(restoreBtn.dataset.bkRestore);
+          if (!confirm('Restore backup #' + seq + '?\n\nYour current data will be replaced with this version. A safety backup of the current state is taken first, so this can be undone.')) return;
+          try {
+            const rec = await BackupVault.get(seq);
+            if (!rec) { Toast.error('Backup not found'); return; }
+            await BackupVault.snapshot('pre-restore');
+            const n = nodeStore.replaceAllFromJSON(rec.json);
+            Toast.success('Restored ' + n + ' node' + (n === 1 ? '' : 's') + ' from #' + seq);
+            App.updateSidebarStats?.();
+            refreshBackups();
+          } catch (err) { Toast.error('Restore failed: ' + err.message); }
+        }
+
+        if (dlBtn) {
+          const rec = await BackupVault.get(Number(dlBtn.dataset.bkDl));
+          if (rec) BackupVault.download(rec);
+        }
+
+        if (delBtn) {
+          const seq = Number(delBtn.dataset.bkDel);
+          if (!confirm('Delete backup #' + seq + '? This cannot be undone.')) return;
+          try { await BackupVault.remove(seq); refreshBackups(); }
+          catch (err) { Toast.error('Delete failed: ' + err.message); }
+        }
+      });
+
+      document.getElementById('reset-onboarding-btn')?.addEventListener('click', () => {
+        Onboarding.reset();
+        Modal.close();
+        Toast.success('Onboarding reset. Reload the page to see the welcome screen.');
+      });
+
+      document.getElementById('purge-all-btn')?.addEventListener('click', () => {
+        this._confirmPurge();
+      });
+    }, 0);
+  },
+
+  _confirmPurge() {
+    Modal.open(`
+      <div style="text-align:center;padding:10px 0 20px;">
+        <div style="font-size:48px;margin-bottom:16px;">⚠</div>
+        <h2 style="font-family:var(--font-ui);font-size:20px;font-weight:800;margin-bottom:10px;color:var(--red);">Purge All Data?</h2>
+        <p style="font-family:var(--font-body);font-size:14px;color:var(--text-secondary);margin-bottom:16px;line-height:1.65;">
+          This will delete <strong>all nodes, study plans, streaks, and settings</strong> from this device.
+          A safety backup is taken first, so you can restore afterwards from <strong>Settings → Backups</strong>.
+        </p>
+        <label style="display:flex;align-items:flex-start;gap:9px;text-align:left;background:var(--bg-surface);border:1px solid var(--border);border-radius:8px;padding:11px 13px;margin-bottom:20px;cursor:pointer;">
+          <input type="checkbox" id="purge-backups-chk" style="margin-top:3px;flex:none;"/>
+          <span style="font-family:var(--font-body);font-size:13px;color:var(--text-secondary);line-height:1.5;">Also delete saved backups (a true clean slate — this <strong>cannot</strong> be undone)</span>
+        </label>
+        <div style="display:flex;gap:10px;justify-content:center;">
+          <button class="btn-danger" id="confirm-purge-btn">Delete</button>
+          <button class="btn-secondary" onclick="Modal.close()">Cancel</button>
+        </div>
+      </div>`);
+    setTimeout(() => {
+      document.getElementById('confirm-purge-btn')?.addEventListener('click', async () => {
+        const alsoBackups = document.getElementById('purge-backups-chk')?.checked;
+        try {
+          if (typeof BackupVault !== 'undefined') {
+            if (alsoBackups) { try { await BackupVault.clearAll(); } catch {} }
+            else             { try { await BackupVault.snapshot('pre-purge'); } catch {} }
+          }
+        } catch {}
+        // Clear all localStorage keys used by the app
+        const keysToRemove = Object.keys(localStorage).filter(k =>
+          k.startsWith('kn_') || k.startsWith('knowledge')
+        );
+        keysToRemove.forEach(k => localStorage.removeItem(k));
+        Modal.close();
+        Toast.success(alsoBackups ? 'All data and backups purged. Reloading…' : 'Data purged — backups kept. Reloading…');
+        setTimeout(() => location.reload(), 1200);
+      });
+    }, 0);
+  },
+  async _renderBackupList() {
+    const el = document.getElementById('settings-backup-list');
+    if (!el) return;
+    let list = [];
+    try { list = await BackupVault.list(); } catch (e) { console.warn(e); }
+    if (!el.isConnected) return;
+    if (!list.length) {
+      el.innerHTML = '<div style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);">No backups yet — tap “Back up now”, or one will be saved automatically as you study.</div>';
+      return;
+    }
+    el.innerHTML = list.map(rec => `
+      <div style="border:1px solid var(--border);border-radius:8px;padding:10px 12px;background:var(--bg-surface);">
+        <div style="font-family:var(--font-ui);font-size:12.5px;font-weight:600;color:var(--text-primary);line-height:1.4;">${BackupVault.labelOf(rec)}</div>
+        <div style="font-family:var(--font-mono);font-size:10px;color:var(--text-muted);margin:2px 0 9px;">${BackupVault.reasonLabel(rec.reason)}</div>
+        <div style="display:flex;gap:6px;flex-wrap:wrap;">
+          <button class="btn-secondary" style="font-size:11px;padding:4px 11px;" data-bk-restore="${rec.seq}">↺ Restore</button>
+          <button class="btn-secondary" style="font-size:11px;padding:4px 11px;" data-bk-dl="${rec.seq}">⤓ Download</button>
+          <button class="btn-secondary" style="font-size:11px;padding:4px 11px;color:var(--red);border-color:rgba(240,86,74,0.3);" data-bk-del="${rec.seq}" aria-label="Delete backup">✕</button>
+        </div>
+      </div>`).join('');
+  },
+
+  _STUDY_COLORS: [
+    { key: 'default', label: 'Default',  color: 'var(--accent)', dark: '#f0a500', desc: 'Original amber — no change' },
+    { key: 'focus',   label: 'Focus',    color: '#4d8dff',       dark: '#4d8dff', desc: 'Calm alertness — math, logic, dense reading' },
+    { key: 'growth',  label: 'Growth',   color: '#43b874',       dark: '#43b874', desc: 'Easiest on the eyes — long study marathons' },
+    { key: 'energy',  label: 'Energy',   color: '#ff7a1a',       dark: '#ff7a1a', desc: 'Alertness — flashcards & exam prep' },
+  ],
+
+  _buildStamp() {
+    // Read the ?v= cache-buster off a script tag that is ACTUALLY loaded in
+    // this page — so the number shown always matches the files really running,
+    // never a hardcoded value that could go stale.
+    try {
+      const s = document.querySelector('script[src*="v="]');
+      const m = s && s.getAttribute('src').match(/[?&]v=(\d+)/);
+      return m ? m[1] : 'unknown';
+    } catch (e) { return 'unknown'; }
+  },
+
+  _renderStudyColorSwatches() {
+    const current = (typeof AccentTheme !== 'undefined') ? AccentTheme.get() : 'default';
+    return this._STUDY_COLORS.map(c => `
+      <div class="study-color-swatch${c.key===current?' active':''}" style="--swatch-color:${c.dark};" data-accent="${c.key}">
+        <div class="study-color-dot"></div>
+        <div class="study-color-label">${c.label}</div>
+        <span class="study-color-desc">${c.desc}</span>
+      </div>`).join('');
+  },
+
+  _bindStudyColorSwatches() {
+    const grid = document.getElementById('study-color-grid');
+    if (!grid) return;
+    grid.querySelectorAll('[data-accent]').forEach(el => {
+      el.addEventListener('click', () => {
+        if (typeof AccentTheme === 'undefined') return;
+        AccentTheme.set(el.dataset.accent);
+        grid.innerHTML = this._renderStudyColorSwatches();
+        this._bindStudyColorSwatches();
+      });
+    });
+  },
+
+  _renderCorrectionsPanel() {
+    if (typeof AICorrections === 'undefined') return '<p style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);">No corrections yet.</p>';
+    const nodes = nodeStore.getAll().filter(n => n.aiCorrections?.length > 0);
+    if (!nodes.length) return '<p style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);">No corrections yet. Long-press any AI-generated item in your notes to record one.</p>';
+
+    let html = '';
+    nodes.forEach(node => {
+      const cors = AICorrections.getAll(node);
+      html += `<div style="margin-bottom:16px;">
+        <div style="font-family:var(--font-ui);font-size:12px;font-weight:700;color:var(--text-primary);margin-bottom:6px;display:flex;align-items:center;gap:8px;">
+          <span>${String(node.title||"").replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;")}</span>
+          <span style="font-family:var(--font-mono);font-size:9px;color:var(--text-muted);">${cors.length} correction${cors.length !== 1 ? 's' : ''}</span>
+          <button class="btn-secondary" data-node-clear="${node.id}" style="font-size:10px;padding:2px 8px;margin-left:auto;">Clear all</button>
+        </div>`;
+      cors.forEach(c => {
+        html += `<div style="background:var(--bg-base);border:1px solid var(--border);border-radius:8px;padding:9px 12px;margin-bottom:6px;display:flex;align-items:flex-start;gap:10px;">
+          <div style="flex:1;min-width:0;">
+            <div style="font-family:var(--font-mono);font-size:9px;color:var(--accent);margin-bottom:3px;text-transform:uppercase;">${c.category} · ${AICorrections._timeAgo(c.ts)}</div>
+            <div style="font-family:var(--font-body);font-size:12px;color:var(--text-primary);line-height:1.5;">${c.userNote}</div>
+            ${c.aiOutput ? `<div style="font-family:var(--font-body);font-size:11px;color:var(--text-muted);margin-top:3px;font-style:italic;">AI said: "${c.aiOutput.slice(0, 120)}${c.aiOutput.length > 120 ? '…' : ''}"</div>` : ''}
+          </div>
+          <button class="btn-secondary" data-cor-del="${c.id}" data-cor-node="${node.id}" style="font-size:10px;padding:3px 8px;flex-shrink:0;color:var(--red);">✕</button>
+        </div>`;
+      });
+      html += '</div>';
+    });
+    return html;
+  },
+};

--- a/knowledgenode/www/js/ui/SocraticTutor.js
+++ b/knowledgenode/www/js/ui/SocraticTutor.js
@@ -1,0 +1,285 @@
+/**
+ * SocraticTutor.js — Socratic tutoring flow
+ * Step 1: Ask what's confusing
+ * Step 2: Explain the confusing part
+ * Step 3: Simplified practice question
+ * Step 4: Exam-style question
+ * Step 5: Mark and save session summary
+ */
+/**
+ * VIEW NOTE: this overlay is a different SKIN over the same CoachEngine that
+ * powers the Study Coach chat — one shared history, one mode state machine,
+ * one AI pathway, one Director memory. Opening it starts the engine's
+ * 'example' mode; closing it returns the engine to normal coaching.
+ */
+const SocraticTutor = {
+  _node: null, _example: null, _saved: false, _lastChips: [],
+
+  open(node, example) {
+    this._node = node; this._example = example; this._saved = false;
+    CoachEngine.startExample(node, example);
+    document.getElementById('st-root')?.remove();
+
+    const root = document.createElement('div');
+    root.id = 'st-root';
+    root.setAttribute('data-kn-overlay', '');
+    root.setAttribute('data-kn-close', '#st-back');
+    // Full screen — header fixed, footer fixed, chat fills remaining space
+    root.style.cssText = 'position:fixed;inset:0;z-index:9999;display:flex;flex-direction:column;background:var(--bg-base);font-family:var(--font-body);';
+
+    const headerH = '52px';
+    const footerH = '130px';
+
+    root.innerHTML =
+      // ── HEADER ──────────────────────────────────────────────────
+      '<div style="height:' + headerH + ';flex-shrink:0;display:flex;align-items:center;gap:8px;padding:0 14px;background:var(--bg-raised);border-bottom:1px solid var(--border);">'
+        + '<button id="st-back" style="background:none;border:none;color:var(--text-muted);font-size:22px;cursor:pointer;padding:4px;line-height:1;flex-shrink:0;">←</button>'
+        + '<div style="flex:1;min-width:0;">'
+          + '<div style="font-family:var(--font-ui);font-size:13px;font-weight:700;color:var(--text-primary);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">⬡ ' + this._esc(example.title) + '</div>'
+          + '<div style="font-family:var(--font-mono);font-size:10px;color:var(--text-muted);">' + this._esc(node.subject||'') + ' · Step <span id="st-step">1</span>/5</div>'
+        + '</div>'
+        + '<button id="st-show-q" style="flex-shrink:0;background:var(--accent-soft);border:1px solid var(--accent-dim);border-radius:8px;color:var(--accent);font-size:11px;font-weight:700;padding:5px 10px;cursor:pointer;font-family:var(--font-mono);">📋 Q</button>'
+      + '</div>'
+
+      // ── QUESTION PANEL (hidden by default, slides down) ──────────
+      + '<div id="st-qpanel" style="flex-shrink:0;overflow:hidden;max-height:0;transition:max-height 0.3s ease;background:var(--bg-raised);border-bottom:1px solid var(--border);">'
+        + '<div style="padding:12px 16px;max-height:40vh;overflow-y:auto;-webkit-overflow-scrolling:touch;">'
+          + '<div style="font-family:var(--font-mono);font-size:9px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--accent);margin-bottom:8px;">Question</div>'
+          + '<div style="font-size:13.5px;line-height:1.7;color:var(--text-primary);">' + this._esc(example.question) + '</div>'
+        + '</div>'
+      + '</div>'
+
+      // ── CHAT (fills all remaining space) ─────────────────────────
+      + '<div id="st-chat" style="flex:1;overflow-y:auto;-webkit-overflow-scrolling:touch;padding:14px;display:flex;flex-direction:column;gap:12px;min-height:0;"></div>'
+
+      // ── FOOTER (fixed height) ─────────────────────────────────────
+      + '<div style="flex-shrink:0;padding:8px 12px 16px;background:var(--bg-raised);border-top:1px solid var(--border);">'
+        + '<div style="display:flex;gap:8px;margin-bottom:8px;">'
+          + '<textarea id="st-input" rows="2" placeholder="Ask, answer, or say what\'s confusing…" style="flex:1;resize:none;background:var(--bg-base);border:1px solid var(--border);border-radius:12px;color:var(--text-primary);font-size:14px;line-height:1.5;padding:10px 13px;font-family:var(--font-body);"></textarea>'
+          + '<button id="st-send" style="align-self:flex-end;background:var(--accent);color:#060709;border:none;border-radius:12px;font-family:var(--font-ui);font-size:14px;font-weight:800;padding:13px 18px;cursor:pointer;">Send</button>'
+        + '</div>'
+        + '<div id="st-chips" style="display:flex;gap:6px;flex-wrap:wrap;"></div>'
+      + '</div>';
+
+    document.body.appendChild(root);
+
+    // Events
+    document.getElementById('st-back').onclick = () => this._close();
+    document.getElementById('st-send').onclick = () => this._submit();
+    document.getElementById('st-input').onkeydown = e => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); this._submit(); } };
+
+    document.getElementById('st-show-q').onclick = () => {
+      const panel = document.getElementById('st-qpanel');
+      const btn   = document.getElementById('st-show-q');
+      const open  = panel.style.maxHeight && panel.style.maxHeight !== '0px' && panel.style.maxHeight !== '0';
+      panel.style.maxHeight = open ? '0' : '40vh';
+      btn.textContent = open ? '📋 Q' : '📋 Hide';
+    };
+
+    document.getElementById('st-chips').addEventListener('click', e => {
+      const c = e.target.closest('[data-chip]');
+      if (c) { document.getElementById('st-input').value = c.dataset.chip; this._submit(); }
+    });
+
+    this._opening();
+  },
+
+  _opening() {
+    this._step_n(1);
+    const msg = 'Let\'s work through this together. 🎯\n\nTap **📋 Q** up top to see the question. Tell me where you\'d like to start — or just ask me anything about it.';
+    this._ai(msg);
+    CoachEngine.history.push({ role: 'coach', text: msg });
+    this._chips(['Explain the question', 'I don\'t know how to start', 'Show me step by step', 'I\'ll try it myself']);
+  },
+
+  async _submit() {
+    const inp  = document.getElementById('st-input');
+    const text = inp?.value.trim();
+    if (!text) return;
+    inp.value = '';
+    this._chips([]);
+    this._student(text);
+    CoachEngine.history.push({ role: 'user', text });
+    this._loading(true);
+    try {
+      await this._turn();
+    } catch(e) {
+      this._ai('⚠ ' + (e.message || 'Something went wrong'));
+    }
+    this._loading(false);
+  },
+
+  /** One conversational turn — through the SAME CoachEngine.turn() pathway
+   *  the chat uses: shared history, shared memory signal, one prompt system.
+   *  The engine's 'example' mode supplies the worked-example context and this
+   *  view's control-tag protocol ([[CHIPS]]/[[PHASE]]/[[DONE]]). */
+  async _turn() {
+    const lastUser = [...CoachEngine.history].reverse().find(h => h.role === 'user');
+    const entry = await CoachEngine.turn(lastUser ? lastUser.text : '');
+    const { text, chips, phase, done } = this._parseControls(entry.text);
+    entry.text = text; // keep the shared record clean of view control tags
+    this._ai(text);
+    if (phase) this._step_n(phase);
+    if (done) { this._finish(); return; }
+    this._chips(chips && chips.length ? chips : this._defaultChips());
+  },
+
+  /** Pull optional control tags out of the reply; return cleaned text + UI hints. */
+  _parseControls(raw) {
+    let text = String(raw || '');
+    let chips = null, phase = null, done = false;
+    const cm = text.match(/\[\[CHIPS:([^\]]*)\]\]/i);
+    if (cm) chips = cm[1].split('|').map(s => s.trim()).filter(Boolean).slice(0, 4);
+    const pm = text.match(/\[\[PHASE:\s*(\d)\s*\]\]/i);
+    if (pm) phase = Math.max(1, Math.min(5, parseInt(pm[1], 10)));
+    if (/\[\[DONE\]\]/i.test(text)) done = true;
+    text = text.replace(/\[\[CHIPS:[^\]]*\]\]/ig, '')
+               .replace(/\[\[PHASE:[^\]]*\]\]/ig, '')
+               .replace(/\[\[DONE\]\]/ig, '').trim();
+    return { text, chips, phase, done };
+  },
+
+  _defaultChips() {
+    return ['Explain it simpler', 'Give me a hint', 'Let me try the answer', 'Try a different method'];
+  },
+
+  /** Natural finish: save a summary and offer Done / Try another. */
+  _finish() {
+    this._step_n(5);
+    this._saveSummaryFromHistory();
+    const chips = document.getElementById('st-chips');
+    if (chips) {
+      chips.innerHTML =
+        '<button id="st-done-btn" style="background:var(--accent);border:none;border-radius:10px;color:#060709;padding:10px 20px;font-family:var(--font-ui);font-size:13px;font-weight:700;cursor:pointer;">✓ Done</button>'
+        + '<button id="st-retry-btn" style="background:var(--bg-base);border:1px solid var(--border);border-radius:10px;color:var(--text-primary);padding:10px 18px;font-family:var(--font-ui);font-size:13px;cursor:pointer;">↩ Try another</button>';
+      document.getElementById('st-done-btn').onclick  = () => this._close();
+      document.getElementById('st-retry-btn').onclick = () => { const nid = this._node?.id; this._close(); setTimeout(() => { if (nid) NodeDetailView.open(nid); }, 100); };
+    }
+    // Keep the input available — the student can still ask follow-ups.
+  },
+
+  /** Save a session summary from the conversation (most recent student attempt
+   *  + tutor reply). Captures its own refs so it is safe even if the session is
+   *  closed immediately after. Runs at most once per session. */
+  _saveSummaryFromHistory() {
+    if (this._saved || !this._node || !this._example) return;
+    if (CoachEngine.history.length < 3) return;   // not enough of a session to log
+    this._saved = true;
+    const node = this._node, example = this._example;
+    const lastStudent = [...CoachEngine.history].reverse().find(h => h.role === 'user')?.text || '';
+    const lastTutor   = [...CoachEngine.history].reverse().find(h => h.role === 'coach')?.text || '';
+    (async () => {
+      try {
+        const s = await AIService._callWithFunction('noteProcessing', [{ role:'user',
+          content: 'Summarise in 20 words: topic="' + node.title + '", example="' + example.title + '". Student: ' + lastStudent.slice(0,100) + '. Feedback: ' + lastTutor.slice(0,150) + '. What understood and gaps.'
+        }], 80);
+        if (!node.sessionLog) node.sessionLog = [];
+        node.sessionLog.push({ date: new Date().toLocaleDateString(), type:'tutor', example: example.title, summary: s.trim() });
+        if (node.sessionLog.length > 30) node.sessionLog = node.sessionLog.slice(-30);
+        LearnerMemory.recordTutorSession(node, example.title, s.trim());
+        nodeStore.save(node);
+      } catch(e) { console.warn('Summary save failed:', e); }
+    })();
+  },
+
+  // ── UI helpers ─────────────────────────────────────────────────
+  _ai(rawText) {
+    const chat = document.getElementById('st-chat');
+    if (!chat) return;
+
+    // Clean the response — strip JSON fences, extract text from JSON objects
+    let text = String(rawText || '').trim();
+
+    // Strip markdown fences
+    text = text.replace(/^```(?:json)?\s*/i, '').replace(/\s*```\s*$/i, '').trim();
+
+    // If it looks like a JSON object, try to extract the text value
+    if (text.startsWith('{')) {
+      try {
+        const obj = JSON.parse(text);
+        // Common keys AI might use
+        text = obj.response || obj.text || obj.message || obj.explanation || obj.answer || Object.values(obj)[0] || text;
+        text = String(text);
+      } catch(e) {
+        // Not valid JSON — use as-is but strip braces/quotes
+        text = text.replace(/^[{"]|[}"]$/g, '').trim();
+      }
+    }
+
+    // Convert literal \n sequences to real newlines
+    text = text.replace(/\\n/g, '\n');
+
+    const wrap = document.createElement('div');
+    wrap.style.cssText = 'display:flex;flex-direction:column;align-items:flex-start;margin-bottom:2px;';
+    const lbl = document.createElement('div');
+    lbl.style.cssText = 'font-family:var(--font-mono);font-size:10px;color:var(--accent);margin-bottom:5px;font-weight:700;letter-spacing:.04em;display:flex;align-items:center;gap:8px;';
+    lbl.innerHTML = '<span>⬡ Tutor</span>'
+      + (typeof AICorrections !== 'undefined' && this._node
+          ? AICorrections.renderButton('tutor', text)
+          : '');
+    const bub = document.createElement('div');
+    bub.style.cssText = 'max-width:92%;padding:12px 15px;border-radius:4px 16px 16px 16px;background:var(--bg-raised);border:1px solid var(--border);font-size:14px;line-height:1.7;color:var(--text-primary);word-break:break-word;';
+    // Render markdown bold and line breaks
+    bub.innerHTML = this._esc(text)
+      .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
+      .replace(/\n/g, '<br>');
+    wrap.appendChild(lbl);
+    wrap.appendChild(bub);
+    chat.appendChild(wrap);
+    if (typeof AICorrections !== 'undefined' && this._node) AICorrections.bindCorrectionButtons(wrap, this._node);
+    // Land at the TOP of the tutor's reply once layout settles.
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+      if (wrap.scrollIntoView) wrap.scrollIntoView({ block: 'start', behavior: 'auto' });
+    }));
+  },
+
+  _student(text) {
+    const chat = document.getElementById('st-chat');
+    if (!chat) return;
+    const wrap = document.createElement('div');
+    wrap.style.cssText = 'display:flex;justify-content:flex-end;margin-bottom:2px;';
+    const bub = document.createElement('div');
+    bub.style.cssText = 'max-width:82%;padding:11px 15px;border-radius:16px 16px 4px 16px;background:var(--accent-soft);border:1px solid var(--accent-dim);font-size:14px;line-height:1.65;color:var(--text-primary);word-break:break-word;';
+    bub.innerHTML = this._esc(text).replace(/\n/g,'<br>');
+    wrap.appendChild(bub);
+    chat.appendChild(wrap);
+    chat.scrollTop = chat.scrollHeight;
+  },
+
+  _chips(options) {
+    this._lastChips = options;
+    const area = document.getElementById('st-chips');
+    if (!area) return;
+    area.innerHTML = options.map(o =>
+      '<button data-chip="' + this._esc(o) + '" style="background:var(--bg-raised);border:1px solid var(--border);border-radius:20px;color:var(--text-secondary);cursor:pointer;font-size:12px;padding:5px 13px;white-space:nowrap;">' + this._esc(o) + '</button>'
+    ).join('');
+  },
+
+  _loading(on) {
+    const btn = document.getElementById('st-send');
+    if (btn) { btn.textContent = on ? '…' : 'Send'; btn.disabled = on; }
+    document.getElementById('st-thinking')?.remove();
+    if (on) {
+      const d = document.createElement('div');
+      d.id = 'st-thinking';
+      d.style.cssText = 'color:var(--text-muted);font-family:var(--font-mono);font-size:11px;padding:2px 0;';
+      d.textContent = '⬡ Tutor is thinking…';
+      const chat = document.getElementById('st-chat');
+      if (chat) { chat.appendChild(d); chat.scrollTop = chat.scrollHeight; }
+    }
+  },
+
+  _step_n(n) {
+    const el = document.getElementById('st-step');
+    if (el) el.textContent = n;
+  },
+
+  _close() {
+    this._saveSummaryFromHistory();   // capture the session even if they just leave
+    document.getElementById('st-root')?.remove();
+    CoachEngine.end();                // back to normal coaching — history is kept
+    this._node = null; this._example = null; this._saved = false;
+  },
+
+  _esc: s => String(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'),
+};

--- a/knowledgenode/www/js/ui/SpeechPill.js
+++ b/knowledgenode/www/js/ui/SpeechPill.js
@@ -1,0 +1,58 @@
+/**
+ * SpeechPill.js — Floating stop button for active speech
+ *
+ * Whenever any part of the app starts speaking, call SpeechPill.show().
+ * A small pill appears in the bottom-right corner above the nav bar.
+ * Tapping it cancels all speech immediately.
+ * It disappears automatically when speech ends.
+ */
+const SpeechPill = {
+  _el: null,
+
+  show() {
+    if (this._el) return; // already showing
+    const pill = document.createElement('button');
+    pill.id = 'speech-pill';
+    pill.innerHTML = '🔊 <span>Reading…</span> <span style="opacity:.7;font-size:11px;margin-left:4px;">tap to stop</span>';
+    pill.style.cssText = [
+      'position:fixed',
+      'bottom:calc(64px + env(safe-area-inset-bottom,0px))',
+      'right:16px',
+      'z-index:9100',
+      'background:var(--accent)',
+      'color:#000',
+      'border:none',
+      'border-radius:20px',
+      'padding:8px 16px',
+      'font-family:var(--font-ui)',
+      'font-size:13px',
+      'font-weight:700',
+      'cursor:pointer',
+      'box-shadow:0 4px 16px rgba(0,0,0,.4)',
+      'display:flex',
+      'align-items:center',
+      'gap:6px',
+      'animation:pill-in .2s ease',
+    ].join(';');
+
+    pill.addEventListener('click', () => {
+      window.speechSynthesis?.cancel();
+      this.hide();
+      // Notify GuidedView so its button state resets
+      if (typeof GuidedView !== 'undefined') GuidedView._updateSpeechBtns(false);
+      if (typeof LectureMode !== 'undefined') LectureMode._isPlaying = false;
+    });
+
+    document.body.appendChild(pill);
+    this._el = pill;
+  },
+
+  hide() {
+    if (!this._el) return;
+    this._el.style.animation = 'pill-out .15s ease forwards';
+    setTimeout(() => {
+      this._el?.remove();
+      this._el = null;
+    }, 160);
+  },
+};

--- a/knowledgenode/www/js/ui/StreakTracker.js
+++ b/knowledgenode/www/js/ui/StreakTracker.js
@@ -1,0 +1,67 @@
+/**
+ * StreakTracker.js — Daily study streak
+ * Tracks consecutive days of activity (any review or node creation).
+ */
+const StreakTracker = {
+  _key: 'kn_streak_v1',
+
+  _data() {
+    try { return JSON.parse(localStorage.getItem(this._key)) || { streak: 0, longest: 0, lastDate: null, history: {} }; }
+    catch { return { streak: 0, longest: 0, lastDate: null, history: {} }; }
+  },
+
+  _save(d) { localStorage.setItem(this._key, JSON.stringify(d)); },
+
+  /** Call on any study activity */
+  recordActivity() {
+    const d    = this._data();
+    const today = this._today();
+    if (d.lastDate === today) return;          // already recorded today
+
+    const yesterday = this._daysAgo(1);
+    d.streak   = d.lastDate === yesterday ? d.streak + 1 : 1;
+    d.longest  = Math.max(d.longest, d.streak);
+    d.lastDate = today;
+    d.history[today] = (d.history[today] || 0) + 1;
+    this._save(d);
+    this.render();
+  },
+
+  getStats() {
+    const d = this._data();
+    const today = this._today();
+    const isActive = d.lastDate === today || d.lastDate === this._daysAgo(1);
+    return {
+      streak:  isActive ? d.streak : 0,
+      longest: d.longest,
+      history: d.history,
+      lastDate: d.lastDate,
+    };
+  },
+
+  render() {
+    const s = this.getStats();
+    document.querySelectorAll('.streak-count').forEach(el => el.textContent = s.streak);
+    document.querySelectorAll('.streak-fire').forEach(el => {
+      el.textContent = s.streak >= 7 ? '🔥' : s.streak >= 3 ? '⚡' : '📅';
+    });
+  },
+
+  /** Build a 7-column heatmap grid for the past 12 weeks */
+  buildHeatmap() {
+    const d = this._data();
+    const weeks = 12;
+    const days  = weeks * 7;
+    const cells = [];
+    for (let i = days - 1; i >= 0; i--) {
+      const date  = this._daysAgo(i);
+      const count = d.history[date] || 0;
+      const level = count === 0 ? 0 : count === 1 ? 1 : count <= 3 ? 2 : 3;
+      cells.push(`<div class="heatmap-cell level-${level}" title="${date}: ${count} activities"></div>`);
+    }
+    return `<div class="heatmap-grid">${cells.join('')}</div>`;
+  },
+
+  _today()        { return new Date().toISOString().slice(0, 10); },
+  _daysAgo(n)     { const d = new Date(); d.setDate(d.getDate() - n); return d.toISOString().slice(0, 10); },
+};

--- a/knowledgenode/www/js/ui/StudyCoach.js
+++ b/knowledgenode/www/js/ui/StudyCoach.js
@@ -1,0 +1,540 @@
+/**
+ * StudyCoach.js — "Talk to your coach."
+ *
+ * A read-only conversational layer over the cross-node brain. The learner can
+ * ask how to study — where to start, what's weak, how to spend their time —
+ * and the coach answers using their whole library (mastery, weak spots,
+ * history, plan). It advises only; it does not change settings.
+ */
+const StudyCoach = {
+  _pending: false,
+
+  // ── UNIFIED ENGINE BRIDGES ─────────────────────────────────────────
+  // The chat is a VIEW over CoachEngine — the same engine (and the same
+  // history, mode, and memory) that powers the Socratic Tutor overlay.
+  get _history()  { return CoachEngine.history; },
+  set _history(v) { CoachEngine.history = Array.isArray(v) ? v : []; },
+  get _tutor()    { return CoachEngine.mode.kind === 'tutor' ? CoachEngine.mode : null; },
+  set _tutor(v)   { CoachEngine.mode = v ? { kind: 'tutor', nodeId: v.nodeId, i: v.i || 0 } : { kind: 'advise' }; },
+  get _focus()    { return CoachEngine.mode.kind === 'resource' ? CoachEngine.mode : null; },
+
+  /* ─── Socratic tutoring (State A): the coach pivots from advisor to tutor ── */
+
+  _tutorCtx() { return CoachEngine.tutorContext(); },
+
+  _startTutor(nodeId) {
+    const node = nodeStore.get(nodeId);
+    if (!node || !(node.questions || []).length) {
+      Toast.info('That topic has no practice questions yet — upload or add some first.');
+      return;
+    }
+    CoachEngine.startTutor(node.id);
+    this._ask('Tutor me through the first question step by step. Start with the strategy.');
+  },
+
+  /** Self-mark the current question (updates the Revision Questions node's
+   *  SRS state + struggle log through the engine), then advance. */
+  _tutorRate(gotIt) {
+    if (!this._tutor) return;
+    CoachEngine.recordOutcome(gotIt);
+    this._tutorNext();
+  },
+
+  _tutorNext() {
+    if (!this._tutor) return;
+    if (!CoachEngine.tutorAdvance()) {
+      this._history.push({ role: 'coach', text: 'That was the last question — great work making it through the whole set. 🎉 Your misses are tracked under each topic\'s Mastery tab → "Review in your textbook".' });
+      this._renderLog();
+      return;
+    }
+    this._ask('I\'m ready — next question please. Start with the strategy.');
+  },
+
+  _tutorEnd() {
+    CoachEngine.end();
+    this._history.push({ role: 'coach', text: 'Tutoring ended — back to normal coaching. Ask me anything, or say "tutor me through …" to start again.' });
+    this._renderLog();
+  },
+
+  /* ─── Resource mode (State B): studying an existing node's material ── */
+
+  _startResource(nodeId) {
+    const node = nodeStore.get(nodeId);
+    if (!node) { Toast.info('That topic no longer exists.'); return; }
+    CoachEngine.startResource(node.id);
+    this._ask('Let\'s study this topic together. Give me a quick orientation: the key ideas in this material and where students usually slip up.');
+  },
+
+  _resourceEnd() {
+    CoachEngine.end();
+    this._history.push({ role: 'coach', text: 'Done studying that topic — back to normal coaching.' });
+    this._renderLog();
+  },
+
+  /** Compile a linked Revision Questions node from the source node — the
+   *  engine does the node-graph work; the chat just reports and offers to
+   *  tutor the new set. */
+  async _compileQuestions(nodeId) {
+    if (this._pending) return;
+    this._pending = true;
+    this._renderLog();
+    try {
+      const qNode = await CoachEngine.compileQuestionsNode(nodeId);
+      const entry = { role: 'coach', text: 'Done — I built "' + qNode.title + '" with ' + qNode.questions.length + ' questions from your saved material. It\'s in your Library, linked to the source topic. Want me to tutor you through it now?' };
+      entry.action = { kind: 'tutorQuestions', params: { _nodeId: qNode.id, _nodeTitle: qNode.title }, label: '🎓 Tutor me through "' + qNode.title + '"' };
+      this._history.push(entry);
+    } catch (e) {
+      this._history.push({ role: 'coach', text: 'I couldn\'t build the question set: ' + (e.message || 'unknown error') + '. Try again in a moment.' });
+    }
+    this._pending = false;
+    this._renderLog();
+  },
+
+  open() {
+    // Restore the saved conversation so reopening the app continues where the
+    // student left off instead of starting from a blank slate.
+    if (!CoachEngine.history.length) CoachEngine.loadHistory();
+    if (!AIService.hasApiKey()) {
+      Toast.info('Configure AI in Settings to talk to your study coach.');
+      return;
+    }
+    if (!nodeStore.getAll().length) {
+      Toast.info('Add a topic or two first — the coach reads your library.');
+      return;
+    }
+    Modal.open(
+      '<div class="coach">'
+      + '<div class="coach-head"><span class="coach-orb">⬡</span><div><h2 style="margin:0;font-family:var(--font-ui);font-size:18px;font-weight:800;">Your Study Coach</h2>'
+      + '<p style="margin:2px 0 0;font-family:var(--font-mono);font-size:10px;color:var(--text-muted);">Ask about how to study — it sees your whole library.</p></div></div>'
+      + '<div id="coach-log" class="coach-log"></div>'
+      + '<div class="coach-input-row">'
+      + '<input type="text" id="coach-input" class="config-input" placeholder="e.g. Where should I start today?" style="flex:1;font-size:13px;" />'
+      + '<button class="btn-primary" id="coach-send" style="padding:9px 14px;">→</button>'
+      + '</div></div>',
+      () => { document.querySelector('#modal-overlay .modal')?.classList.remove('modal-coach'); }
+    );
+    setTimeout(() => {
+      // Lock the modal to a fixed height and stop IT from scrolling, so the
+      // only scroll container is the coach log. Two nested scrollers were
+      // fighting and painting over each other.
+      document.querySelector('#modal-overlay .modal')?.classList.add('modal-coach');
+      this._renderLog();
+      const input = document.getElementById('coach-input');
+      const send  = () => { const v = input.value.trim(); if (v) { input.value=''; this._ask(v); } };
+      document.getElementById('coach-send')?.addEventListener('click', send);
+      input?.addEventListener('keydown', e => { if (e.key === 'Enter') send(); });
+      input?.focus();
+    }, 0);
+  },
+
+  _renderSuggestions() { /* suggestions now render inside the log */ },
+
+  _renderLog() {
+    const log = document.getElementById('coach-log');
+    // Modal may have been closed while a request was in-flight — silently abort render.
+    // _pending was already reset to false in _ask's finally path, so next open is clean.
+    if (!log) return;
+    if (!this._history.length && !this._pending) {
+      // Director-aware opening: if the Director ran recently, surface its
+      // assessment and offer to explain or act on it instead of generic chips.
+      const state     = (typeof LearnerState !== 'undefined') ? LearnerState.get() : {};
+      const directive = state.director;
+      let openingHtml = '';
+      // Hoisted to outer scope: referenced below at the "coach-empty" line even
+      // when there's no directive (fresh/demo session), so it must always exist.
+      let isExpired = false;
+      let chips = [
+        'Where should I start today?',
+        'What am I weakest at?',
+        'How do I manage my time before the exam?',
+        'How do I deal with study stress?',
+      ];
+
+      if (directive && directive.at) {
+        const daysAgo = Math.floor((Date.now() - directive.at) / 86400000);
+        const when    = daysAgo === 0 ? 'today' : daysAgo === 1 ? 'yesterday' : daysAgo + ' days ago';
+        const urgents = (directive.urgentNodes || []).slice(0, 2);
+        const methodLabel = {
+          review: 'spaced repetition review',
+          guided: 'guided step-by-step study',
+          'blank-recall': 'active recall practice',
+          exam: 'exam-pressure practice',
+        }[directive.overallStudyMethod] || (directive.overallStudyMethod || 'study');
+
+        // After 7 days the assessment is likely outdated — show a nudge instead
+        // of the full card. After 30 days, don't show it at all.
+        const isStale   = daysAgo >= 7;
+        isExpired = daysAgo >= 30;
+
+        if (!isExpired) {
+          if (isStale) {
+            // Soft nudge — still surfaceable but flagged outdated
+            openingHtml = '<div class="coach-director-context coach-dir-stale">'
+              + '<span class="coach-dir-badge">⬡ AI assessment from ' + this._esc(when) + ' — may be outdated</span>'
+              + '<p style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);">Your library has likely changed. Run a fresh assessment for an accurate read.</p>'
+              + '</div>';
+            chips = [
+              'Run a fresh AI assessment',
+              'What am I weakest at right now?',
+              'How do I manage my time before the exam?',
+              'Where should I start today?',
+            ];
+          } else {
+            // Fresh assessment — show in full
+            openingHtml = '<div class="coach-director-context">'
+              + '<span class="coach-dir-badge">⬡ Last AI assessment — ' + this._esc(when) + '</span>'
+              + (directive.assessment ? '<p>' + this._esc(directive.assessment) + '</p>' : '')
+              + (urgents.length ? '<p>Flagged urgent: <strong>' + urgents.map(n => this._esc(n)).join(', ') + '</strong></p>' : '')
+              + (directive.planGuidance ? '<p class="coach-dir-plan">' + this._esc(directive.planGuidance) + '</p>' : '')
+              + (directive.firstAction ? '<p class="coach-dir-action">▶ ' + this._esc(directive.firstAction) + '</p>' : '')
+              + '</div>';
+
+            chips = [
+              'Why did the AI choose ' + methodLabel + ' for me?',
+              urgents.length ? 'Help me understand ' + urgents[0] : 'What should I focus on now?',
+              'Have I done what the AI suggested?',
+              'How do I manage my time before the exam?',
+            ];
+          }
+        }
+      }
+
+      log.innerHTML = openingHtml
+        + '<div class="coach-empty">'
+        + (directive && !isExpired ? "I can see the assessment above. Ask me anything — I'll explain the reasoning, challenge it, or help you start." : "Ask me anything about how to study. I can see every topic, your mastery, what you keep getting wrong, and your plan.")
+        + '</div>'
+        + '<div class="coach-suggest">' + chips.map(c =>
+            '<button class="coach-chip" data-q="' + c.replace(/"/g, '&quot;') + '">' + this._esc(c) + '</button>'
+          ).join('') + '</div>';
+      log.querySelectorAll('.coach-chip').forEach(b =>
+        b.addEventListener('click', () => this._ask(b.dataset.q)));
+      return;
+    }
+    const html = this._history.map((m, i) =>
+      m.role === 'user'
+        ? '<div class="coach-msg user" data-msg="' + i + '">' + this._esc(m.text) + '</div>'
+        : '<div class="coach-msg coach cclamp" data-msg="' + i + '">'
+            + m.text.split('\n').filter(l=>l.trim()).map(l=>'<p style="margin:0 0 8px;">'+this._md(l)+'</p>').join('')
+            + (m.action ? '<button class="coach-action" data-i="' + i + '">' + this._esc(m.action.label) + '</button>' : '')
+          + '</div>'
+    ).join('') + (this._pending ? '<div class="coach-msg coach" data-msg="pending"><div class="aif-loading"><div class="aif-dot"></div><div class="aif-dot"></div><div class="aif-dot"></div></div></div>' : '')
+    + (this._tutor && !this._pending
+        ? (() => {
+            const node = nodeStore.get(this._tutor.nodeId);
+            const total = node ? (node.questions || []).length : 0;
+            return '<div class="coach-tutor-bar" style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;padding:8px 4px;">'
+              + '<span style="font-family:var(--font-mono);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--accent);">🎓 Tutoring — Q' + (this._tutor.i + 1) + ' of ' + total + '</span>'
+              + '<button class="btn-secondary" id="coach-tutor-next" style="font-size:11px;padding:5px 10px;color:var(--green,#34c77b);">✓ Got it — next</button>'
+              + '<button class="btn-secondary" id="coach-tutor-miss" style="font-size:11px;padding:5px 10px;color:var(--red,#f0564a);">✗ Struggled — next</button>'
+              + '<button class="btn-secondary" id="coach-tutor-end" style="font-size:11px;padding:5px 10px;color:var(--text-muted);">✕ End tutoring</button>'
+              + '</div>';
+          })()
+        : '')
+    + (this._focus && !this._pending
+        ? (() => {
+            const node = nodeStore.get(this._focus.nodeId);
+            return '<div class="coach-resource-bar" style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;padding:8px 4px;">'
+              + '<span style="font-family:var(--font-mono);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--accent);">📖 Studying — ' + this._esc(node ? node.title : '') + '</span>'
+              + '<button class="btn-secondary" id="coach-res-compile" style="font-size:11px;padding:5px 10px;">⚡ Make revision questions</button>'
+              + '<button class="btn-secondary" id="coach-res-end" style="font-size:11px;padding:5px 10px;color:var(--text-muted);">✕ Done</button>'
+              + '</div>';
+          })()
+        : '');
+
+    // Render synchronously in one shot. (Earlier deferred/double-buffered
+    // rendering raced with rapid successive calls and left overlapping bubbles.)
+    log.innerHTML = html;
+
+    log.querySelectorAll('.coach-action').forEach(btn =>
+      btn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        const m = this._history[parseInt(btn.dataset.i, 10)];
+        if (m && m.action) this._runAction(m.action);
+      }));
+    document.getElementById('coach-tutor-next')?.addEventListener('click', (e) => { e.stopPropagation(); this._tutorRate(true); });
+    document.getElementById('coach-tutor-miss')?.addEventListener('click', (e) => { e.stopPropagation(); this._tutorRate(false); });
+    document.getElementById('coach-tutor-end') ?.addEventListener('click', (e) => { e.stopPropagation(); this._tutorEnd(); });
+    document.getElementById('coach-res-compile')?.addEventListener('click', (e) => { e.stopPropagation(); if (this._focus) this._compileQuestions(this._focus.nodeId); });
+    document.getElementById('coach-res-end')   ?.addEventListener('click', (e) => { e.stopPropagation(); this._resourceEnd(); });
+
+    // Messages render clamped to a preview height (.cclamp). Here we check —
+    // locally on each element — whether the content actually overflows that
+    // clamp. This compares the element's own content height to its own clamped
+    // height, so it does NOT depend on the sheet's outer layout being settled
+    // (the source of the earlier flakiness). Overflowing → keep the clamp + add
+    // the expand pill. Fits → drop the clamp and show it in full, no pill.
+    const wireExpand = () => {
+      log.querySelectorAll('.coach-msg.coach[data-msg]').forEach(el => {
+        if (el.dataset.msg === 'pending' || el.dataset.expChecked === '1') return;
+        if (!el.clientHeight) return; // not laid out yet — a later pass will catch it
+        const i = parseInt(el.dataset.msg, 10);
+        const overflowing = el.scrollHeight - el.clientHeight > 8;
+        el.dataset.expChecked = '1';
+        if (overflowing) {
+          if (!el.querySelector('.coach-expand')) {
+            el.insertAdjacentHTML('afterbegin',
+              '<button class="coach-expand" data-exp="' + i + '">⤢ Tap to expand full message</button>');
+            el.querySelector('.coach-expand')
+              .addEventListener('click', (e) => { e.stopPropagation(); this._expand(i); });
+            el.addEventListener('click', (e) => {
+              if (e.target.closest('.coach-action') || e.target.closest('.coach-expand')) return;
+              if ((window.getSelection?.().toString() || '').trim()) return; // don't hijack selection
+              this._expand(i);
+            });
+          }
+        } else {
+          el.classList.remove('cclamp'); // fits — show in full
+        }
+      });
+    };
+
+    // WhatsApp-style: keep the conversation pinned to the BOTTOM. Measure after
+    // layout, and once more on a short delay in case the sheet was still
+    // animating open on the first frame.
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        wireExpand();
+        log.scrollTop = log.scrollHeight;
+      });
+    });
+    setTimeout(() => { wireExpand(); log.scrollTop = log.scrollHeight; }, 250);
+  },
+
+  /** Escape, then apply light markdown (bold) so **text** renders bold. */
+  /** Expand one message in-place: a panel that fills the chat area above the
+   *  input box, so the conversation context stays and you read the full text. */
+  _expand(index) {
+    const m = this._history[index];
+    if (!m) return;
+    const coach = document.querySelector('#modal-overlay .coach');
+    if (!coach) return;
+    let panel = document.getElementById('coach-reader');
+    if (panel) panel.remove();
+    panel = document.createElement('div');
+    panel.id = 'coach-reader';
+    panel.className = 'coach-reader';
+    panel.innerHTML =
+      '<div class="coach-reader-bar">'
+      + '<span class="coach-reader-who">' + (m.role === 'user' ? 'You' : 'Your coach') + '</span>'
+      + '<button class="coach-reader-close" id="coach-reader-close">← Back</button>'
+      + '</div>'
+      + '<div class="coach-reader-body">'
+      + m.text.split('\n').filter(l => l.trim()).map(l => '<p>' + this._md(l) + '</p>').join('')
+      + '</div>';
+    // Insert just before the input row so it sits ABOVE the text box.
+    const inputRow = coach.querySelector('.coach-input-row');
+    coach.insertBefore(panel, inputRow);
+
+    const close = () => { panel.remove(); };
+
+    // Tap anywhere in the reader to close — far easier than reaching the button.
+    // We close on `click` (not pointerup) and stop propagation: closing on
+    // pointerup removed the panel before the click fired, so the click fell
+    // through to the chat message underneath and instantly re-expanded it.
+    // Guards keep scrolling and text-selection working.
+    let sx = 0, sy = 0, moved = false;
+    panel.addEventListener('pointerdown', (e) => { sx = e.clientX; sy = e.clientY; moved = false; });
+    panel.addEventListener('pointermove', (e) => {
+      if (Math.abs(e.clientX - sx) > 10 || Math.abs(e.clientY - sy) > 10) moved = true;
+    });
+    panel.addEventListener('click', (e) => {
+      if (moved) return;                                              // was a scroll/drag
+      if ((window.getSelection?.().toString() || '').trim()) return;  // user is selecting text
+      e.stopPropagation();                                            // don't fall through to the chat message
+      close();
+    });
+  },
+
+  _md(s) {
+    let t = String(s ?? '');
+    // --- Strip/convert artifacts the model sometimes emits, so they don't show raw ---
+    // LaTeX delimiters and common commands → plain text
+    t = t.replace(/\$\$?/g, '');
+    t = t.replace(/\\text\{([^}]*)\}/g, '$1');
+    t = t.replace(/\\frac\{([^}]*)\}\{([^}]*)\}/g, '($1) / ($2)');
+    t = t.replace(/\\times/g, '×').replace(/\\div/g, '/').replace(/\\,/g, ' ').replace(/\\%/g, '%');
+    t = t.replace(/\\[a-zA-Z]+/g, '');           // any other stray \commands
+    // Markdown headers (## Step 2) → just the text
+    t = t.replace(/^#{1,6}\s*/gm, '');
+    // Horizontal rules (--- on their own line) → blank
+    t = t.replace(/^\s*-{3,}\s*$/gm, '');
+    // Markdown table separator rows (|---|---|) → drop
+    t = t.replace(/^\s*\|?[\s:|-]*\|[\s:|-]*$/gm, m => (/^[\s|:-]+$/.test(m) ? '' : m));
+    // Table rows: turn "| a | b | c |" into "a — b — c" (do this BEFORE <br/> so
+    // rows containing <br/> still match as a single line)
+    t = t.replace(/^\s*\|(.+)\|\s*$/gm, (m, inner) =>
+      inner.split('|').map(c => c.replace(/<br\s*\/?>/gi, '; ').trim()).filter(Boolean).join('  —  '));
+    // Remaining HTML line breaks → real newlines
+    t = t.replace(/<br\s*\/?>/gi, '\n');
+
+    return this._esc(t)
+      .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+      .replace(/(?:^|\s)\*([^*]+)\*(?=\s|$)/g, m => m.replace(/\*([^*]+)\*/, '<em>$1</em>'));
+  },
+
+  async _ask(question, exampleContext = null) {
+    if (this._pending) return;
+    this._history.push({ role: 'user', text: question });
+    CoachEngine.saveHistory();     // keep the question even if the reply fails
+    this._pending = true;
+    this._renderLog();
+    try {
+      // ONE engine turn: mode context (tutor/resource/example) is attached by
+      // the engine itself, the reply lands in the shared history, and the
+      // learning signal is written to the shared Director memory.
+      const entry = await CoachEngine.turn(question, { exampleContext });
+      const { text, action } = this._extractAction(entry.text);
+      entry.text   = text || entry.text;
+      entry.action = action || null;
+    } catch (e) {
+      const msg = (e && /quota|limit|429|rate/i.test(e.message || ''))
+        ? 'I have hit the AI usage limit for now — that is an OpenRouter/Haiku cap, not the app. Try again later or check your AI plan.'
+        : 'Sorry — I could not reach the AI just now. Check your connection and AI key in Settings, then try again.';
+      // Flagged as an error so it is shown to the student but NEVER fed back as
+      // conversation context — a failed call must not pollute the coach's memory.
+      this._history.push({ role: 'coach', text: msg, error: true });
+      CoachEngine.saveHistory();
+    }
+    this._pending = false;
+    this._renderLog();
+  },
+
+  /** Build full text of one stored example and ask the coach to teach it.
+   *  The content is already on the device — we only pay to send it this once. */
+  _teachExample(nodeId, exampleId) {
+    const node = nodeStore.get(nodeId);
+    if (!node) return;
+    const ex = (node.workedExamples || []).find(e => e.id === exampleId)
+            || (node.workedExamples || [])[0];
+    if (!ex) { Toast.info('No example found to teach.'); return; }
+    let ctx = 'WORKED EXAMPLE — "' + (ex.title || 'Example') + '" (from topic "' + node.title + '")\n';
+    if (ex.question) ctx += '\nProblem:\n' + ex.question + '\n';
+    if (ex.solution) ctx += '\nSolution:\n' + ex.solution + '\n';
+    if (Array.isArray(ex.steps) && ex.steps.length) {
+      ctx += '\nSteps:\n' + ex.steps.map((s, i) => (i + 1) + '. ' + (typeof s === 'string' ? s : (s && (s.text || s.title) || ''))).join('\n') + '\n';
+    }
+    if (Array.isArray(ex.tables) && ex.tables.length) {
+      ctx += '\n(The example also contains ' + ex.tables.length + ' table(s) of figures.)\n';
+    }
+    this._ask('Walk me through the "' + (ex.title || 'example') + '" example step by step.', ctx);
+  },
+
+  /** Pull a trailing [[ACTION:...]] line out of the reply, if present. */
+  /** Strip [[SIGNAL:...]] from the reply before display and return it separately.
+   *  The signal is a distilled one-liner the Director can read — never shown to student. */
+  _extractSignal(raw) { return CoachEngine.extractSignal(raw); },
+
+  _extractAction(raw) {
+    const m = String(raw || '').match(/\[\[ACTION:([^\]]+)\]\]/);
+    if (!m) return { text: raw, action: null };
+    const text = raw.replace(/\[\[ACTION:[^\]]+\]\]/, '').trim();
+    const body = m[1];
+    const kind = body.split('|')[0].trim();
+    const params = {};
+    body.split('|').slice(1).forEach(p => {
+      const i = p.indexOf('=');
+      if (i !== -1) params[p.slice(0, i).trim()] = p.slice(i + 1).trim();
+    });
+    // Whitelist: only known, safe actions are accepted.
+    if (!['startGuided', 'openExamples', 'teachExample', 'tutorQuestions', 'studyNode', 'compileQuestions', 'openReview', 'openLibrary', 'openStudyPlan', 'runDirector', 'setLoad'].includes(kind)) return { text, action: null };
+    let label = '';
+    if (kind === 'tutorQuestions' || kind === 'studyNode' || kind === 'compileQuestions') {
+      const node = nodeStore.getAll().find(n => n.title === params.node)
+                || nodeStore.getAll().find(n => (n.title||'').toLowerCase().trim() === (params.node||'').toLowerCase().trim());
+      if (!node) return { text, action: null }; // node must really exist
+      if (kind === 'tutorQuestions' && !(node.questions || []).length) return { text, action: null }; // needs questions
+      params._nodeId = node.id;
+      params._nodeTitle = node.title;
+      label = kind === 'tutorQuestions' ? '🎓 Tutor me through "' + node.title + '" (' + node.questions.length + ' questions)'
+            : kind === 'studyNode'      ? '📖 Study "' + node.title + '" together'
+            :                             '⚡ Build revision questions from "' + node.title + '"';
+      return { text, action: { kind, params, label } };
+    }
+    if (kind === 'startGuided' || kind === 'openExamples' || kind === 'teachExample') {
+      const node = nodeStore.getAll().find(n => n.title === params.node)
+                || nodeStore.getAll().find(n => (n.title||'').toLowerCase().trim() === (params.node||'').toLowerCase().trim());
+      if (!node) return { text, action: null }; // node must really exist
+      params._nodeId = node.id;
+      params._nodeTitle = node.title;
+      if (kind === 'teachExample') {
+        const exCount = (node.workedExamples || []).length;
+        if (!exCount) return { text, action: null }; // nothing to teach
+        params._exampleId = node.workedExamples[0].id;
+        label = '📖 Teach me the "' + (node.workedExamples[0].title || 'example') + '" example';
+      } else if (kind === 'openExamples') {
+        label = '💡 Open examples in "' + node.title + '"';
+      } else {
+        label = '▶ Start studying "' + node.title + '"';
+      }
+    } else if (kind === 'openReview') {
+      label = '↺ Open Review';
+    } else if (kind === 'openLibrary') {
+      label = '⊞ Open Library';
+    } else if (kind === 'openStudyPlan') {
+      label = '📅 Open Study Plan';
+    } else if (kind === 'runDirector') {
+      label = '🧠 Run full AI assessment';
+    } else if (kind === 'setLoad') {
+      const lvl = ['light','normal','deep'].includes(params.level) ? params.level : 'normal';
+      params._level = lvl;
+      label = lvl === 'light' ? '🌙 Keep this session light'
+            : lvl === 'deep'  ? '🔥 Make this a deep session'
+            :                   '⚖ Set to a normal session';
+    }
+    return { text, action: { kind, params, label } };
+  },
+
+  _runAction(action) {
+    if (!action) return;
+    try {
+      if (action.kind === 'startGuided') {
+        if (typeof GuidedView !== 'undefined') GuidedView.startAtNode(action.params._nodeId);
+        Modal.close();
+        App.navigateTo('guided');
+      } else if (action.kind === 'openExamples') {
+        Modal.close();
+        if (typeof NodeDetailView !== 'undefined') NodeDetailView.open(action.params._nodeId, 'examples');
+      } else if (action.kind === 'teachExample') {
+        // Stay in the chat; load the example content and have the coach teach it.
+        this._teachExample(action.params._nodeId, action.params._exampleId);
+      } else if (action.kind === 'tutorQuestions') {
+        // Stay in the chat; pivot into the Socratic tutoring state.
+        this._startTutor(action.params._nodeId);
+      } else if (action.kind === 'studyNode') {
+        // Stay in the chat; pivot into resource mode on that node's material.
+        this._startResource(action.params._nodeId);
+      } else if (action.kind === 'compileQuestions') {
+        // Stay in the chat; the engine builds a linked Revision Questions node.
+        this._compileQuestions(action.params._nodeId);
+      } else if (action.kind === 'openReview') {
+        Modal.close();
+        App.navigateTo('review');
+      } else if (action.kind === 'openLibrary') {
+        Modal.close();
+        App.navigateTo('library');
+      } else if (action.kind === 'openStudyPlan') {
+        Modal.close();
+        App.navigateTo('studyplan');
+      } else if (action.kind === 'runDirector') {
+        Modal.close();
+        if (typeof AIDirector !== 'undefined') AIDirector.run();
+      } else if (action.kind === 'setLoad') {
+        if (typeof LearnerState !== 'undefined') {
+          LearnerState.setSessionLoad(action.params._level, action.params.reason || '');
+          const lvl = action.params._level;
+          const drained = (lvl === 'deep' && LearnerState.deferredCount() > 0)
+            ? LearnerState.deferredCount() : 0;
+          Toast.success(
+            lvl === 'light' ? 'Session set to light — skipped work stays queued for later.'
+          : lvl === 'deep'  ? (drained ? `Deep session — pulling in ${drained} deferred task(s).` : 'Session set to deep.')
+          :                   'Session set to normal.'
+          );
+        }
+      }
+    } catch (e) {
+      Toast.error('Could not do that — try the tab directly.');
+    }
+  },
+
+  _esc(s) { return String(s ?? '').replace(/[&<>"]/g, c => ({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;' }[c])); },
+};

--- a/knowledgenode/www/js/ui/StudyCoach.js
+++ b/knowledgenode/www/js/ui/StudyCoach.js
@@ -107,9 +107,20 @@ const StudyCoach = {
       + '<div class="coach-head"><span class="coach-orb">⬡</span><div><h2 style="margin:0;font-family:var(--font-ui);font-size:18px;font-weight:800;">Your Study Coach</h2>'
       + '<p style="margin:2px 0 0;font-family:var(--font-mono);font-size:10px;color:var(--text-muted);">Ask about how to study — it sees your whole library.</p></div></div>'
       + '<div id="coach-log" class="coach-log"></div>'
-      + '<div class="coach-input-row">'
-      + '<input type="text" id="coach-input" class="config-input" placeholder="e.g. Where should I start today?" style="flex:1;font-size:13px;" />'
-      + '<button class="btn-primary" id="coach-send" style="padding:9px 14px;">→</button>'
+      + '<div class="coach-composer" id="coach-composer">'
+      +   '<div id="coach-attachments" class="coach-attachments" hidden></div>'
+      +   '<textarea id="coach-input" class="coach-textarea" rows="1" placeholder="e.g. Where should I start today?"></textarea>'
+      +   '<div class="coach-composer-actions">'
+      +     '<button type="button" class="coach-attach-btn" id="coach-attach" title="Attach a photo for the coach to read" aria-label="Attach a photo">'
+      +       '<svg viewBox="0 0 24 24" width="19" height="19" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">'
+      +       '<path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/></svg>'
+      +     '</button>'
+      +     '<button class="coach-send-btn" id="coach-send" title="Send" aria-label="Send">'
+      +       '<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">'
+      +       '<path d="M12 19V5M5 12l7-7 7 7"/></svg>'
+      +     '</button>'
+      +   '</div>'
+      +   '<input type="file" id="coach-file" accept="image/*" multiple hidden />'
       + '</div></div>',
       () => { document.querySelector('#modal-overlay .modal')?.classList.remove('modal-coach'); }
     );
@@ -119,12 +130,145 @@ const StudyCoach = {
       // fighting and painting over each other.
       document.querySelector('#modal-overlay .modal')?.classList.add('modal-coach');
       this._renderLog();
-      const input = document.getElementById('coach-input');
-      const send  = () => { const v = input.value.trim(); if (v) { input.value=''; this._ask(v); } };
-      document.getElementById('coach-send')?.addEventListener('click', send);
-      input?.addEventListener('keydown', e => { if (e.key === 'Enter') send(); });
-      input?.focus();
+      this._wireComposer();
     }, 0);
+  },
+
+  /** Pending images the student attached but has not sent yet. */
+  _pendingImages: [],
+
+  /** The composer: a text box that grows with what you type (like a chat app)
+   *  instead of a one-line field that scrolls sideways, plus an attach button
+   *  so the coach can read a photo. */
+  _wireComposer() {
+    const input = document.getElementById('coach-input');
+    if (!input) return;
+
+    // Grow to fit the text, up to a cap, then scroll inside.
+    const MAX = 160;
+    const autoGrow = () => {
+      input.style.height = 'auto';
+      const h = Math.min(input.scrollHeight, MAX);
+      input.style.height = h + 'px';
+      input.style.overflowY = input.scrollHeight > MAX ? 'auto' : 'hidden';
+    };
+    input.addEventListener('input', autoGrow);
+    autoGrow();
+
+    const send = () => {
+      const v = input.value.trim();
+      if (!v && !this._pendingImages.length) return;
+      input.value = '';
+      autoGrow();
+      this._askWithAttachments(v);
+    };
+    document.getElementById('coach-send')?.addEventListener('click', send);
+
+    // On a physical keyboard Enter sends and Shift+Enter makes a new line. On a
+    // touch keyboard Enter must insert a new line — there is no Shift to hold —
+    // so sending there is the button's job.
+    const touch = window.matchMedia && window.matchMedia('(pointer: coarse)').matches;
+    input.addEventListener('keydown', e => {
+      if (e.key === 'Enter' && !e.shiftKey && !touch) { e.preventDefault(); send(); }
+    });
+
+    // Attach photos for the coach to read.
+    const file = document.getElementById('coach-file');
+    document.getElementById('coach-attach')?.addEventListener('click', () => file?.click());
+    file?.addEventListener('change', async () => {
+      const picked = Array.from(file.files || []).slice(0, 4);
+      file.value = '';
+      for (const f of picked) {
+        try {
+          const { base64, mediaType } = await UploadView._toBase64WithType(f);
+          this._pendingImages.push({ name: f.name, base64, mediaType });
+        } catch (e) { Toast.error('Could not read ' + f.name); }
+      }
+      this._renderAttachments();
+    });
+
+    input.focus();
+  },
+
+  /** Thumbnails of what is attached, each removable before sending. */
+  _renderAttachments() {
+    const box = document.getElementById('coach-attachments');
+    if (!box) return;
+    if (!this._pendingImages.length) { box.hidden = true; box.innerHTML = ''; return; }
+    box.hidden = false;
+    box.innerHTML = this._pendingImages.map((img, i) =>
+      '<div class="coach-chip">'
+      + '<img src="data:' + img.mediaType + ';base64,' + img.base64 + '" alt="" />'
+      + '<span>' + this._escAttr(img.name).slice(0, 18) + '</span>'
+      + '<button type="button" data-rm="' + i + '" aria-label="Remove">✕</button></div>').join('');
+    box.querySelectorAll('[data-rm]').forEach(b => b.addEventListener('click', () => {
+      this._pendingImages.splice(parseInt(b.dataset.rm, 10), 1);
+      this._renderAttachments();
+    }));
+  },
+
+  _escAttr(s) { return String(s || '').replace(/[&<>"']/g, c => ({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;' }[c])); },
+
+  /** Read one attached photo into text.
+   *
+   *  Not every configured provider can see images — a custom endpoint, for
+   *  example, has its image blocks stripped before sending, so asking it to
+   *  "read this image" would return confident nonsense about an image it never
+   *  received. So: use the AI's vision only when the provider actually supports
+   *  it, and otherwise fall back to on-device OCR (Tesseract, already bundled),
+   *  which also keeps this working offline and free. */
+  async _scanImage(img) {
+    if (AIService.supportsVision && AIService.supportsVision()) {
+      const t = await AIService._extractSingleImageText(img.base64, img.mediaType);
+      if (t && t.trim()) return t;
+    }
+    if (!window.Tesseract) return '';
+    const url = 'data:' + img.mediaType + ';base64,' + img.base64;
+    const res = await Tesseract.recognize(url, 'eng');
+    return (res && res.data && res.data.text) ? res.data.text : '';
+  },
+
+  /** Send a message, first reading any attached photos into text so the coach
+   *  can work with them (and so the text is preserved in the conversation). */
+  async _askWithAttachments(question) {
+    if (this._pending) return;
+    const imgs = this._pendingImages.slice();
+    this._pendingImages = [];
+    this._renderAttachments();
+    if (!imgs.length) return this._ask(question);
+
+    const label = '📎 ' + imgs.length + ' photo' + (imgs.length > 1 ? 's' : '');
+    this._history.push({ role: 'user', text: question ? question + '\n' + label : label });
+    CoachEngine.saveHistory();
+    this._pending = true;
+    this._renderLog();
+
+    let scanned = '';
+    try {
+      for (let i = 0; i < imgs.length; i++) {
+        const t = await this._scanImage(imgs[i]);
+        if (t && t.trim()) scanned += (imgs.length > 1 ? '\n--- photo ' + (i + 1) + ' ---\n' : '') + t.trim();
+      }
+    } catch (e) {
+      this._pending = false;
+      this._history.push({ role: 'coach', text: 'I could not read that photo — try a clearer, better-lit shot.', error: true });
+      CoachEngine.saveHistory();
+      this._renderLog();
+      return;
+    }
+    this._pending = false;
+
+    if (!scanned) {
+      this._history.push({ role: 'coach', text: 'I could not find any text in that photo. Try a closer, sharper shot.', error: true });
+      CoachEngine.saveHistory();
+      this._renderLog();
+      return;
+    }
+    // The scanned text rides along with the question; the turn itself goes
+    // through the normal engine path so memory and actions still work.
+    const combined = (question || 'Here is a photo I want your help with.')
+      + '\n\nTEXT THE STUDENT PHOTOGRAPHED (scanned on their device):\n"""\n' + scanned.slice(0, 6000) + '\n"""';
+    await this._askPrepared(combined);
   },
 
   _renderSuggestions() { /* suggestions now render inside the log */ },
@@ -212,7 +356,9 @@ const StudyCoach = {
     }
     const html = this._history.map((m, i) =>
       m.role === 'user'
-        ? '<div class="coach-msg user" data-msg="' + i + '">' + this._esc(m.text) + '</div>'
+        // Line breaks are preserved: the composer accepts multi-line questions,
+        // so a message typed over several lines must read back the same way.
+        ? '<div class="coach-msg user" data-msg="' + i + '">' + this._esc(m.text).replace(/\n/g, '<br>') + '</div>'
         : '<div class="coach-msg coach cclamp" data-msg="' + i + '">'
             + m.text.split('\n').filter(l=>l.trim()).map(l=>'<p style="margin:0 0 8px;">'+this._md(l)+'</p>').join('')
             + (m.action ? '<button class="coach-action" data-i="' + i + '">' + this._esc(m.action.label) + '</button>' : '')
@@ -322,7 +468,7 @@ const StudyCoach = {
       + m.text.split('\n').filter(l => l.trim()).map(l => '<p>' + this._md(l) + '</p>').join('')
       + '</div>';
     // Insert just before the input row so it sits ABOVE the text box.
-    const inputRow = coach.querySelector('.coach-input-row');
+    const inputRow = coach.querySelector('.coach-composer') || coach.querySelector('.coach-input-row');
     coach.insertBefore(panel, inputRow);
 
     const close = () => { panel.remove(); };
@@ -376,6 +522,13 @@ const StudyCoach = {
     if (this._pending) return;
     this._history.push({ role: 'user', text: question });
     CoachEngine.saveHistory();     // keep the question even if the reply fails
+    return this._askPrepared(question, exampleContext);
+  },
+
+  /** The turn itself, with the student's message already in the log. Lets a
+   *  caller send the engine more than what is displayed (e.g. text scanned
+   *  from an attached photo) without that bulk showing in the chat bubble. */
+  async _askPrepared(question, exampleContext = null) {
     this._pending = true;
     this._renderLog();
     try {

--- a/knowledgenode/www/js/ui/StudyFitCheck.js
+++ b/knowledgenode/www/js/ui/StudyFitCheck.js
@@ -1,0 +1,160 @@
+/**
+ * StudyFitCheck.js — "Does this content fit the Study step?"
+ *
+ * When the learner reaches the Study (read & absorb) step, the AI quietly
+ * reviews the node's blocks. If some content reads poorly there — e.g. a
+ * worked example dumped into prose — it does NOT silently change anything.
+ * Instead it asks the learner: "This looks like a worked example. Want me
+ * to show it as step-by-step instead?" and only reshapes on confirmation.
+ *
+ * Analysis is cached on the node for the session and the learner's
+ * dismissals are remembered, so it never nags.
+ *
+ * Entry point: StudyFitCheck.run(node, container, onReshaped)
+ *   - container: the #step-content element of the Study step
+ *   - onReshaped: callback to re-render the Study step after a change
+ */
+const StudyFitCheck = {
+  _TARGETS: ['procedure', 'table', 'flashcards', 'callout'],
+  _LABELS:  {
+    procedure:  'step-by-step',
+    table:      'a table',
+    flashcards: 'flashcards',
+    callout:    'a highlighted note',
+  },
+
+  async run(node, container, onReshaped) {
+    try {
+      if (!node || !node.blocks || !node.blocks.length) return;
+      if (!AIService.hasApiKey()) return;            // AI off → silent
+      if (node._studyFitDismissed) return;           // learner said "no thanks"
+
+      const anchor = container?.querySelector('#gf-fit-check');
+      if (!anchor) return;
+
+      // Use the cached analysis if we already ran it this session.
+      let suggestions = node._studyFitSuggestions;
+      if (!suggestions) {
+        anchor.innerHTML = this._thinkingHTML();
+        let res;
+        try { res = await AIService.analyzeStudyFit(node); }
+        catch (e) { anchor.innerHTML = ''; return; }  // fail quietly
+        suggestions = (res.suggestions || []).filter(s =>
+          this._TARGETS.includes(s.suggestedType) &&
+          node.blocks.some(b => b.id === s.blockId) &&
+          // never suggest the format a block already is
+          node.blocks.find(b => b.id === s.blockId).type !== s.suggestedType
+        ).slice(0, 2);
+        node._studyFitSuggestions = suggestions;     // runtime-only cache
+      }
+
+      if (!suggestions.length) { anchor.innerHTML = ''; return; }
+      this._render(node, container, anchor, suggestions, onReshaped);
+    } catch (e) {
+      console.error('[StudyFitCheck] run failed:', e);
+    }
+  },
+
+  _thinkingHTML() {
+    return '<div class="sfc-card sfc-thinking">'
+      + '<span class="sfc-orb">⬡</span>'
+      + '<span class="sfc-thinking-text">Checking how this content reads…</span>'
+      + '</div>';
+  },
+
+  _render(node, container, anchor, suggestions, onReshaped) {
+    const rows = suggestions.map((s, i) => {
+      const label  = this._esc(s.label || 'some content');
+      const target = this._LABELS[s.suggestedType] || s.suggestedType;
+      const reason = this._esc(s.reason || '');
+      return '<div class="sfc-row" data-sfc-i="' + i + '">'
+        + '<div class="sfc-row-text">'
+        +   '<div class="sfc-row-q">This looks like <strong>' + label + '</strong>. '
+        +     'Show it as <strong>' + this._esc(target) + '</strong>?</div>'
+        +   (reason ? '<div class="sfc-row-why">' + reason + '</div>' : '')
+        + '</div>'
+        + '<div class="sfc-row-btns">'
+        +   '<button class="sfc-btn sfc-yes" data-sfc-yes="' + i + '">Yes, reshape</button>'
+        +   '<button class="sfc-btn sfc-no" data-sfc-no="' + i + '">Keep as-is</button>'
+        + '</div>'
+        + '</div>';
+    }).join('');
+
+    anchor.innerHTML =
+      '<div class="sfc-card">'
+      + '<div class="sfc-head">'
+      +   '<span class="sfc-orb">⬡</span>'
+      +   '<span class="sfc-title">A quick formatting check</span>'
+      +   '<button class="sfc-dismiss" id="sfc-dismiss" aria-label="Dismiss">✕</button>'
+      + '</div>'
+      + rows
+      + '</div>';
+
+    // Per-suggestion handlers
+    suggestions.forEach((s, i) => {
+      anchor.querySelector('[data-sfc-yes="' + i + '"]')
+        ?.addEventListener('click', () => this._reshape(node, s, anchor, i, onReshaped));
+      anchor.querySelector('[data-sfc-no="' + i + '"]')
+        ?.addEventListener('click', () => this._dismissOne(node, anchor, i));
+    });
+
+    // Dismiss the whole check (don't ask again this session)
+    document.getElementById('sfc-dismiss')?.addEventListener('click', () => {
+      node._studyFitDismissed = true;
+      anchor.innerHTML = '';
+    });
+  },
+
+  async _reshape(node, suggestion, anchor, index, onReshaped) {
+    const row = anchor.querySelector('[data-sfc-i="' + index + '"]');
+    const block = node.blocks.find(b => b.id === suggestion.blockId);
+    if (!block) { this._dismissOne(node, anchor, index); return; }
+
+    if (row) row.innerHTML = '<div class="sfc-working"><span class="sfc-orb">⬡</span> Reshaping into '
+      + this._esc(this._LABELS[suggestion.suggestedType] || suggestion.suggestedType) + '…</div>';
+
+    try {
+      const fresh = await AIService.reshapeBlockTo(block, suggestion.suggestedType, node);
+      const idx = node.blocks.findIndex(b => b.id === suggestion.blockId);
+      if (idx === -1) throw new Error('Block no longer exists.');
+
+      // Keep the original id + position so nothing else breaks.
+      const newBlock = Object.assign({}, fresh, {
+        id: block.id,
+        type: suggestion.suggestedType,
+        title: fresh.title || block.title || '',
+      });
+      node.blocks[idx] = newBlock;
+
+      // Drop this (and any now-stale) suggestion from the session cache.
+      node._studyFitSuggestions = (node._studyFitSuggestions || [])
+        .filter(x => x.blockId !== suggestion.blockId);
+
+      nodeStore.save(node);
+      Toast.success('Reshaped into ' + (this._LABELS[suggestion.suggestedType] || suggestion.suggestedType) + '.');
+
+      // Re-render the whole Study step so the new block shows in place.
+      if (typeof onReshaped === 'function') onReshaped();
+    } catch (e) {
+      if (row) row.innerHTML = '<div class="sfc-error">Couldn\'t reshape that — ' + this._esc(e.message)
+        + ' <button class="sfc-btn sfc-no" id="sfc-err-dismiss">Dismiss</button></div>';
+      document.getElementById('sfc-err-dismiss')
+        ?.addEventListener('click', () => this._dismissOne(node, anchor, index));
+    }
+  },
+
+  _dismissOne(node, anchor, index) {
+    const row = anchor.querySelector('[data-sfc-i="' + index + '"]');
+    if (row) row.remove();
+    // If no rows remain, clear the card and stop asking this session.
+    if (!anchor.querySelector('.sfc-row')) {
+      node._studyFitDismissed = true;
+      anchor.innerHTML = '';
+    }
+  },
+
+  _esc(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  },
+};

--- a/knowledgenode/www/js/ui/StudyPlanBuilder.js
+++ b/knowledgenode/www/js/ui/StudyPlanBuilder.js
@@ -1,0 +1,431 @@
+/**
+ * StudyPlanBuilder.js
+ * UI for creating study plans — manual or AI-generated.
+ * Opened as a full modal wizard.
+ */
+
+const StudyPlanBuilder = {
+  _step: 1,
+  _settings: {},
+  _nodes: [],
+  _aiPlan: null,
+
+  open() {
+    this._step     = 1;
+    this._settings = {};
+    this._nodes    = nodeStore.getAll().filter(n => n.processingStatus === 'ready');
+    this._aiPlan   = null;
+
+    // Plan can be created without nodes - tasks added as nodes are created
+    this._renderStep();
+  },
+
+  _renderStep() {
+    const steps = ['Setup', 'Subjects', 'Method', 'Preview'];
+    const stepBar = steps.map((s,i) => `
+      <div class="wizard-step ${i+1 === this._step ? 'active' : i+1 < this._step ? 'done' : ''}">
+        <div class="wizard-step-dot">${i+1 < this._step ? '✓' : i+1}</div>
+        <span>${s}</span>
+      </div>`).join('<div class="wizard-step-line"></div>');
+
+    Modal.open(`
+      <div id="plan-wizard">
+        <h2 style="font-family:var(--font-ui);font-size:20px;font-weight:800;margin-bottom:20px;">
+          📅 Study Plan Builder
+        </h2>
+        <div class="wizard-steps">${stepBar}</div>
+        <div id="wizard-body" style="margin-top:24px;"></div>
+      </div>
+    `);
+    this[`_renderStep${this._step}`]();
+  },
+
+  _renderStep1() {
+    document.getElementById('wizard-body').innerHTML = `
+      <div class="config-row" style="margin-bottom:16px;">
+        <label class="config-label">Plan Title</label>
+        <input type="text" id="plan-title" class="config-input"
+               placeholder="e.g. Tax Law Exam Prep" value="${this._settings.title||''}"/>
+      </div>
+      <div class="config-row" style="margin-bottom:16px;">
+        <label class="config-label">Exam / Target Date</label>
+        <input type="date" id="plan-exam-date" class="config-input"
+               min="${new Date().toISOString().slice(0,10)}" value="${this._settings.examDate||''}"/>
+      </div>
+      <div style="display:grid;grid-template-columns:1fr 1fr;gap:12px;margin-bottom:16px;">
+        <div class="config-row">
+          <label class="config-label">Daily Study Time</label>
+          <select id="plan-daily-mins" class="config-select">
+            <option value="30"  ${this._settings.dailyMins===30 ?'selected':''}>30 min / day</option>
+            <option value="60"  ${!this._settings.dailyMins||this._settings.dailyMins===60?'selected':''}>1 hour / day</option>
+            <option value="90"  ${this._settings.dailyMins===90 ?'selected':''}>1.5 hours / day</option>
+            <option value="120" ${this._settings.dailyMins===120?'selected':''}>2 hours / day</option>
+            <option value="180" ${this._settings.dailyMins===180?'selected':''}>3 hours / day</option>
+          </select>
+        </div>
+        <div class="config-row">
+          <label class="config-label">Difficulty Order</label>
+          <select id="plan-difficulty" class="config-select">
+            <option value="balanced"   ${(!this._settings.difficulty||this._settings.difficulty==='balanced')  ?'selected':''}>Balanced (recommended)</option>
+            <option value="hard-first" ${this._settings.difficulty==='hard-first'?'selected':''}>Hard topics first</option>
+            <option value="easy-first" ${this._settings.difficulty==='easy-first'?'selected':''}>Easy topics first</option>
+          </select>
+        </div>
+      </div>
+      <div style="display:grid;grid-template-columns:1fr 1fr;gap:12px;margin-bottom:16px;">
+        <div class="config-row">
+          <label class="config-label">Session Length</label>
+          <select id="plan-session-mins" class="config-select">
+            <optgroup label="Short sessions">
+              <option value="5">5 min (no break)</option>
+              <option value="10">10 min + 2 min break</option>
+              <option value="15">15 min + 3 min break</option>
+              <option value="20">20 min + 3 min break</option>
+            </optgroup>
+            <optgroup label="Full sessions">
+              <option value="25">25 min + 5 min break (Pomodoro)</option>
+              <option value="45" selected>45 min + 10 min break (Standard)</option>
+              <option value="60">60 min + 15 min break</option>
+              <option value="90">90 min + 20 min break</option>
+            </optgroup>
+          </select>
+        </div>
+        <div class="config-row">
+          <label class="config-label">Study Days</label>
+          <select id="plan-days-per-week" class="config-select">
+            <option value="7" selected>Every day</option>
+            <option value="6">6 days/week</option>
+            <option value="5">Weekdays only</option>
+            <option value="3">3 days/week</option>
+          </select>
+        </div>
+      </div>
+      <div style="display:flex;gap:8px;justify-content:flex-end;margin-top:8px;">
+        <button class="btn-secondary" onclick="Modal.close()">Cancel</button>
+        <button class="btn-primary" id="wizard-next-1">Next →</button>
+      </div>`;
+
+    document.getElementById('wizard-next-1').addEventListener('click', () => {
+      const title    = document.getElementById('plan-title').value.trim();
+      const examDate = document.getElementById('plan-exam-date').value;
+      if (!title)    { Toast.error('Please enter a plan title.'); return; }
+      if (!examDate) { Toast.error('Please select an exam date.'); return; }
+      this._settings = { ...this._settings, title, examDate,
+        dailyMins:   parseInt(document.getElementById('plan-daily-mins').value),
+        difficulty:  document.getElementById('plan-difficulty').value,
+        sessionMins: parseInt(document.getElementById('plan-session-mins')?.value || 45),
+        daysPerWeek: parseInt(document.getElementById('plan-days-per-week')?.value || 7) };
+      this._step = 2;
+      this._renderStep();
+    });
+  },
+
+  _renderStep2() {
+    this._refreshNodeList();
+    this._renderStep2UI();
+  },
+
+  _refreshNodeList() {
+    this._nodes = nodeStore.getAll().filter(n => n.processingStatus === 'ready');
+  },
+
+  _renderStep2UI() {
+    const subjects = [...new Set(this._nodes.map(n => n.subject).filter(Boolean))];
+    const allSel   = !this._settings.subjects?.length;
+    const noNodes  = this._nodes.length === 0;
+
+    document.getElementById('wizard-body').innerHTML = `
+      <p style="font-family:var(--font-mono);font-size:12px;color:var(--text-muted);margin-bottom:14px;">
+        Select which subjects to include. You can also create new nodes here to structure your plan.
+      </p>
+
+      ${noNodes ? `
+        <div style="background:var(--blue-dim);border:1px solid rgba(78,142,247,0.2);border-radius:var(--radius-md);padding:14px 18px;margin-bottom:16px;font-family:var(--font-body);font-size:13px;color:var(--text-secondary);">
+          ℹ No nodes yet. Create your first node below to structure your plan — you can add content to it later.
+        </div>` : ''}
+
+      <!-- Subject / node list -->
+      <div id="subject-list" style="display:flex;flex-direction:column;gap:8px;margin-bottom:16px;">
+        ${!noNodes ? `
+          <label class="subject-toggle ${allSel?'selected':''}" style="cursor:pointer;display:flex;align-items:center;gap:12px;padding:12px 16px;background:var(--bg-raised);border:1px solid ${allSel?'var(--accent)':'var(--border)'};border-radius:var(--radius-md);">
+            <input type="checkbox" id="subj-all" ${allSel?'checked':''} style="accent-color:var(--accent);width:16px;height:16px;"/>
+            <div>
+              <div style="font-family:var(--font-ui);font-size:13px;font-weight:700;">All Subjects</div>
+              <div style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);">${this._nodes.length} nodes total</div>
+            </div>
+          </label>
+          ${subjects.map(s => {
+            const count   = this._nodes.filter(n=>n.subject===s).length;
+            const avgMast = Math.round(this._nodes.filter(n=>n.subject===s).reduce((a,n)=>a+n.masteryScore,0)/count);
+            const checked = allSel || (this._settings.subjects||[]).includes(s);
+            return `<div style="background:var(--bg-raised);border:1px solid ${checked?'var(--accent-dim)':'var(--border)'};border-radius:var(--radius-md);overflow:hidden;">
+              <label style="cursor:pointer;display:flex;align-items:center;gap:12px;padding:12px 16px;">
+                <input type="checkbox" class="subj-check" value="${s}" ${checked?'checked':''} style="accent-color:var(--accent);width:16px;height:16px;flex-shrink:0;"/>
+                <div style="flex:1;min-width:0;">
+                  <div style="font-family:var(--font-ui);font-size:13px;font-weight:700;">${this._esc(s)}</div>
+                  <div style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);">${count} node${count!==1?'s':''} · ${avgMast}% mastery</div>
+                </div>
+                <div class="mastery-bar-track" style="width:50px;flex-shrink:0;"><div class="mastery-bar-fill" style="width:${avgMast}%"></div></div>
+              </label>
+            </div>`;
+          }).join('')}` : ''}
+      </div>
+
+      <!-- CREATE NODE inline -->
+      <details id="create-node-panel" style="background:var(--bg-raised);border:1px solid var(--border);border-radius:var(--radius-md);margin-bottom:16px;overflow:hidden;">
+        <summary style="padding:12px 16px;cursor:pointer;list-style:none;display:flex;align-items:center;gap:10px;font-family:var(--font-ui);font-size:13px;font-weight:600;color:var(--text-secondary);">
+          <span style="font-size:16px;">+</span> Create a new node to add to this plan
+        </summary>
+        <div style="padding:14px 16px;border-top:1px solid var(--border-soft);">
+          <div style="display:grid;grid-template-columns:1fr 1fr;gap:10px;margin-bottom:10px;">
+            <div class="config-row">
+              <label class="config-label">Subject *</label>
+              <input type="text" id="wizard-node-subject" class="config-input" placeholder="e.g. Tax Law"/>
+            </div>
+            <div class="config-row">
+              <label class="config-label">Chapter *</label>
+              <input type="text" id="wizard-node-chapter" class="config-input" placeholder="e.g. Module 1"/>
+            </div>
+          </div>
+          <div class="config-row" style="margin-bottom:12px;">
+            <label class="config-label">Title (optional)</label>
+            <input type="text" id="wizard-node-title" class="config-input" placeholder="Auto-generated if blank"/>
+          </div>
+          <button class="btn-secondary" id="wizard-create-node-btn" style="font-size:12px;">+ Create Node</button>
+          <span id="wizard-node-result" style="font-family:var(--font-mono);font-size:11px;color:var(--green);margin-left:12px;display:none;">✓ Node created!</span>
+        </div>
+      </details>
+
+      <div style="display:flex;gap:8px;justify-content:space-between;">
+        <button class="btn-secondary" id="wizard-back-2">← Back</button>
+        <button class="btn-primary" id="wizard-next-2">Next →</button>
+      </div>`;
+
+    // All subjects toggle
+    document.getElementById('subj-all')?.addEventListener('change', e => {
+      document.querySelectorAll('.subj-check').forEach(cb => cb.checked = e.target.checked);
+    });
+
+    // Create node inline
+    document.getElementById('wizard-create-node-btn')?.addEventListener('click', () => {
+      const subj = document.getElementById('wizard-node-subject')?.value.trim();
+      const chap = document.getElementById('wizard-node-chapter')?.value.trim();
+      if (!subj || !chap) { Toast.error('Subject and Chapter are required.'); return; }
+      const title = document.getElementById('wizard-node-title')?.value.trim() || `${subj} — ${chap}`;
+      const node  = new KnowledgeNode({ subject:subj, chapter:chap, title, processingStatus:'ready' });
+      nodeStore.save(node);
+      const res = document.getElementById('wizard-node-result');
+      if (res) { res.style.display='inline'; res.textContent=`✓ "${title}" created!`; }
+      // Clear fields
+      document.getElementById('wizard-node-subject').value = '';
+      document.getElementById('wizard-node-chapter').value = '';
+      document.getElementById('wizard-node-title').value   = '';
+      // Refresh node list and re-render subject list
+      this._refreshNodeList();
+      this._renderStep2UI();
+      // Re-open the panel
+      setTimeout(() => { document.getElementById('create-node-panel')?.setAttribute('open',''); }, 50);
+      Toast.success(`Node "${title}" created and added to subjects.`);
+    });
+
+    document.getElementById('wizard-back-2').addEventListener('click', () => { this._step=1; this._renderStep(); });
+    document.getElementById('wizard-next-2').addEventListener('click', () => {
+      const allChecked = document.getElementById('subj-all')?.checked;
+      const subjects   = allChecked ? [] : Array.from(document.querySelectorAll('.subj-check:checked')).map(cb=>cb.value);
+      if (!allChecked && !subjects.length && this._nodes.length > 0) { Toast.error('Select at least one subject.'); return; }
+      this._settings.subjects = subjects;
+      this._step = 3;
+      this._renderStep();
+    });
+  },
+
+  _esc: s => String(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'),
+
+  _renderStep3() {
+    document.getElementById('wizard-body').innerHTML = `
+      <p style="font-family:var(--font-mono);font-size:12px;color:var(--text-muted);margin-bottom:20px;">
+        Choose how to build the plan. AI mode analyses your mastery gaps and writes a rationale.
+      </p>
+      <div style="display:flex;flex-direction:column;gap:10px;margin-bottom:24px;">
+        <button class="export-format-btn" id="build-ai-btn">
+          <span class="exp-icon">⬡</span>
+          <div>
+            <div class="exp-title">AI Plan Builder</div>
+            <div class="exp-desc">AI analyses your mastery gaps, weighs urgency, and explains its decisions. Requires API key.</div>
+          </div>
+        </button>
+        <button class="export-format-btn" id="build-manual-btn">
+          <span class="exp-icon">📋</span>
+          <div>
+            <div class="exp-title">Manual Plan Builder</div>
+            <div class="exp-desc">Algorithm builds the schedule from your settings — no AI needed. Works offline.</div>
+          </div>
+        </button>
+      </div>
+      <div style="display:flex;gap:8px;justify-content:space-between;">
+        <button class="btn-secondary" id="wizard-back-3">← Back</button>
+      </div>
+      <div id="build-status" style="display:none;text-align:center;padding:24px 0;">
+        <div class="hex-ring" style="margin:0 auto 16px;"></div>
+        <p style="font-family:var(--font-mono);font-size:13px;color:var(--accent);">AI is building your personalised plan…</p>
+      </div>`;
+
+    document.getElementById('wizard-back-3').addEventListener('click', () => { this._step=2; this._renderStep(); });
+
+    document.getElementById('build-manual-btn').addEventListener('click', () => {
+      const filteredNodes = this._filteredNodes();
+      const plan = PlanEngine.build(this._settings, filteredNodes);
+      this._aiPlan = plan;
+      this._step = 4;
+      this._renderStep();
+    });
+
+    document.getElementById('build-ai-btn').addEventListener('click', async () => {
+      document.getElementById('build-ai-btn').style.display    = 'none';
+      document.getElementById('build-manual-btn').style.display = 'none';
+      document.getElementById('wizard-back-3').style.display   = 'none';
+      document.getElementById('build-status').style.display    = 'block';
+
+      try {
+        const filteredNodes = this._filteredNodes();
+        let rationale = '';
+
+        if (AIService.hasApiKey()) {
+          rationale = await this._callAIForPlan(filteredNodes);
+        } else {
+          await new Promise(r => setTimeout(r, 1200));
+          rationale = this._mockAIRationale(filteredNodes);
+        }
+
+        const plan = PlanEngine.build(this._settings, filteredNodes, rationale);
+        this._aiPlan = plan;
+        this._step = 4;
+        this._renderStep();
+      } catch(e) {
+        Toast.error('AI plan failed: ' + e.message);
+        document.getElementById('build-status').style.display    = 'none';
+        document.getElementById('build-ai-btn').style.display    = 'flex';
+        document.getElementById('build-manual-btn').style.display = 'flex';
+        document.getElementById('wizard-back-3').style.display   = 'inline-flex';
+      }
+    });
+  },
+
+  _renderStep4() {
+    const plan = this._aiPlan;
+    if (!plan) return;
+
+    const examStr    = new Date(plan.examDate).toLocaleDateString('en-GB',{day:'numeric',month:'long',year:'numeric'});
+    const daysLeft   = plan.daysRemaining;
+    const totalMins  = plan.days.reduce((s,d)=>s+d.totalMins, 0);
+    const totalHours = (totalMins/60).toFixed(1);
+
+    // Preview first 5 days
+    const dayPreview = plan.days.slice(0,5).map(day => {
+      const dateLabel = new Date(day.date + 'T00:00:00').toLocaleDateString('en-GB',{weekday:'short',day:'numeric',month:'short'});
+      const taskList  = day.tasks.map(t => `
+        <div style="display:flex;align-items:center;gap:8px;padding:5px 0;border-bottom:1px solid var(--border-soft);">
+          <span style="font-size:13px;">${this._actIcon(t.activityType)}</span>
+          <span style="font-family:var(--font-body);font-size:12px;color:var(--text-primary);flex:1;">${this._esc(t.nodeTitle)}</span>
+          <span style="font-family:var(--font-mono);font-size:10px;color:var(--text-muted);">${t.estimatedMins}m</span>
+          <span class="priority-dot priority-${t.priority}"></span>
+        </div>`).join('');
+      return `
+        <div style="background:var(--bg-raised);border:1px solid var(--border);border-radius:var(--radius-md);padding:14px 16px;margin-bottom:10px;">
+          <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:10px;">
+            <span style="font-family:var(--font-ui);font-size:12px;font-weight:700;color:var(--accent);">${dateLabel}</span>
+            <span style="font-family:var(--font-mono);font-size:10px;color:var(--text-muted);">${day.totalMins} min</span>
+          </div>
+          ${taskList}
+        </div>`;
+    }).join('');
+
+    document.getElementById('wizard-body').innerHTML = `
+      <!-- Summary stats -->
+      <div style="display:grid;grid-template-columns:repeat(3,1fr);gap:10px;margin-bottom:20px;">
+        <div class="mastery-stat-card"><span class="mastery-stat-value">${daysLeft}</span><span class="mastery-stat-label">Days Left</span></div>
+        <div class="mastery-stat-card"><span class="mastery-stat-value">${plan.totalTasks}</span><span class="mastery-stat-label">Total Tasks</span></div>
+        <div class="mastery-stat-card"><span class="mastery-stat-value">${totalHours}h</span><span class="mastery-stat-label">Study Time</span></div>
+      </div>
+
+      ${plan.aiRationale ? `
+        <div style="background:var(--accent-soft);border:1px solid var(--accent-dim);border-radius:var(--radius-md);padding:14px 18px;margin-bottom:20px;">
+          <div style="font-family:var(--font-ui);font-size:11px;font-weight:700;color:var(--accent);text-transform:uppercase;letter-spacing:0.08em;margin-bottom:8px;">⬡ AI Rationale</div>
+          <div style="font-family:var(--font-body);font-size:13px;color:var(--text-secondary);line-height:1.65;">${this._esc(plan.aiRationale)}</div>
+        </div>` : ''}
+
+      <!-- Day preview -->
+      <div style="font-family:var(--font-ui);font-size:11px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.1em;margin-bottom:12px;">
+        First ${Math.min(5,plan.days.length)} days preview${plan.days.length > 5 ? ` (+ ${plan.days.length-5} more)` : ''}
+      </div>
+      <div style="max-height:320px;overflow-y:auto;padding-right:4px;">${dayPreview}</div>
+
+      <div style="display:flex;gap:8px;justify-content:space-between;margin-top:20px;flex-wrap:wrap;">
+        <button class="btn-secondary" id="wizard-back-4">← Rebuild</button>
+        <div style="display:flex;gap:8px;">
+          <button class="btn-secondary" onclick="Modal.close()">Cancel</button>
+          <button class="btn-primary" id="wizard-save-plan">✓ Activate Plan</button>
+        </div>
+      </div>`;
+
+    document.getElementById('wizard-back-4').addEventListener('click', () => { this._step=3; this._renderStep(); });
+    document.getElementById('wizard-save-plan').addEventListener('click', () => {
+      // Deactivate existing plans
+      PlanStore.getAll().forEach(p => { p.isActive = false; PlanStore.save(p); });
+      this._aiPlan.isActive = true;
+      PlanStore.save(this._aiPlan);
+      Onboarding.markPlanSet();
+      Modal.close();
+      Toast.success('Study plan activated! Check the Study Plan view.');
+      App.navigateTo('studyplan');
+    });
+  },
+
+  // ─── Helpers ──────────────────────────────────────────
+
+  _filteredNodes() {
+    const subjects = this._settings.subjects || [];
+    return subjects.length
+      ? this._nodes.filter(n => subjects.includes(n.subject))
+      : this._nodes;
+  },
+
+  async _callAIForPlan(nodes) {
+    const nodesSummary = nodes.map(n =>
+      `- "${n.title}" (${n.subject}, mastery: ${n.masteryScore}%, questions: ${n.questions.length})`
+    ).join('\n');
+
+    const prompt = `You are an expert academic study planner.
+
+A student has the following exam settings:
+- Exam date: ${this._settings.examDate}
+- Daily study time: ${this._settings.dailyMins} minutes
+- Difficulty preference: ${this._settings.difficulty}
+- Days until exam: ${Math.ceil((new Date(this._settings.examDate)-new Date())/86400000)}
+
+Their Knowledge Nodes (study material) are:
+${nodesSummary}
+
+Write a brief (3-5 sentences) study plan rationale explaining:
+1. Which topics need the most urgent attention and why (based on mastery gaps)
+2. How you recommend distributing study time given the difficulty preference
+3. When competency tests should be taken
+4. Any specific advice for their situation
+
+Be specific, practical, and encouraging. Reference actual topic names. Output ONLY the rationale text, no headings or bullets.`;
+
+    return await AIService._call([{ role: 'user', content: prompt }], 600);
+  },
+
+  _mockAIRationale(nodes) {
+    const weakest = nodes.sort((a,b)=>a.masteryScore-b.masteryScore).slice(0,2);
+    const days    = Math.ceil((new Date(this._settings.examDate)-new Date())/86400000);
+    return `With ${days} days until your exam and ${this._settings.dailyMins} minutes of daily study time, I've prioritised ${weakest.map(n=>n.title).join(' and ')} first since these show the lowest mastery scores and need the most reinforcement. The plan follows a ${this._settings.difficulty} difficulty curve — beginning with foundational review sessions, progressing to recall and application practice, and reserving the final 20% of your study period for competency tests across each subject. I recommend completing each competency test in one sitting to simulate real exam conditions. Stay consistent with your daily sessions and use the spaced repetition reviews to reinforce what you've already covered.`;
+  },
+
+  _actIcon(type) {
+    return { review:'📖', recall:'🔁', application:'🧩', summary:'📝', lecture:'🎓', competency:'🏆' }[type] || '📌';
+  },
+
+  _esc: s => String(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'),
+};

--- a/knowledgenode/www/js/ui/StudyPlanView.js
+++ b/knowledgenode/www/js/ui/StudyPlanView.js
@@ -1,0 +1,647 @@
+/**
+ * StudyPlanView.js — Final
+ * Fixes:
+ *  - Checkbox no longer collapses dropdown (partial re-render instead of full refresh)
+ *  - Breaks shown in schedule with visual separator
+ *  - Timer integrated into Start Today's Study Session
+ *  - Better schedule layout — tasks breathe, hierarchy clear
+ *  - Empty node creation from plan
+ *  - Past days never added (fixed in StudyPlan.js dateStr)
+ */
+
+const StudyPlanView = {
+  _plan:              null,
+  _rebalanceChanges:  [],
+  _openDays:          new Set(), // track which <details> are open
+
+  init() {},
+
+  refresh() {
+    const incoming = PlanStore.getActive();
+    // If the plan changed (new or deleted), reset delegation so the new
+    // container gets a fresh listener binding on next _bindEvents() call.
+    if (incoming?.id !== this._plan?.id) this._delegated = false;
+    this._plan = incoming;
+    if (this._plan) this._checkRebalanceDirty();
+    this._render();
+  },
+
+  _checkRebalanceDirty() {
+    if (!this._plan) return;
+    // Only run the full rebalance when something that affects it has changed.
+    // Rebalance is O(sessions × nodes) — too expensive to run on every nav tap.
+    const fp = nodeStore.getAll()
+      .map(n => n.id + ':' + n.masteryScore + ':' + (n.updatedAt || 0))
+      .join('|');
+    if (fp === this._rebalanceFp) return; // nothing changed
+    this._rebalanceFp = fp;
+    const changes = PlanEngine.rebalance(this._plan, nodeStore.getAll());
+    if (changes.length) this._rebalanceChanges = changes;
+
+    // Deferred-load safety valve: warn (once per dirty cycle) if the backlog
+    // from light days can no longer fit before the exam.
+    try {
+      if (typeof PlanEngine.checkDeferredFit === 'function') {
+        const fit = PlanEngine.checkDeferredFit(this._plan);
+        if (fit && !fit.fits && typeof Toast !== 'undefined') Toast.warn(fit.message);
+      }
+    } catch (_) {}
+  },
+
+  // ─── Full render (only on load / plan change, NOT on checkbox) ──────
+
+  _render() {
+    const container = document.getElementById('studyplan-body');
+    if (!container) return;
+
+    if (!this._plan) {
+      container.innerHTML = `
+        <div class="empty-state">
+          <span class="empty-icon">📅</span>
+          <p>No active study plan yet.</p>
+          <button class="btn-primary" style="margin-top:16px;" id="sp-create-btn">+ Create Study Plan</button>
+        </div>`;
+      document.getElementById('sp-create-btn')?.addEventListener('click', () => StudyPlanBuilder.open());
+      return;
+    }
+
+    const plan     = this._plan;
+    const today    = StudyPlan._dateStr(new Date());
+    const examStr  = new Date(plan.examDate + 'T00:00:00').toLocaleDateString('en-GB', { day:'numeric', month:'long', year:'numeric' });
+    const daysLeft = plan.daysRemaining;
+    const pct      = plan.progressPct;
+
+    // Auto-open today's day
+    this._openDays.add(today);
+
+    const rebalanceBanner = this._rebalanceChanges.length ? `
+      <div class="rebalance-banner">
+        <div style="display:flex;align-items:flex-start;gap:12px;">
+          <span style="font-size:18px;">⬡</span>
+          <div style="flex:1;">
+            <div style="font-family:var(--font-ui);font-size:13px;font-weight:700;color:var(--accent);margin-bottom:5px;">Plan Update Available</div>
+            <div style="font-family:var(--font-body);font-size:13px;color:var(--text-secondary);margin-bottom:8px;">${this._rebalanceChanges.length} task${this._rebalanceChanges.length!==1?'s':''} can be adjusted based on your recent performance:</div>
+            <ul style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);margin:0;padding-left:16px;">
+              ${this._rebalanceChanges.slice(0,3).map(c=>`<li style="margin-bottom:3px;">${this._esc(c.reason)}</li>`).join('')}
+              ${this._rebalanceChanges.length > 3 ? `<li style="color:var(--accent);">+${this._rebalanceChanges.length-3} more…</li>` : ''}
+            </ul>
+          </div>
+        </div>
+        <div style="display:flex;gap:8px;margin-top:10px;">
+          <button class="btn-primary" style="font-size:12px;padding:8px 16px;" id="apply-rebalance">Apply all</button>
+          <button class="btn-secondary" style="font-size:12px;padding:8px 16px;" id="dismiss-rebalance">Dismiss</button>
+        </div>
+      </div>` : '';
+
+    container.innerHTML = `
+      ${rebalanceBanner}
+
+      <!-- PLAN HEADER -->
+      <div class="sp-header">
+        <div class="sp-title-row">
+          <div>
+            <h3 class="sp-title">${this._esc(plan.title)}</h3>
+            <p class="sp-meta">
+              Exam: <strong>${examStr}</strong> ·
+              <span style="color:${daysLeft<=7?'var(--red)':daysLeft<=14?'var(--accent)':'var(--green)'};">${daysLeft} days left</span>
+              ${plan.aiGenerated ? ' · <span style="color:var(--accent);">⬡ AI</span>' : ''}
+            </p>
+          </div>
+          <div class="sp-header-actions">
+            <button class="btn-secondary sp-action-btn" id="sp-edit-plan-btn">✏ Edit</button>
+            <button class="btn-secondary sp-action-btn" id="sp-new-plan-btn">🔄 New</button>
+            <button class="btn-secondary sp-action-btn sp-delete-btn" id="sp-delete-btn">🗑</button>
+          </div>
+        </div>
+
+        <!-- Progress -->
+        <div class="sp-progress-row">
+          <div class="progress-track" style="flex:1;height:6px;">
+            <div class="progress-fill" style="width:${pct}%;height:6px;"></div>
+          </div>
+          <span class="sp-progress-label">${pct}% · ${plan.completedTasks}/${plan.totalTasks}</span>
+        </div>
+
+        ${plan.aiRationale ? `
+          <details class="sp-rationale">
+            <summary>⬡ AI Rationale ▾</summary>
+            <p style="font-family:var(--font-body);font-size:13px;color:var(--text-secondary);line-height:1.65;margin-top:8px;">${this._esc(plan.aiRationale)}</p>
+          </details>` : ''}
+      </div>
+
+      <!-- START SESSION — integrated timer -->
+      <button class="btn-primary" id="sp-start-session-btn"
+        style="width:100%;justify-content:center;padding:16px;font-size:15px;margin-bottom:24px;border-radius:var(--radius-lg);">
+        ▶ Start Today's Study Session
+      </button>
+
+      <!-- FULL CALENDAR -->
+      <div class="notes-section-title" style="margin-bottom:16px;">Full Schedule</div>
+      <div id="sp-calendar">
+        ${plan.days.map(day => this._renderDayCard(day, today)).join('')}
+      </div>
+    `;
+
+    this._bindEvents();
+    this._bindDayToggles(); // re-bind after innerHTML rebuild
+  },
+
+  _bindEvents() {
+    // All listeners on the stable container — set once, never re-bound on refresh.
+    // This replaces per-element querySelectorAll().forEach() which rebound on every render.
+    if (this._delegated) return;
+    this._delegated = true;
+    const container = document.getElementById('studyplan-body');
+    if (!container) return;
+
+    container.addEventListener('click', e => {
+      const t = e.target;
+
+      if (t.id === 'apply-rebalance' || t.closest('#apply-rebalance')) {
+        PlanEngine.applyRebalance(this._plan, this._rebalanceChanges);
+        PlanStore.save(this._plan);
+        this._rebalanceChanges = [];
+        Toast.success('Plan updated!');
+        this._render(); return;
+      }
+      if (t.id === 'dismiss-rebalance') { this._rebalanceChanges = []; this._render(); return; }
+      if (t.id === 'sp-edit-plan-btn')  { this._openEditPlanModal(); return; }
+      if (t.id === 'sp-new-plan-btn' || t.id === 'sp-create-btn') { StudyPlanBuilder.open(); return; }
+      if (t.id === 'sp-delete-btn')     { this._confirmDelete(); return; }
+      if (t.id === 'sp-start-session-btn') { this._startIntegratedSession(); return; }
+
+      const launchBtn = t.closest('.task-launch-btn');
+      if (launchBtn) { this._launchTask(launchBtn.dataset.nodeId, launchBtn.dataset.activity); return; }
+
+      const addBtn = t.closest('.sp-add-task-btn');
+      if (addBtn) { this._openAddTaskModal(addBtn.dataset.dayDate); return; }
+    });
+
+    container.addEventListener('change', e => {
+      const cb = e.target.closest('.task-check');
+      if (cb) this._toggleTaskPartial(cb);
+    });
+
+    // Day card open/closed state — <details> toggle doesn't bubble, needs direct binding.
+    // Re-applied each render since <details> elements are recreated in innerHTML.
+    // Wrapped here rather than in _render() to keep all event logic in one place.
+    this._bindDayToggles();
+  },
+
+  /** Re-bind <details> toggle listeners after innerHTML rebuild.
+   *  toggle events don't bubble, so event delegation can't catch them. */
+  _bindDayToggles() {
+    document.querySelectorAll('.plan-day-card').forEach(el => {
+      el.addEventListener('toggle', () => {
+        const date = el.dataset.date;
+        if (date) {
+          if (el.open) this._openDays.add(date);
+          else this._openDays.delete(date);
+        }
+      });
+    });
+  },
+
+  // ─── Day card rendering ────────────────────────────────
+
+  _renderDayCard(day, today) {
+    const dateObj   = new Date(day.date + 'T00:00:00');
+    const dateLabel = dateObj.toLocaleDateString('en-GB', { weekday:'short', day:'numeric', month:'short' });
+    const isPast    = day.date < today;
+    const isToday   = day.date === today;
+    const isDone    = day.isComplete;
+    const shouldOpen= this._openDays.has(day.date);
+
+    // Build task + break timeline
+    const timeline = this._renderTimeline(day, isToday, isPast);
+
+    // Stats row
+    const doneTasks  = day.tasks.filter(t=>t.done).length;
+    const totalTasks = day.tasks.length;
+    const totalBreakMins = (day.breaks||[]).reduce((s,b)=>s+b.durationMins,0);
+
+    return `
+      <details class="plan-day-card" data-date="${day.date}" ${shouldOpen ? 'open' : ''}>
+        <summary class="plan-day-summary">
+          <div class="plan-day-left">
+            <span class="sp-day-label ${isToday?'today':isPast?'past':''}">${dateLabel}</span>
+            ${isToday  ? '<span class="sp-today-badge">TODAY</span>' : ''}
+            ${isDone   ? '<span class="sp-done-badge">✓</span>'     : ''}
+          </div>
+          <div class="plan-day-right">
+            <span class="plan-day-stats">${totalTasks} task${totalTasks!==1?'s':''} · ${day.totalMins}m${totalBreakMins ? ` + ${totalBreakMins}m break` : ''}</span>
+            ${doneTasks > 0 ? `<span class="plan-day-progress-text">${doneTasks}/${totalTasks}</span>` : ''}
+            <span class="sp-chevron">›</span>
+          </div>
+        </summary>
+
+        <!-- Progress bar inside day card -->
+        ${totalTasks > 0 ? `
+          <div style="padding:0 16px;">
+            <div class="mastery-bar-track" style="height:3px;border-radius:0;">
+              <div class="mastery-bar-fill" style="width:${Math.round((doneTasks/totalTasks)*100)}%;height:3px;border-radius:0;"></div>
+            </div>
+          </div>` : ''}
+
+        <div class="sp-day-body">
+          ${timeline}
+          ${isToday || !isPast ? `<button class="sp-add-task-btn" data-day-date="${day.date}">+ Add Task</button>` : ''}
+        </div>
+      </details>`;
+  },
+
+  _renderTimeline(day, isToday, isPast) {
+    if (!day.tasks.length) return '<p style="font-family:var(--font-mono);font-size:12px;color:var(--text-muted);padding:8px 0;">No tasks scheduled.</p>';
+
+    const actLabel = { review:'Review', recall:'Recall', application:'Apply', summary:'Summary', lecture:'Lecture', competency:'Test' };
+    const actIcon  = t => ({ review:'📖', recall:'🔁', application:'🧩', summary:'📝', lecture:'🎓', competency:'🏆' }[t]||'📌');
+
+    const breakMap = {};
+    (day.breaks||[]).forEach(b => { breakMap[b.afterTaskIndex] = b.durationMins; });
+
+    // Group tasks by module prefix (e.g. "M1" from "M1.2 - Gross Income")
+    const getModuleGroup = title => {
+      const match = (title || '').match(/^(M\d+|Module\s*\d+)/i);
+      return match ? match[1].toUpperCase().replace(/\s+/g,'') : null;
+    };
+
+    let html = '';
+    let lastGroup = null;
+
+    day.tasks.forEach((task, idx) => {
+      const isDone       = task.done;
+      const isLaunchable = !isDone && !isPast && task.nodeId && !task.nodeId.startsWith('competency_');
+      const isTestable   = !isDone && task.nodeId?.startsWith('competency_');
+      const group        = getModuleGroup(task.nodeTitle);
+
+      // Insert module group header when group changes
+      if (group && group !== lastGroup) {
+        html += `<div style="font-family:var(--font-mono);font-size:9px;font-weight:700;
+                   text-transform:uppercase;letter-spacing:.08em;color:var(--accent);
+                   padding:8px 0 4px;margin-top:${lastGroup ? '8px' : '0'};">
+                   ${this._esc(group)}
+                 </div>`;
+        lastGroup = group;
+      }
+
+      html += `
+        <div class="sp-task-row ${isDone ? 'done' : ''}" data-task-id="${task.id}">
+          <input type="checkbox" class="task-check"
+            data-day-date="${day.date}" data-task-id="${task.id}"
+            ${isDone ? 'checked' : ''}
+            style="accent-color:var(--accent);width:18px;height:18px;flex-shrink:0;cursor:pointer;"/>
+          <span class="sp-task-icon">${actIcon(task.activityType)}</span>
+          <div class="sp-task-info">
+            <div class="sp-task-title ${isDone ? 'done-text' : ''}">${this._esc(task.nodeTitle)}</div>
+            <div class="sp-task-meta">${actLabel[task.activityType]||task.activityType} · ${task.estimatedMins} min</div>
+          </div>
+          <div class="sp-task-actions">
+            <span class="priority-dot priority-${task.priority}"></span>
+            ${isLaunchable ? `<button class="task-launch-btn sp-open-btn" data-node-id="${task.nodeId}" data-activity="${task.activityType}">Open</button>` : ''}
+            ${isTestable   ? `<button class="task-launch-btn sp-test-btn" data-node-id="${task.nodeId}" data-activity="competency">🏆 Test</button>` : ''}
+          </div>
+        </div>`;
+
+      // Insert break separator after this task if needed
+      if (breakMap[idx] !== undefined) {
+        html += `
+          <div class="sp-break-row">
+            <div class="sp-break-line"></div>
+            <div class="sp-break-badge">
+              ☕ ${breakMap[idx]} min break
+            </div>
+            <div class="sp-break-line"></div>
+          </div>`;
+      }
+    });
+
+    return html;
+  },
+
+  // ─── Partial checkbox update (no full re-render = no collapse) ──────
+
+  _toggleTaskPartial(cb) {
+    const date   = cb.dataset.dayDate;
+    const taskId = cb.dataset.taskId;
+    const done   = cb.checked;
+
+    // Update data
+    const day  = this._plan.days.find(d => d.date === date);
+    const task = day?.tasks.find(t => t.id === taskId);
+    if (!task) return;
+    task.done   = done;
+    task.doneAt = done ? Date.now() : null;
+    PlanStore.save(this._plan);
+    if (done) StreakTracker.recordActivity();
+
+    // Partial DOM update — only update the task row appearance
+    const row = cb.closest('.sp-task-row');
+    if (row) {
+      row.classList.toggle('done', done);
+      const titleEl = row.querySelector('.sp-task-title');
+      if (titleEl) titleEl.classList.toggle('done-text', done);
+    }
+
+    // Update the day card's progress bar and stats — without closing it
+    this._updateDayCardProgress(date);
+
+    // Update overall plan progress
+    this._updatePlanProgress();
+  },
+
+  _updateDayCardProgress(date) {
+    const day = this._plan.days.find(d => d.date === date);
+    if (!day) return;
+    const done  = day.tasks.filter(t=>t.done).length;
+    const total = day.tasks.length;
+    const pct   = total ? Math.round((done/total)*100) : 0;
+
+    // Find the day card by data-date attribute
+    const card = document.querySelector(`.plan-day-card[data-date="${date}"]`);
+    if (!card) return;
+
+    // Update progress bar inside card
+    const bar = card.querySelector('.mastery-bar-fill');
+    if (bar) bar.style.width = pct + '%';
+
+    // Update done badge in summary
+    const summary = card.querySelector('.plan-day-summary');
+    const existingDone = summary?.querySelector('.sp-done-badge');
+    if (pct === 100 && !existingDone) {
+      const badge = document.createElement('span');
+      badge.className = 'sp-done-badge';
+      badge.textContent = '✓';
+      summary?.querySelector('.plan-day-left')?.appendChild(badge);
+    }
+
+    // Update task count text
+    const statsEl = card.querySelector('.plan-day-progress-text');
+    if (statsEl) { statsEl.textContent = `${done}/${total}`; }
+    else if (done > 0) {
+      const statsArea = card.querySelector('.plan-day-right');
+      if (statsArea) {
+        const span = document.createElement('span');
+        span.className = 'plan-day-progress-text';
+        span.textContent = `${done}/${total}`;
+        statsArea.insertBefore(span, statsArea.querySelector('.sp-chevron'));
+      }
+    }
+  },
+
+  _updatePlanProgress() {
+    const pct   = this._plan.progressPct;
+    const done  = this._plan.completedTasks;
+    const total = this._plan.totalTasks;
+    const bar   = document.querySelector('#studyplan-body .progress-fill');
+    const label = document.querySelector('#studyplan-body .sp-progress-label');
+    if (bar)   bar.style.width = pct + '%';
+    if (label) label.textContent = `${pct}% · ${done}/${total}`;
+  },
+
+  // ─── Integrated timer session ─────────────────────────
+
+  _startIntegratedSession() {
+    const today    = StudyPlan._dateStr(new Date());
+    const dayPlan  = this._plan?.days.find(d => d.date === today);
+    const pending  = dayPlan?.tasks.filter(t => !t.done) || [];
+
+    if (!pending.length) { Toast.info("Today's tasks are all done! 🎉"); return; }
+
+    const sessionMins = this._plan.sessionMins || 45;
+    const breakMins   = sessionMins <= 25 ? 5 : sessionMins <= 45 ? 10 : sessionMins <= 60 ? 15 : 20;
+
+    // Build session queue from today's pending tasks
+    const queue = [...pending];
+    let currentIdx = 0;
+
+    const launchNext = () => {
+      if (currentIdx >= queue.length) {
+        Toast.success("All of today's tasks complete! Great session. 🎉");
+        StudySession._endSession?.();
+        return;
+      }
+      const task = queue[currentIdx];
+      Toast.info(`Starting: ${task.nodeTitle} — ${task.activityType} (${task.estimatedMins} min)`);
+      this._launchTask(task.nodeId, task.activityType);
+      currentIdx++;
+    };
+
+    // Start the session timer with integrated callbacks
+    StudySession._sessionLen  = sessionMins * 60;
+    StudySession._breakLen    = breakMins * 60;
+    StudySession._elapsed     = 0;
+    StudySession._phase       = 'studying';
+    StudySession._onBreakEnd  = () => {
+      Toast.info('Break over! Continuing session… 📚');
+      launchNext();
+    };
+    StudySession._showOverlay();
+    StudySession._tick();
+
+    // Launch first task
+    launchNext();
+  },
+
+  // ─── Task launch ─────────────────────────────────────
+
+  _launchTask(nodeId, activity) {
+    if (!nodeId) return;
+    if (nodeId.startsWith('competency_')) { CompetencyView.open(nodeId.replace('competency_','')); return; }
+    const node = nodeStore.get(nodeId);
+    if (!node) { Toast.error('Node not found.'); return; }
+    NodeDetailView.open(nodeId);
+    if (activity === 'recall' || activity === 'application') {
+      setTimeout(() => {
+        NodeDetailView._currentSection = 'questions';
+        document.querySelectorAll('.detail-nav-btn,.detail-tab-btn').forEach(b => b.classList.toggle('active', b.dataset.section==='questions'));
+        NodeDetailView._renderSection();
+      }, 150);
+    }
+  },
+
+  // ─── Create empty node from plan ─────────────────────
+
+  _createNodeFromPlan() {
+    Modal.open(`
+      <h2 style="font-family:var(--font-ui);font-size:19px;font-weight:800;margin-bottom:6px;">Add Node to Plan</h2>
+      <p style="font-family:var(--font-mono);font-size:12px;color:var(--text-muted);margin-bottom:20px;">
+        Create an empty node to add to the plan schedule. Fill in content later.
+      </p>
+      <div class="config-row" style="margin-bottom:14px;">
+        <label class="config-label">Subject *</label>
+        <input type="text" id="pn-subject" class="config-input" placeholder="e.g. Income Tax"/>
+      </div>
+      <div class="config-row" style="margin-bottom:14px;">
+        <label class="config-label">Chapter / Module *</label>
+        <input type="text" id="pn-chapter" class="config-input" placeholder="e.g. Module 4 — Deductions"/>
+      </div>
+      <div class="config-row" style="margin-bottom:14px;">
+        <label class="config-label">Node Title</label>
+        <input type="text" id="pn-title" class="config-input" placeholder="Auto-generated if blank"/>
+      </div>
+      <div class="config-row" style="margin-bottom:20px;">
+        <label class="config-label">Add to Schedule</label>
+        <select id="pn-schedule" class="config-select">
+          <option value="auto">Auto-schedule (next available day)</option>
+          <option value="none">Just create — don't schedule yet</option>
+        </select>
+      </div>
+      <div style="display:flex;gap:8px;">
+        <button class="btn-primary" id="pn-create-btn" style="flex:1;justify-content:center;">Create Node</button>
+        <button class="btn-secondary" onclick="Modal.close()">Cancel</button>
+      </div>`);
+
+    setTimeout(() => {
+      document.getElementById('pn-subject')?.focus();
+      document.getElementById('pn-create-btn')?.addEventListener('click', () => {
+        const subject  = document.getElementById('pn-subject')?.value.trim();
+        const chapter  = document.getElementById('pn-chapter')?.value.trim();
+        const titleIn  = document.getElementById('pn-title')?.value.trim();
+        const schedule = document.getElementById('pn-schedule')?.value;
+        if (!subject || !chapter) { Toast.error('Subject and Chapter are required.'); return; }
+
+        const title = titleIn || [subject, chapter].filter(Boolean).join(' — ');
+        const node  = new KnowledgeNode({ subject, chapter, title, processingStatus: 'ready' });
+        nodeStore.save(node);
+
+        if (schedule === 'auto' && this._plan) {
+          // Find next available day with capacity
+          const today      = StudyPlan._dateStr(new Date());
+          const targetDay  = this._plan.days.find(d => d.date >= today && d.totalMins < (this._plan.dailyMins || 60));
+          if (targetDay) {
+            targetDay.tasks.push(new StudyTask({ nodeId: node.id, nodeTitle: title, subject, activityType: 'review', estimatedMins: 20, priority: 2 }));
+            targetDay.tasks.push(new StudyTask({ nodeId: node.id, nodeTitle: title, subject, activityType: 'recall',  estimatedMins: 15, priority: 2 }));
+            PlanStore.save(this._plan);
+            Toast.success(`Node created and scheduled!`);
+          } else {
+            Toast.success(`Node created! No available slot found — open the node to add manually.`);
+          }
+        } else {
+          Toast.success(`Node "${title}" created. Open Library to add content.`);
+        }
+
+        Modal.close();
+        this._render();
+      });
+    }, 0);
+  },
+
+  // ─── Edit plan ────────────────────────────────────────
+
+  _openEditPlanModal() {
+    const plan = this._plan;
+    Modal.open(`
+      <h2 style="font-family:var(--font-ui);font-size:18px;font-weight:800;margin-bottom:20px;">Edit Plan</h2>
+      <div class="config-row" style="margin-bottom:14px;">
+        <label class="config-label">Plan Title</label>
+        <input type="text" id="ep-title" class="config-input" value="${this._esc(plan.title)}"/>
+      </div>
+      <div class="config-row" style="margin-bottom:14px;">
+        <label class="config-label">Exam Date</label>
+        <input type="date" id="ep-exam-date" class="config-input" value="${plan.examDate}"
+               min="${StudyPlan._dateStr(new Date())}"/>
+      </div>
+      <div style="display:grid;grid-template-columns:1fr 1fr;gap:12px;margin-bottom:20px;">
+        <div class="config-row">
+          <label class="config-label">Daily Time (min)</label>
+          <input type="number" id="ep-daily-mins" class="config-input" value="${plan.dailyMins}" min="15" max="480"/>
+        </div>
+        <div class="config-row">
+          <label class="config-label">Session (min)</label>
+          <select id="ep-session-mins" class="config-select">
+            <option value="25"  ${plan.sessionMins===25 ?'selected':''}>25 (Pomodoro)</option>
+            <option value="45"  ${(!plan.sessionMins||plan.sessionMins===45)?'selected':''}>45 (Standard)</option>
+            <option value="60"  ${plan.sessionMins===60 ?'selected':''}>60 min</option>
+            <option value="90"  ${plan.sessionMins===90 ?'selected':''}>90 min</option>
+          </select>
+        </div>
+      </div>
+      <div style="display:flex;gap:8px;">
+        <button class="btn-primary" id="ep-save-btn">Save</button>
+        <button class="btn-secondary" onclick="Modal.close()">Cancel</button>
+      </div>`);
+    setTimeout(() => {
+      document.getElementById('ep-save-btn')?.addEventListener('click', () => {
+        plan.title       = document.getElementById('ep-title')?.value.trim()            || plan.title;
+        plan.examDate    = document.getElementById('ep-exam-date')?.value               || plan.examDate;
+        plan.dailyMins   = parseInt(document.getElementById('ep-daily-mins')?.value)    || plan.dailyMins;
+        plan.sessionMins = parseInt(document.getElementById('ep-session-mins')?.value)  || 45;
+        plan.updatedAt   = Date.now();
+        PlanStore.save(plan);
+        Modal.close();
+        Toast.success('Plan updated!');
+        this._render();
+      });
+    }, 0);
+  },
+
+  _openAddTaskModal(dayDate) {
+    const nodes = nodeStore.getAll().filter(n => n.processingStatus === 'ready');
+    Modal.open(`
+      <h2 style="font-family:var(--font-ui);font-size:18px;font-weight:800;margin-bottom:20px;">Add Task</h2>
+      <div class="config-row" style="margin-bottom:14px;">
+        <label class="config-label">Node</label>
+        <select id="add-task-node" class="config-select">
+          ${nodes.map(n=>`<option value="${n.id}">${this._esc(n.title)}</option>`).join('')}
+          ${!nodes.length ? '<option value="">No nodes yet — create one first</option>' : ''}
+        </select>
+      </div>
+      <div class="config-row" style="margin-bottom:14px;">
+        <label class="config-label">Activity Type</label>
+        <select id="add-task-type" class="config-select">
+          <option value="review">📖 Review</option>
+          <option value="recall">🔁 Recall</option>
+          <option value="application">🧩 Application</option>
+          <option value="summary">📝 Summary</option>
+          <option value="competency">🏆 Competency Test</option>
+        </select>
+      </div>
+      <div class="config-row" style="margin-bottom:20px;">
+        <label class="config-label">Time (minutes)</label>
+        <input type="number" id="add-task-mins" class="config-input" value="20" min="5" max="180"/>
+      </div>
+      <div style="display:flex;gap:8px;">
+        <button class="btn-primary" id="add-task-save-btn">Add</button>
+        <button class="btn-secondary" onclick="Modal.close()">Cancel</button>
+      </div>`);
+    setTimeout(() => {
+      document.getElementById('add-task-save-btn')?.addEventListener('click', () => {
+        const nodeId = document.getElementById('add-task-node').value;
+        const type   = document.getElementById('add-task-type').value;
+        const mins   = parseInt(document.getElementById('add-task-mins').value) || 20;
+        const node   = nodeStore.get(nodeId);
+        const day    = this._plan.days.find(d => d.date === dayDate);
+        if (!day) { Toast.error('Day not found.'); return; }
+        day.tasks.push(new StudyTask({ nodeId, nodeTitle: node?.title||'Custom Task', subject: node?.subject||'', activityType: type, estimatedMins: mins, priority: 2 }));
+        PlanStore.save(this._plan);
+        Modal.close();
+        Toast.success('Task added!');
+        this._render();
+      });
+    }, 0);
+  },
+
+  _confirmDelete() {
+    Modal.open(`
+      <h2 style="font-family:var(--font-ui);font-size:18px;font-weight:800;margin-bottom:12px;">Delete Plan?</h2>
+      <p style="font-family:var(--font-body);font-size:14px;color:var(--text-secondary);margin-bottom:24px;">
+        Permanently delete "<strong>${this._esc(this._plan.title)}</strong>"?
+      </p>
+      <div style="display:flex;gap:10px;">
+        <button class="btn-danger" id="confirm-del-plan-btn">Delete</button>
+        <button class="btn-secondary" onclick="Modal.close()">Cancel</button>
+      </div>`);
+    setTimeout(() => {
+      document.getElementById('confirm-del-plan-btn')?.addEventListener('click', () => {
+        PlanStore.delete(this._plan.id);
+        Modal.close();
+        Toast.success('Plan deleted.');
+        this._plan = null;
+        this._openDays.clear();
+        this._render();
+      });
+    }, 0);
+  },
+
+  _esc: s => String(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'),
+};

--- a/knowledgenode/www/js/ui/StudySession.js
+++ b/knowledgenode/www/js/ui/StudySession.js
@@ -1,0 +1,356 @@
+/**
+ * StudySession.js — Final
+ * - Pause / Resume / Skip to break / Skip break
+ * - Minimise / restore overlay (timer keeps running)
+ * - Short sessions: 5, 10, 15, 20 min + all existing presets
+ * - _onBreakEnd callback for integrated plan sessions
+ */
+
+const StudySession = {
+  // ─── State ────────────────────────────────────────────
+  _timer:      null,
+  _elapsed:    0,
+  _sessionLen: 45 * 60,
+  _breakLen:   10 * 60,
+  _phase:      'idle',     // 'idle'|'studying'|'break'|'paused'
+  _pausedAt:   0,
+  _overlay:    null,
+  _minimised:  false,
+  _onBreakEnd: null,
+
+  // ─── OPEN SETTINGS MODAL ──────────────────────────────
+  open() {
+    Modal.open(`
+      <h2 style="font-family:var(--font-ui);font-size:19px;font-weight:800;margin-bottom:6px;">⏱ Study Session</h2>
+      <p style="font-family:var(--font-mono);font-size:12px;color:var(--text-muted);margin-bottom:20px;">
+        Choose a session length. A break reminder fires automatically when time is up.
+      </p>
+
+      <div style="margin-bottom:16px;">
+        <label class="config-label" style="margin-bottom:10px;">Quick sessions</label>
+        <div class="session-presets" id="session-presets-quick" style="grid-template-columns:repeat(4,1fr);">
+          <button class="session-preset" data-mins="5">5 min<span>Micro</span></button>
+          <button class="session-preset" data-mins="10">10 min<span>Burst</span></button>
+          <button class="session-preset" data-mins="15">15 min<span>Quick</span></button>
+          <button class="session-preset" data-mins="20">20 min<span>Focus</span></button>
+        </div>
+      </div>
+
+      <div style="margin-bottom:16px;">
+        <label class="config-label" style="margin-bottom:10px;">Full sessions</label>
+        <div class="session-presets" id="session-presets-full">
+          <button class="session-preset active" data-mins="25">25 min<span>Pomodoro</span></button>
+          <button class="session-preset" data-mins="45">45 min<span>Standard</span></button>
+          <button class="session-preset" data-mins="60">60 min<span>Deep</span></button>
+          <button class="session-preset" data-mins="90">90 min<span>Extended</span></button>
+          <button class="session-preset" data-mins="custom">Custom<span>Any</span></button>
+        </div>
+      </div>
+
+      <div id="custom-mins-row" style="display:none;margin-bottom:16px;">
+        <label class="config-label">Custom minutes</label>
+        <input type="number" id="custom-mins-input" class="config-input"
+          value="50" min="1" max="300" style="width:140px;margin-top:6px;"/>
+      </div>
+
+      <div style="padding:14px 18px;background:var(--bg-raised);border:1px solid var(--border);border-radius:var(--radius-md);margin-bottom:20px;" id="break-preview-box">
+        <div style="font-family:var(--font-ui);font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:0.08em;color:var(--text-muted);margin-bottom:8px;">Break Schedule</div>
+        <div id="break-preview" style="font-family:var(--font-body);font-size:13px;color:var(--text-secondary);line-height:1.7;">
+          After 25 min → 5 min break
+        </div>
+      </div>
+
+      <div style="display:flex;gap:8px;">
+        <button class="btn-primary" id="start-session-modal-btn" style="flex:1;justify-content:center;padding:14px;">▶ Start Session</button>
+        <button class="btn-secondary" onclick="Modal.close()">Cancel</button>
+      </div>`);
+
+    setTimeout(() => {
+      let selectedMins = 25;
+
+      const allPresets = () => document.querySelectorAll('.session-preset');
+      const setActive  = btn => { allPresets().forEach(b => b.classList.remove('active')); btn.classList.add('active'); };
+
+      allPresets().forEach(btn => {
+        btn.addEventListener('click', () => {
+          setActive(btn);
+          const m = btn.dataset.mins;
+          const customRow = document.getElementById('custom-mins-row');
+          if (m === 'custom') {
+            customRow.style.display = 'block';
+            selectedMins = parseInt(document.getElementById('custom-mins-input').value) || 50;
+          } else {
+            customRow.style.display = 'none';
+            selectedMins = parseInt(m);
+          }
+          this._updateBreakPreview(selectedMins);
+        });
+      });
+
+      document.getElementById('custom-mins-input')?.addEventListener('input', e => {
+        selectedMins = parseInt(e.target.value) || 50;
+        this._updateBreakPreview(selectedMins);
+      });
+
+      document.getElementById('start-session-modal-btn')?.addEventListener('click', () => {
+        const active = document.querySelector('.session-preset.active');
+        if (active?.dataset.mins === 'custom') {
+          selectedMins = parseInt(document.getElementById('custom-mins-input').value) || 50;
+        }
+        Modal.close();
+        this._startSession(selectedMins);
+      });
+
+      this._updateBreakPreview(25);
+    }, 0);
+  },
+
+  _updateBreakPreview(mins) {
+    const el = document.getElementById('break-preview');
+    if (!el) return;
+    const b = this._calcBreak(mins);
+    if (b === 0) {
+      el.innerHTML = `<span style="color:var(--text-muted);">No break for sessions under 5 min.</span>`;
+    } else {
+      const reps = mins <= 25 ? '4× = ~${mins*4} min total' : '';
+      el.innerHTML = `After ${mins} min → <strong>${b} min break</strong>${reps ? `<br><span style="color:var(--text-muted);font-size:11px;">${reps}</span>` : ''}`;
+    }
+  },
+
+  _calcBreak(mins) {
+    if (mins < 5)  return 0;
+    if (mins <= 10) return 2;
+    if (mins <= 20) return 3;
+    if (mins <= 25) return 5;
+    if (mins <= 45) return 10;
+    if (mins <= 60) return 15;
+    return 20;
+  },
+
+  // ─── START ────────────────────────────────────────────
+
+  _startSession(mins) {
+    const b = this._calcBreak(mins);
+    this._sessionLen = mins * 60;
+    this._breakLen   = b * 60;
+    this._elapsed    = 0;
+    this._phase      = 'studying';
+    this._minimised  = false;
+    this._showOverlay();
+    this._tick();
+  },
+
+  // ─── OVERLAY ─────────────────────────────────────────
+
+  _showOverlay() {
+    if (this._overlay) this._overlay.remove();
+
+    this._overlay = document.createElement('div');
+    this._overlay.id = 'session-overlay';
+    this._overlay.innerHTML = this._overlayHTML();
+    document.body.appendChild(this._overlay);
+    this._bindOverlayEvents();
+  },
+
+  _overlayHTML() {
+    const sesMins   = Math.round(this._sessionLen / 60);
+    const breakMins = Math.round(this._breakLen / 60);
+    return `
+      <!-- Full overlay -->
+      <div id="session-full" style="display:block;">
+        <div class="so-header">
+          <span id="session-phase-label" class="so-phase">Studying</span>
+          <div style="display:flex;gap:4px;">
+            <button id="session-minimise-btn" class="so-icon-btn" title="Minimise">⬇</button>
+            <button id="end-session-btn"      class="so-icon-btn" title="End session">✕</button>
+          </div>
+        </div>
+
+        <div id="session-timer-display" class="so-timer">0:00</div>
+        <div style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);text-align:center;margin-bottom:10px;" id="session-sub">
+          ${sesMins} min session · ${breakMins > 0 ? breakMins + ' min break' : 'no break'}
+        </div>
+
+        <div class="mastery-bar-track" style="height:4px;margin-bottom:14px;">
+          <div class="mastery-bar-fill" id="session-progress" style="width:0%;height:4px;"></div>
+        </div>
+
+        <!-- Controls -->
+        <div class="so-controls">
+          <button id="session-pause-btn" class="so-ctrl-btn primary">⏸ Pause</button>
+          <button id="session-skip-btn"  class="so-ctrl-btn">⏭ Skip</button>
+        </div>
+      </div>
+
+      <!-- Minimised pill -->
+      <div id="session-mini" style="display:none;">
+        <span id="mini-phase-icon">⏱</span>
+        <span id="mini-timer">0:00</span>
+        <button id="session-restore-btn" class="so-icon-btn" title="Restore">⬆</button>
+        <button id="session-minimise-end" class="so-icon-btn" title="End">✕</button>
+      </div>`;
+  },
+
+  _bindOverlayEvents() {
+    document.getElementById('end-session-btn')       ?.addEventListener('click', () => this._endSession());
+    document.getElementById('session-minimise-btn')  ?.addEventListener('click', () => this._minimise());
+    document.getElementById('session-restore-btn')   ?.addEventListener('click', () => this._restore());
+    document.getElementById('session-minimise-end')  ?.addEventListener('click', () => this._endSession());
+    document.getElementById('session-pause-btn')     ?.addEventListener('click', () => this._togglePause());
+    document.getElementById('session-skip-btn')      ?.addEventListener('click', () => this._skipPhase());
+  },
+
+  _minimise() {
+    this._minimised = true;
+    document.getElementById('session-full').style.display = 'none';
+    document.getElementById('session-mini').style.display = 'flex';
+    // Shrink overlay to pill
+    this._overlay.classList.add('minimised');
+  },
+
+  _restore() {
+    this._minimised = false;
+    document.getElementById('session-full').style.display = 'block';
+    document.getElementById('session-mini').style.display = 'none';
+    this._overlay.classList.remove('minimised');
+  },
+
+  _togglePause() {
+    const btn = document.getElementById('session-pause-btn');
+    if (this._phase === 'paused') {
+      // Resume
+      this._phase = this._pausedPhase || 'studying';
+      this._tick();
+      if (btn) { btn.textContent = '⏸ Pause'; btn.classList.add('primary'); }
+      Toast.info('Session resumed.');
+    } else {
+      // Pause
+      this._pausedPhase = this._phase;
+      this._phase = 'paused';
+      clearInterval(this._timer);
+      if (btn) { btn.textContent = '▶ Resume'; btn.classList.remove('primary'); }
+      Toast.info('Session paused.');
+    }
+  },
+
+  _skipPhase() {
+    clearInterval(this._timer);
+    this._elapsed = 0;
+    if (this._phase === 'studying' || this._phase === 'paused') {
+      if (this._breakLen > 0) {
+        this._showBreakAlert();
+      } else {
+        Toast.info('Session skipped — no break configured.');
+        this._phase = 'studying';
+        this._tick();
+      }
+    } else if (this._phase === 'break') {
+      this._showStudyAlert();
+    }
+  },
+
+  // ─── TICK ─────────────────────────────────────────────
+
+  _tick() {
+    clearInterval(this._timer);
+    this._timer = setInterval(() => {
+      if (this._phase === 'paused') return;
+      this._elapsed++;
+      this._updateDisplay();
+
+      const limit = this._phase === 'break' ? this._breakLen : this._sessionLen;
+
+      // 80% warning
+      if (this._phase === 'studying' && this._sessionLen > 60 &&
+          this._elapsed === Math.round(this._sessionLen * 0.8)) {
+        const rem = Math.round((this._sessionLen - this._elapsed) / 60);
+        Toast.info(`⏱ ${rem} min left — start wrapping up.`);
+      }
+
+      if (this._elapsed >= limit) {
+        clearInterval(this._timer);
+        this._phase === 'break' ? this._showStudyAlert() : this._showBreakAlert();
+      }
+    }, 1000);
+  },
+
+  _updateDisplay() {
+    const m   = Math.floor(this._elapsed / 60);
+    const s   = this._elapsed % 60;
+    const str = `${m}:${s.toString().padStart(2,'0')}`;
+    const lim = this._phase === 'break' ? this._breakLen : this._sessionLen;
+    const pct = Math.min(100, (this._elapsed / Math.max(1,lim)) * 100);
+
+    // Full view
+    const timerEl = document.getElementById('session-timer-display');
+    const progEl  = document.getElementById('session-progress');
+    if (timerEl) {
+      timerEl.textContent = str;
+      timerEl.style.color = pct > 90 ? 'var(--red)' : pct > 70 ? 'var(--accent)' : 'var(--text-primary)';
+    }
+    if (progEl) progEl.style.width = pct + '%';
+
+    // Mini view
+    const miniTimer = document.getElementById('mini-timer');
+    if (miniTimer) miniTimer.textContent = str;
+    const miniIcon  = document.getElementById('mini-phase-icon');
+    if (miniIcon)  miniIcon.textContent  = this._phase === 'break' ? '☕' : '⏱';
+  },
+
+  _showBreakAlert() {
+    this._phase   = 'break';
+    this._elapsed = 0;
+    StreakTracker.recordActivity();
+    const bm = Math.round(this._breakLen / 60);
+
+    if ('Notification' in window && Notification.permission === 'granted') {
+      new Notification('KnowledgeNode — Take a break! 🧠', {
+        body: `Session done. Take a ${bm} min break.`, icon: 'icons/icon.svg',
+      });
+    }
+
+    const label = document.getElementById('session-phase-label');
+    const sub   = document.getElementById('session-sub');
+    if (label) { label.textContent = 'Break'; label.style.color = 'var(--green)'; }
+    if (sub)   sub.textContent = `${bm} min break — stand up, stretch`;
+
+    const skipBtn = document.getElementById('session-skip-btn');
+    if (skipBtn) skipBtn.textContent = '⏭ Skip break';
+
+    Toast.success(`✓ Session done! Take a ${bm > 0 ? bm + ' min' : 'short'} break.`);
+    if (this._breakLen > 0) this._tick();
+  },
+
+  _showStudyAlert() {
+    this._phase   = 'studying';
+    this._elapsed = 0;
+    const sesMins = Math.round(this._sessionLen / 60);
+
+    const label = document.getElementById('session-phase-label');
+    const sub   = document.getElementById('session-sub');
+    const skip  = document.getElementById('session-skip-btn');
+    if (label) { label.textContent = 'Studying'; label.style.color = 'var(--accent)'; }
+    if (sub)   sub.textContent = `${sesMins} min session`;
+    if (skip)  skip.textContent = '⏭ Skip to break';
+
+    Toast.info('Break over! Back to work. 📚');
+    if (typeof this._onBreakEnd === 'function') this._onBreakEnd();
+    this._tick();
+  },
+
+  _endSession() {
+    clearInterval(this._timer);
+    this._overlay?.remove();
+    this._overlay  = null;
+    this._phase    = 'idle';
+    this._onBreakEnd = null;
+    const mins = Math.round(this._elapsed / 60);
+    if (mins > 0) Toast.success(`Session ended. Studied for ${mins} min. Great work! 🎉`);
+  },
+
+  requestNotifications() {
+    if ('Notification' in window && Notification.permission === 'default') {
+      Notification.requestPermission();
+    }
+  },
+};

--- a/knowledgenode/www/js/ui/TextAnnotator.js
+++ b/knowledgenode/www/js/ui/TextAnnotator.js
@@ -1,0 +1,36 @@
+/**
+ * TextAnnotator.js — Persistent text highlights stored per-node
+ * Highlights are stored in node.annotations = [{ id, selector, color, note }]
+ */
+const TextAnnotator = {
+  _colors: ['#f0a500','#3ecf82','#5a9cf5','#f0615a','#9b7ef5'],
+  _colorIdx: 0,
+
+  /** Restore saved highlights in a container */
+  restoreHighlights(container, node) {
+    if (!node.annotations?.length) return;
+    // Simple approach: restore by matching text snippets
+    node.annotations.forEach(ann => {
+      this._highlightText(container, ann.text, ann.color, ann.id);
+    });
+  },
+
+  _highlightText(container, searchText, color, id) {
+    const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
+    let node;
+    while ((node = walker.nextNode())) {
+      const idx = node.textContent.indexOf(searchText);
+      if (idx === -1) continue;
+      const range = document.createRange();
+      range.setStart(node, idx);
+      range.setEnd(node, idx + searchText.length);
+      const mark = document.createElement('mark');
+      mark.className = 'kn-highlight';
+      mark.dataset.annId = id;
+      mark.style.background = color + '40';
+      mark.style.borderBottom = `2px solid ${color}`;
+      try { range.surroundContents(mark); } catch { /* skip cross-element */ }
+      break;
+    }
+  },
+};

--- a/knowledgenode/www/js/ui/Toast.js
+++ b/knowledgenode/www/js/ui/Toast.js
@@ -1,0 +1,38 @@
+/**
+ * Toast.js — Notification System
+ */
+
+const Toast = {
+  _container: null,
+
+  _getContainer() {
+    if (!this._container) {
+      this._container = document.getElementById('toast-container');
+    }
+    return this._container;
+  },
+
+  show(message, type = 'info', duration = 4000) {
+    const toast = document.createElement('div');
+    toast.className = `toast toast-${type}`;
+
+    const icons = { success: '✓', error: '✕', info: 'ℹ', warn: '⚠' };
+    toast.innerHTML = `<span>${icons[type] || 'ℹ'}</span><span class="toast-msg">${message}</span><button class="toast-close" aria-label="Dismiss">✕</button>`;
+
+    this._getContainer().appendChild(toast);
+
+    let timer;
+    const dismiss = () => {
+      clearTimeout(timer);
+      toast.classList.add('toast-out');
+      setTimeout(() => toast.remove(), 300);
+    };
+    toast.querySelector('.toast-close').addEventListener('click', dismiss);
+    timer = setTimeout(dismiss, duration);
+  },
+
+  success(msg) { this.show(msg, 'success'); },
+  error(msg)   { this.show(msg, 'error', 6000); },
+  info(msg, duration)    { this.show(msg, 'info', duration); },
+  warn(msg)    { this.show(msg, 'warn', 6000); },
+};

--- a/knowledgenode/www/js/ui/UnderstandingCheck.js
+++ b/knowledgenode/www/js/ui/UnderstandingCheck.js
@@ -1,0 +1,293 @@
+/**
+ * UnderstandingCheck.js — AI-powered assess-first diagnostic
+ *
+ * Before reading notes, the AI:
+ *   1. Generates 3 questions SPECIFIC to this node's content
+ *   2. Evaluates the student's answers against the source — gently,
+ *      praising reasoning, explaining gaps, never just "wrong"
+ *   3. Tells the student exactly what to focus on while reading
+ *
+ * Falls back to generic questions if no AI key is configured.
+ */
+const UnderstandingCheck = {
+  _node: null, _onPass: null, _questions: null,
+
+  show(node, onPass) {
+    this._node = node;
+    this._onPass = onPass;
+    this._questions = null;
+    this._render();
+  },
+
+  _genericQuestions(node) {
+    return [
+      { q: `What problem does ${(node.title||"").replace(/[<>"']/g,"")} solve? What is it trying to do?`, hint: 'e.g. It calculates… / it records…' },
+      { q: 'When would you use this — and when would you not use it?', hint: 'e.g. Use when… but not when…' },
+      { q: 'What mistakes could you make when applying this?', hint: 'e.g. Forgetting to…, confusing X with Y…' },
+    ];
+  },
+
+  _render() {
+    const node = this._node;
+    const container = document.getElementById('step-content');
+    if (!container) return;
+
+    const hasAI = AIService.hasApiKey();
+
+    // Show loading state while AI generates questions
+    container.innerHTML = `
+      <div class="uc-wrapper">
+        <div class="uc-header">
+          <div class="uc-badge">Step 1.5 — Understanding Check</div>
+          <h3 class="uc-title">Before you read your notes</h3>
+          <p class="uc-subtitle">Answer from memory or your initial reading. No wrong answers — this surfaces gaps before you study.</p>
+        </div>
+        <div id="uc-q-area">
+          ${hasAI ? `
+            <div class="aif-loading" style="padding:30px;justify-content:center;">
+              <div class="aif-dot"></div><div class="aif-dot"></div><div class="aif-dot"></div>
+            </div>
+            <p style="text-align:center;font-family:var(--font-mono);font-size:11px;color:var(--text-muted);">Preparing questions about this topic…</p>
+          ` : ''}
+        </div>
+      </div>`;
+
+    if (hasAI) {
+      // Use cached questions if we've generated them before for this node.
+      // They only depend on the node's content, so they're stable across visits.
+      if (node.ucQuestionCache?.length) {
+        this._questions = node.ucQuestionCache.slice(0, 3);
+        this._renderQuestions();
+        return;
+      }
+      AIService.generateUnderstandingQuestions(node)
+        .then(data => {
+          this._questions = (data?.questions?.length ? data.questions : this._genericQuestions(node)).slice(0, 3);
+          // Cache for next time
+          node.ucQuestionCache = this._questions;
+          try { nodeStore.save(node); } catch(e) { /* best-effort */ }
+          this._renderQuestions();
+        })
+        .catch(() => {
+          this._questions = this._genericQuestions(node);
+          this._renderQuestions();
+        });
+    } else {
+      this._questions = this._genericQuestions(node);
+      this._renderQuestions();
+    }
+  },
+
+  _renderQuestions() {
+    const node = this._node;
+    const qArea = document.getElementById('uc-q-area');
+    if (!qArea) return;
+
+    const src = KnowledgeNode.cleanSourceText(node.rawOCR);
+    const showSource = src && src !== '[Demo]' && src !== '[Demo mode]';
+
+    qArea.innerHTML = `
+      <div class="uc-questions">
+        ${this._questions.map((item, i) => `
+          <div class="uc-question">
+            <div class="uc-q-label">
+              <span class="uc-q-num">${i + 1}</span>
+              <span>${this._esc(item.q)}</span>
+            </div>
+            <textarea id="uc-q${i}" class="config-input uc-textarea" rows="3"
+              placeholder="${this._esc(item.hint || 'Your answer…')}"></textarea>
+          </div>
+        `).join('')}
+      </div>
+
+      ${showSource ? `
+        <details class="uc-source">
+          <summary>📄 Re-read source text before answering</summary>
+          <div class="uc-source-text">${this._esc(src.slice(0, 2000))}${src.length > 2000 ? '…' : ''}</div>
+        </details>` : ''}
+
+      <div class="uc-actions">
+        <button class="btn-primary" id="uc-proceed-btn" style="flex:1;justify-content:center;">✓ Check my understanding</button>
+        <button class="btn-secondary" id="uc-skip-btn">Skip</button>
+      </div>
+
+      <div class="uc-tip">
+        💡 Even partial answers are valuable. The gap between what you wrote and the notes tells you exactly what to focus on.
+      </div>`;
+
+    document.getElementById('uc-proceed-btn').addEventListener('click', () => {
+      const answers = this._questions.map((item, i) => ({
+        q: item.q,
+        a: document.getElementById('uc-q' + i)?.value.trim() || '',
+      }));
+      if (answers.every(a => !a.a)) {
+        Toast.info('Try answering at least one question — even a few words helps.');
+        document.getElementById('uc-q0')?.focus();
+        return;
+      }
+      node.understandingCheck = { answeredAt: Date.now(), answers };
+      nodeStore.save(node);
+      this._evaluate(answers);
+    });
+
+    document.getElementById('uc-skip-btn').addEventListener('click', () => this._onPass?.());
+  },
+
+  _evaluate(answers) {
+    const node = this._node;
+    const container = document.getElementById('step-content');
+    const hasAI = AIService.hasApiKey();
+
+    if (!hasAI) { this._showStaticComparison(answers); return; }
+
+    // Loading state
+    container.innerHTML = `
+      <div class="uc-wrapper">
+        <div class="uc-header">
+          <div class="uc-badge">Checking…</div>
+          <h3 class="uc-title">Reviewing your answers</h3>
+        </div>
+        <div class="aif-loading" style="padding:30px;justify-content:center;">
+          <div class="aif-dot"></div><div class="aif-dot"></div><div class="aif-dot"></div>
+        </div>
+        <p style="text-align:center;font-family:var(--font-mono);font-size:11px;color:var(--text-muted);">Your teacher is reviewing what you wrote…</p>
+      </div>`;
+
+    AIService.evaluateUnderstanding(node, answers)
+      .then(result => {
+        if (result && result.perAnswer) {
+          this._showAIFeedback(answers, result);
+        } else {
+          // AI returned nothing usable — fall back gracefully
+          this._showStaticComparison(answers);
+        }
+      })
+      .catch(err => {
+        console.warn('[UnderstandingCheck] AI evaluation failed:', err);
+        this._showStaticComparison(answers);
+      });
+  },
+
+  _showAIFeedback(answers, result) {
+    const container = document.getElementById('step-content');
+    const per   = result?.perAnswer || [];
+    const focus = result?.focusAreas || [];
+    const enc   = result?.encouragement || '';
+
+    const cards = answers.map((a, i) => {
+      const fb = per[i] || {};
+      const answered = a.a.length > 0;
+      return `
+        <div style="background:var(--bg-surface);border:1px solid var(--border);border-radius:12px;padding:14px 16px;">
+          <div style="display:flex;align-items:flex-start;gap:10px;margin-bottom:12px;">
+            <span class="uc-q-num" style="flex-shrink:0;">${i + 1}</span>
+            <span style="font-family:var(--font-ui);font-size:13px;font-weight:600;color:var(--text-primary);line-height:1.4;">${this._esc(a.q)}</span>
+          </div>
+          <div style="background:var(--bg-base);border:1px solid var(--border-soft);border-radius:10px;padding:12px 14px;margin-bottom:8px;">
+            <div style="font-family:var(--font-mono);font-size:9px;text-transform:uppercase;letter-spacing:.08em;color:${answered?'var(--green)':'var(--text-muted)'};margin-bottom:5px;">${answered?'✓ Your answer':'○ Not answered'}</div>
+            <div style="font-family:var(--font-body);font-size:13px;color:var(--text-primary);line-height:1.55;">${answered ? this._esc(a.a) : '<em style="color:var(--text-muted)">Skipped</em>'}</div>
+          </div>
+          ${fb.gotRight ? `<div style="display:flex;gap:8px;margin-bottom:8px;padding-top:2px;"><span style="flex-shrink:0;">✅</span><div style="font-family:var(--font-body);font-size:13px;color:var(--text-secondary);line-height:1.55;">${this._esc(fb.gotRight)}</div></div>` : ''}
+          ${fb.toImprove ? `<div style="display:flex;gap:8px;"><span style="flex-shrink:0;">🎯</span><div style="font-family:var(--font-body);font-size:13px;color:var(--text-secondary);line-height:1.55;">${this._esc(fb.toImprove)}</div></div>` : ''}
+          ${!fb.gotRight && !fb.toImprove && fb.feedback ? `<div style="font-family:var(--font-body);font-size:13px;color:var(--text-secondary);line-height:1.55;">${this._esc(fb.feedback)}</div>` : ''}
+        </div>`;
+    }).join('');
+
+    container.innerHTML = `
+      <div class="uc-wrapper">
+        <div class="uc-header">
+          <div class="uc-badge">⬡ Your Teacher's Feedback</div>
+          <h3 class="uc-title">Here's what I noticed</h3>
+          ${enc ? `<p class="uc-subtitle">${this._esc(enc)}</p>` : ''}
+        </div>
+
+        <div style="display:flex;flex-direction:column;gap:14px;margin-bottom:20px;">${cards}</div>
+
+        ${focus.length ? `
+          <div class="uc-gap-tip" style="background:var(--accent-soft);border:1px solid var(--accent-dim);">
+            <strong>📌 Focus on these as you read:</strong>
+            <ul style="margin:8px 0 0;padding-left:18px;">
+              ${focus.map(f => `<li style="font-family:var(--font-body);font-size:13px;color:var(--text-primary);line-height:1.6;margin-bottom:4px;">${this._esc(f)}</li>`).join('')}
+            </ul>
+          </div>` : ''}
+
+        <div style="margin-top:20px;">
+          <button class="btn-primary" id="uc-viewnotes-btn" style="width:100%;justify-content:center;padding:14px;">📋 View Notes Now</button><div style="text-align:center;font-family:var(--font-mono);font-size:9px;color:var(--text-muted);margin-top:8px;">build v63-22</div>
+        </div>
+      </div>`;
+
+    // Save focus areas to the node so the Notes step / AI can use them
+    if (focus.length) {
+      this._node.understandingCheck = { ...(this._node.understandingCheck || {}), focusAreas: focus };
+      nodeStore.save(this._node);
+    }
+
+    document.getElementById('uc-viewnotes-btn').addEventListener('click', () => {
+      let advanced = false;
+      try {
+        if (this._onPass) { this._onPass(); advanced = true; }
+      } catch(e) { console.warn('[UnderstandingCheck] onPass failed:', e); }
+      if (!advanced && typeof GuidedView !== 'undefined') {
+        try { GuidedView._advance(); } catch(e) { console.error('[UnderstandingCheck] advance failed:', e); }
+      }
+    });
+  },
+
+  /* Fallback when no AI — the old static note comparison */
+  _showStaticComparison(answers) {
+    const node = this._node;
+    const container = document.getElementById('step-content');
+    const noteAnswers = [
+      node.summary || node.definitions?.[0]?.description || 'See your notes below.',
+      node.formulas?.map(f => f.constraints).filter(Boolean).join('; ') || 'Check constraints in your notes.',
+      node.commonMistakes?.slice(0, 2).join('; ') || 'Check your notes for common mistakes.',
+    ];
+
+    const rows = answers.map((a, i) => {
+      const has = a.a.length > 0;
+      return `
+        <div class="uc-compare-row">
+          <div class="uc-compare-q">
+            <span class="uc-q-num" style="flex-shrink:0;">${i + 1}</span>
+            <span style="font-family:var(--font-ui);font-size:12px;font-weight:600;color:var(--text-muted);">${this._esc(a.q)}</span>
+          </div>
+          <div class="uc-compare-cols">
+            <div class="uc-compare-col yours">
+              <div class="uc-col-label" style="color:${has ? 'var(--green)' : 'var(--text-muted)'};">${has ? '✓' : '○'} Your answer</div>
+              <div class="uc-col-text">${has ? this._esc(a.a) : '<em style="color:var(--text-muted)">Not answered</em>'}</div>
+            </div>
+            <div class="uc-compare-col notes">
+              <div class="uc-col-label">📋 From your notes</div>
+              <div class="uc-col-text">${this._esc(noteAnswers[i] || 'See notes.')}</div>
+            </div>
+          </div>
+        </div>`;
+    }).join('');
+
+    container.innerHTML = `
+      <div class="uc-wrapper">
+        <div class="uc-header">
+          <div class="uc-badge">Gap Analysis</div>
+          <h3 class="uc-title">Your answers vs. your notes</h3>
+          <p class="uc-subtitle">The gaps you see here are exactly what to focus on as you study now.</p>
+        </div>
+        <div class="uc-compare">${rows}</div>
+        <div class="uc-gap-tip"><strong>Gaps = your highest priority topics.</strong> Keep them in mind as you read the notes.</div>
+        <div style="margin-top:20px;">
+          <button class="btn-primary" id="uc-viewnotes-btn" style="width:100%;justify-content:center;padding:14px;">📋 View Notes Now</button><div style="text-align:center;font-family:var(--font-mono);font-size:9px;color:var(--text-muted);margin-top:8px;">build v63-22</div>
+        </div>
+      </div>`;
+
+    document.getElementById('uc-viewnotes-btn').addEventListener('click', () => {
+      let advanced = false;
+      try {
+        if (this._onPass) { this._onPass(); advanced = true; }
+      } catch(e) { console.warn('[UnderstandingCheck] onPass failed:', e); }
+      if (!advanced && typeof GuidedView !== 'undefined') {
+        try { GuidedView._advance(); } catch(e) { console.error('[UnderstandingCheck] advance failed:', e); }
+      }
+    });
+  },
+
+  _esc: s => String(s || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;'),
+};

--- a/knowledgenode/www/js/ui/UploadView.js
+++ b/knowledgenode/www/js/ui/UploadView.js
@@ -1,0 +1,1177 @@
+/**
+ * UploadView.js — Final v14
+ * Multi-image upload with drag-to-reorder, AI processes all images together
+ */
+const UploadView = {
+  _files:       [],
+  _scannedText: '',
+  _targetNodeId:null,
+  _dragSrcIdx:  null,
+
+  init() {
+    this._zone    = document.getElementById('upload-zone');
+    this._input   = document.getElementById('file-input');
+    this._preview = document.getElementById('upload-preview');
+    this._config  = document.getElementById('upload-config');
+    this._status  = document.getElementById('processing-status');
+    this._label   = document.getElementById('processing-label');
+
+    this._input.addEventListener('change', e => {
+      if (e.target.files.length) this._handleFiles(e.target.files);
+      e.target.value = '';
+    });
+
+    this._zone.addEventListener('click', e => {
+      // Only a genuine tap on empty zone space should open the normal picker.
+      // Ignore clicks bubbling up from the hidden file inputs (e.g. BulkImport's
+      // programmatic bulk-import-input.click()) or from the action buttons/labels —
+      // otherwise tapping "Bulk Import" also fires the normal file-input.
+      if (e.target.closest('input, button, label')) return;
+      this._input.click();
+    });
+    this._zone.addEventListener('dragover', e => { e.preventDefault(); this._zone.classList.add('drag-over'); });
+    this._zone.addEventListener('dragleave',  () => this._zone.classList.remove('drag-over'));
+    this._zone.addEventListener('drop',     e => { e.preventDefault(); this._zone.classList.remove('drag-over'); this._handleFiles(e.dataTransfer.files); });
+
+    document.getElementById('bulk-import-btn')?.addEventListener('click', e => { e.stopPropagation(); BulkImport.trigger(); });
+    document.getElementById('bulk-import-input')?.addEventListener('change', e => {
+      if (e.target.files.length) BulkImport.start(e.target.files);
+      e.target.value = '';
+    });
+
+    document.getElementById('process-ai-btn')       ?.addEventListener('click', () => this._processWithAI());
+    document.getElementById('process-plain-btn')     ?.addEventListener('click', () => this._saveAsPlain());
+    document.getElementById('scan-camera-btn')       ?.addEventListener('click', e => { e.stopPropagation(); this._openCameraCapture(); });
+    document.getElementById('manual-text-btn')       ?.addEventListener('click', e => { e.stopPropagation(); this._showManualTextPanel(); });
+    document.getElementById('create-empty-node-btn') ?.addEventListener('click', e => { e.stopPropagation(); this._createEmptyNode(); });
+    document.getElementById('exam-paper-btn')          ?.addEventListener('click', e => { e.stopPropagation(); this._uploadExamPaper(); });
+    document.getElementById('revision-questions-btn')  ?.addEventListener('click', e => { e.stopPropagation(); this._uploadRevisionQuestions(); });
+
+    document.getElementById('manual-text-input')?.addEventListener('input', () => {
+      const words = (document.getElementById('manual-text-input').value.trim().match(/\S+/g)||[]).length;
+      const el = document.getElementById('manual-word-count');
+      if (el) el.textContent = words + ' words';
+    });
+    document.getElementById('manual-text-confirm-btn')?.addEventListener('click', () => this._confirmManualText());
+    document.getElementById('manual-text-cancel-btn') ?.addEventListener('click', () => document.getElementById('manual-text-panel').classList.add('hidden'));
+
+    // Live "what have I already created?" hint, keyed off the subject typed
+    const subjEl = document.getElementById('node-subject');
+    const chapEl = document.getElementById('node-chapter');
+    subjEl?.addEventListener('input', () => this._updateModuleHint());
+    subjEl?.addEventListener('focus', () => this._updateModuleHint());
+    chapEl?.addEventListener('focus', () => this._updateModuleHint());
+  },
+
+  /** Show which module/node numbers already exist for the typed subject,
+   *  so the user doesn't have to remember where they left off. */
+  _updateModuleHint() {
+    const hint = document.getElementById('existing-modules-hint');
+    if (!hint) return;
+    const subjectRaw = document.getElementById('node-subject')?.value.trim() || '';
+    const subjKey = subjectRaw.toLowerCase().trim();
+
+    const all = nodeStore.getAll();
+    // If they've typed a subject, scope to it; otherwise show all subjects briefly.
+    const scoped = subjKey
+      ? all.filter(n => (n.subject || '').toLowerCase().trim() === subjKey)
+      : all;
+
+    if (!scoped.length) {
+      hint.classList.add('hidden');
+      hint.innerHTML = '';
+      return;
+    }
+
+    // Group by chapter/module, list the node titles under each, sorted naturally
+    const byChapter = {};
+    scoped.forEach(n => {
+      const ch = n.chapter || 'No module';
+      (byChapter[ch] = byChapter[ch] || []).push(n.title || '(untitled)');
+    });
+    const chapters = Object.keys(byChapter).sort((a, b) =>
+      a.localeCompare(b, undefined, { numeric: true })
+    );
+
+    const label = subjKey
+      ? 'You already have in "' + this._esc(subjectRaw) + '":'
+      : 'Already in your library:';
+
+    hint.innerHTML =
+      '<div class="emh-title">📚 ' + label + '</div>'
+      + chapters.map(ch => {
+          const titles = byChapter[ch]
+            .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
+            .map(t => this._esc(t));
+          return '<div class="emh-row"><span class="emh-chapter">' + this._esc(ch) + '</span>'
+            + '<span class="emh-nodes">' + titles.join(' · ') + '</span></div>';
+        }).join('')
+      + '<div class="emh-foot">Tip: continue the sequence (e.g. next after the highest number above).</div>';
+    hint.classList.remove('hidden');
+  },
+
+  /* ─── Manual text ──────────────────────────────────── */
+  _showManualTextPanel() {
+    document.getElementById('manual-text-panel').classList.remove('hidden');
+    setTimeout(() => document.getElementById('manual-text-input')?.focus(), 50);
+  },
+
+  _confirmManualText() {
+    const text = document.getElementById('manual-text-input')?.value?.trim();
+    if (!text) { Toast.info('Type or paste some notes first.'); return; }
+    this._scannedText = text;
+    document.getElementById('manual-text-panel').classList.add('hidden');
+    document.getElementById('manual-text-input').value = '';
+    this._config.classList.remove('hidden'); this._updateModuleHint();
+    const words = (text.match(/\S+/g)||[]).length;
+    Toast.success(words + ' words ready. Fill Subject/Chapter then choose import method.');
+  },
+
+  /* ─── Upload Past Exam Paper ──────────────────────── */
+  _uploadExamPaper() {
+    const subjects = [...new Set(nodeStore.getAll().map(n => n.subject).filter(Boolean))];
+    const existingById = {};
+    nodeStore.getAll().forEach(n => { existingById[n.id] = n; });
+    Modal.open(
+      '<h2 style="font-family:var(--font-ui);font-size:19px;font-weight:800;margin-bottom:6px;">📝 Past Exam Paper</h2>'
+      + '<p style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);margin-bottom:18px;">AI analyses the exam style (question types, mark allocation) to steer future questions, AND extracts every real question with its model answer — added as gradeable questions you can actually practice, tracked with spaced repetition and included in Exam Mode.</p>'
+      + '<div class="config-row" style="margin-bottom:14px;"><label class="config-label">Add questions to</label>'
+      + '<select id="ep-target" class="config-select"><option value="__new__">＋ Create a new node</option>'
+      + nodeStore.getAll().map(n => '<option value="'+n.id+'">'+this._esc(n.subject||'')+' — '+this._esc(n.title||'')+'</option>').join('')
+      + '</select></div>'
+      + '<div class="config-row" style="margin-bottom:14px;"><label class="config-label">Subject *</label>'
+      + (subjects.length
+          ? '<select id="ep-subject" class="config-select"><option value="">Select or type below…</option>' + subjects.map(s=>'<option value="'+this._esc(s)+'">'+this._esc(s)+'</option>').join('') + '</select>'
+          : '<input type="text" id="ep-subject-text" class="config-input" placeholder="e.g. Income Tax"/>')
+      + '</div>'
+      + (subjects.length ? '<div class="config-row" style="margin-bottom:14px;"><label class="config-label">Or type subject</label><input type="text" id="ep-subject-text" class="config-input" placeholder="Custom subject name…"/></div>' : '')
+      + '<div class="config-row" style="margin-bottom:14px;"><label class="config-label">Exam Year / Name</label><input type="text" id="ep-name" class="config-input" placeholder="e.g. 2023 Final Exam, Midterm 2024"/></div>'
+      + '<div class="config-row" style="margin-bottom:18px;"><label class="config-label">Upload Paper * <span style="font-weight:400;color:var(--text-muted);">(select ALL pages — including the memo/solutions if you have them)</span></label>'
+      + '<input type="file" id="ep-file" accept="image/*,.pdf" multiple style="font-family:var(--font-mono);font-size:12px;color:var(--text-primary);padding:8px 0;display:block;width:100%;"/></div>'
+      + '<div id="ep-progress" style="display:none;text-align:center;padding:12px 0;">' + KNLoader.hex(40) + '<p style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);margin-top:8px;">Analysing exam style and extracting questions…</p></div>'
+      + '<div id="ep-actions" style="display:flex;gap:8px;">'
+      + '<button class="btn-primary" id="ep-analyse-btn" style="flex:1;justify-content:center;">⬡ Analyse &amp; Extract Questions</button>'
+      + '<button class="btn-secondary" onclick="Modal.close()">Cancel</button></div>'
+    );
+    setTimeout(() => {
+      document.getElementById('ep-analyse-btn')?.addEventListener('click', async () => {
+        const targetId    = document.getElementById('ep-target')?.value;
+        const isNew       = !targetId || targetId === '__new__';
+        const subjectSel  = document.getElementById('ep-subject')?.value.trim();
+        const subjectText = document.getElementById('ep-subject-text')?.value.trim();
+        const subject = subjectText || subjectSel || (isNew ? '' : (existingById[targetId]?.subject || ''));
+        const name    = document.getElementById('ep-name')?.value.trim() || 'Past Exam';
+        const files   = document.getElementById('ep-file')?.files;
+        if (!subject) { Toast.error('Please enter a subject.'); return; }
+        if (!files || !files.length) { Toast.error('Please upload the exam paper (you can select several photos at once).'); return; }
+        if (!AIService.hasApiKey()) { Toast.error('Configure AI first in Settings.'); return; }
+        document.getElementById('ep-actions').style.display = 'none';
+        document.getElementById('ep-progress').style.display = 'block';
+        try {
+          const ocrText = await this._extractFilesText(files,
+            'These are pages of an exam paper. Extract all text exactly as it appears — every question, every multiple-choice option, mark allocation, instruction, and any memo/solutions.',
+            'Extract all text from this exam paper exactly as it appears. Include all questions, options, marks, instructions and any solutions.',
+            'the paper');
+          // Step 2: Analyse extracted text as JSON — style metadata AND every question, not a sample
+          const prompt = 'Analyse this exam paper text for the subject "' + subject + '".'
+            + ' Extract question types, mark allocations, topic areas, and style.'
+            + ' Also extract EVERY question on the paper with its full model answer, EXACTLY as written — do not summarise, shorten, or limit to a sample. Extract all of them, however many there are.'
+            + '\nRULES for specific formats:'
+            + '\n- Multiple-choice questions: include ALL the options (A, B, C, D…) inside the "question" text, each on its own line.'
+            + '\n- Answer keys: if solutions are given as a separate key of letters (e.g. "1.1 A"), write the modelAnswer as the letter PLUS the full text of that option.'
+            + '\n- Long scenario/case questions with several required parts ((a), (b)…): output one entry per required part, and include the scenario facts and figures needed to answer it inside the "question" text. Keep the full worked solution as the modelAnswer.'
+            + '\n- If a question has no answer/memo given, leave "modelAnswer" empty rather than inventing one.'
+            + '\nOutput ONLY raw JSON, no fences: {"questionTypes":[],"markPattern":"","topicAreas":[],"style":"","examQuestions":[{"question":"","marks":0,"modelAnswer":"","type":""}]}'
+            + '\n\nEXAM TEXT:\n' + ocrText;
+          const analysisMsgs = [
+            {role:'user', content: prompt},
+          ];
+          const raw = await AIService._callWithFunction('noteProcessing', analysisMsgs, 8000);
+          const analysis = AIService._parseJSON(raw);
+          const key = 'kn_exam_style_' + subject.toLowerCase().replace(/\s+/g,'_');
+          const existing = JSON.parse(localStorage.getItem(key) || '{"papers":[]}');
+          existing.papers.push({ name, analysis, addedAt: Date.now() });
+          localStorage.setItem(key, JSON.stringify(existing));
+
+          const extracted = (analysis.examQuestions || []).filter(q => q && q.question && q.question.trim());
+          const newQs = extracted.map(q => ({
+            id: KnowledgeNode._generateQuestionId(), type: 'recall',
+            question: q.question.trim(), answer: (q.modelAnswer || '').trim(),
+          }));
+          let node = null;
+          if (newQs.length) {
+            if (isNew) {
+              node = new KnowledgeNode({
+                subject, title: name, rawOCR: ocrText, userNotes: ocrText,
+                questions: newQs, processingStatus: 'ready',
+              });
+            } else {
+              node = existingById[targetId] || nodeStore.get(targetId);
+              if (node) node.questions = (node.questions || []).concat(newQs);
+            }
+            if (node) { nodeStore.save(node); StreakTracker.recordActivity(); }
+          }
+
+          Modal.close();
+          const qCount = newQs.length;
+          Toast.success('Exam style saved! ' + qCount + ' real question' + (qCount===1?'':'s') + ' extracted and ready to practice.');
+          if (qCount && typeof PastPaperDrill !== 'undefined') setTimeout(() => PastPaperDrill.open(subject), 400);
+        } catch(err) {
+          document.getElementById('ep-actions').style.display = 'flex';
+          document.getElementById('ep-progress').style.display = 'none';
+          const msg = (err && err.message) ? err.message : (typeof err === 'string' ? err : 'Unknown error — check console');
+          Toast.error('Analysis failed: ' + msg);
+        }
+      });
+    }, 0);
+  },
+
+  /** Shared OCR pipeline for exam-paper-like documents (PDF or a single image).
+   *  Tries the PDF text layer first, falls back to rasterising pages and having
+   *  the AI read them. `multiPageHint`/`singlePageHint` tell the OCR call what
+   *  to preserve, and `noun` names the document in the "couldn't read it" error. */
+  async _extractDocumentText(file, multiPageHint, singlePageHint, noun) {
+    const isPDF = file.type === 'application/pdf' || /\.pdf$/i.test(file.name);
+    let ocrText = '';
+
+    if (isPDF) {
+      // 1) Try the PDF's text layer first (digital PDFs)
+      const extracted = await this._extractPDFText(file);
+      const looksEmptyOrScanned = !extracted
+        || extracted.startsWith('[PDF:')
+        || extracted.replace(/\s/g, '').length < 40;
+
+      if (!looksEmptyOrScanned) {
+        ocrText = extracted;
+      } else {
+        // 2) Scanned/image PDF — rasterise pages and OCR them with the AI
+        const pageImages = await this._pdfPagesToImages(file, 12);
+        if (!pageImages.length) {
+          throw new Error('This PDF has no readable text and its pages could not be converted. Try uploading a clear photo of each page instead.');
+        }
+        const content = [];
+        pageImages.forEach(b64 => content.push({ type:'image_url', image_url:{ url:'data:image/jpeg;base64,' + b64 } }));
+        content.push({ type:'text', text: multiPageHint });
+        ocrText = await AIService._callWithFunction('noteProcessing', [{ role:'user', content }], 6000);
+      }
+    } else {
+      // Single image file — normalise to a Claude-supported type, then OCR
+      const { base64, mediaType } = await new Promise((res, rej) => {
+        const r = new FileReader();
+        r.onload = () => {
+          const dataUrl = r.result;
+          const parts = dataUrl.split(',');
+          let mt = parts[0].match(/data:([^;]+);/)?.[1] || file.type || 'image/jpeg';
+          const supported = ['image/jpeg','image/png','image/gif','image/webp'];
+          if (!supported.includes(mt)) {
+            const img = new Image();
+            img.onload = () => { const c=document.createElement('canvas'); c.width=img.width; c.height=img.height; c.getContext('2d').drawImage(img,0,0); const j=c.toDataURL('image/jpeg',0.92); res({base64:j.split(',')[1],mediaType:'image/jpeg'}); };
+            img.onerror = () => rej(new Error('Could not read image file. Try a JPG or PNG photo.'));
+            img.src = dataUrl;
+          } else { res({base64:parts[1],mediaType:mt}); }
+        };
+        r.onerror = () => rej(new Error('Could not read file'));
+        r.readAsDataURL(file);
+      });
+      const ocrMsgs = [{role:'user', content:[
+        {type:'image_url', image_url:{url:'data:'+mediaType+';base64,'+base64}},
+        {type:'text', text: singlePageHint}
+      ]}];
+      ocrText = await AIService._callWithFunction('noteProcessing', ocrMsgs, 2000);
+    }
+
+    if (!ocrText || ocrText.replace(/\s/g,'').length < 20) {
+      throw new Error('Could not read any text from ' + noun + '. Try a clearer scan or photo.');
+    }
+    return ocrText;
+  },
+
+  /** Multi-file version: several photos are read as pages of ONE document (in
+   *  the order selected), so questions on one page and the answer key on
+   *  another stay together. A single file (image or PDF) uses the same
+   *  pipeline as before. Mixing PDFs with other files isn't supported. */
+  async _extractFilesText(files, multiPageHint, singlePageHint, noun) {
+    const list = Array.from(files || []);
+    if (list.length <= 1) return this._extractDocumentText(list[0], multiPageHint, singlePageHint, noun);
+    if (list.some(f => f.type === 'application/pdf' || /\.pdf$/i.test(f.name))) {
+      throw new Error('Please upload ONE PDF, or a set of photos — not both together.');
+    }
+    const imageData = await Promise.all(list.map(f => this._toBase64WithType(f)));
+    const ocrText = await AIService._extractMultiPageText(
+      imageData.map(d => d.base64), imageData.map(d => d.mediaType));
+    if (!ocrText || ocrText.replace(/\s/g,'').length < 20) {
+      throw new Error('Could not read any text from ' + noun + '. Try clearer photos.');
+    }
+    return ocrText;
+  },
+
+  /* ─── Upload Revision Questions ───────────────────────
+   * Extracts EVERY question + its full answer/solution verbatim from an
+   * uploaded worksheet — no AI rewriting — and adds them as real, gradeable
+   * questions on a node (new or existing), fully wired into spaced repetition
+   * and mastery tracking. This is the "test myself, then know exactly what
+   * to go re-read in the textbook" workflow. */
+  _uploadRevisionQuestions() {
+    const subjects = [...new Set(nodeStore.getAll().map(n => n.subject).filter(Boolean))];
+    const existingById = {};
+    nodeStore.getAll().forEach(n => { existingById[n.id] = n; });
+    Modal.open(
+      '<h2 style="font-family:var(--font-ui);font-size:19px;font-weight:800;margin-bottom:6px;">📚 Revision Questions</h2>'
+      + '<p style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);margin-bottom:18px;">AI extracts every question and its answer/solution exactly as written — nothing rewritten. They\'re added as real graded questions, tracked with spaced repetition so you can see exactly which ones to go back to the textbook for.</p>'
+      + '<div class="config-row" style="margin-bottom:14px;"><label class="config-label">Add to</label>'
+      + '<select id="rq-target" class="config-select"><option value="__new__">＋ Create a new node</option>'
+      + nodeStore.getAll().map(n => '<option value="'+n.id+'">'+this._esc(n.subject||'')+' — '+this._esc(n.title||'')+'</option>').join('')
+      + '</select></div>'
+      + '<div id="rq-new-fields">'
+      + '<div class="config-row" style="margin-bottom:14px;"><label class="config-label">Subject *</label>'
+      + (subjects.length
+          ? '<select id="rq-subject" class="config-select"><option value="">Select or type below…</option>' + subjects.map(s=>'<option value="'+this._esc(s)+'">'+this._esc(s)+'</option>').join('') + '</select>'
+          : '<input type="text" id="rq-subject-text" class="config-input" placeholder="e.g. Income Tax"/>')
+      + '</div>'
+      + (subjects.length ? '<div class="config-row" style="margin-bottom:14px;"><label class="config-label">Or type subject</label><input type="text" id="rq-subject-text" class="config-input" placeholder="Custom subject name…"/></div>' : '')
+      + '<div class="config-row" style="margin-bottom:14px;"><label class="config-label">Title</label><input type="text" id="rq-title" class="config-input" placeholder="e.g. Chapter 4 Revision Questions"/></div>'
+      + '</div>'
+      + '<div class="config-row" style="margin-bottom:18px;"><label class="config-label">Upload Worksheet * <span style="font-weight:400;color:var(--text-muted);">(select ALL pages — questions AND the answer/solution pages)</span></label>'
+      + '<input type="file" id="rq-file" accept="image/*,.pdf" multiple style="font-family:var(--font-mono);font-size:12px;color:var(--text-primary);padding:8px 0;display:block;width:100%;"/></div>'
+      + '<div id="rq-progress" style="display:none;text-align:center;padding:12px 0;">' + KNLoader.hex(40) + '<p style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);margin-top:8px;">Extracting questions…</p></div>'
+      + '<div id="rq-actions" style="display:flex;gap:8px;">'
+      + '<button class="btn-primary" id="rq-extract-btn" style="flex:1;justify-content:center;">⬡ Extract Questions</button>'
+      + '<button class="btn-secondary" onclick="Modal.close()">Cancel</button></div>'
+    );
+    setTimeout(() => {
+      const targetSel = document.getElementById('rq-target');
+      const newFields = document.getElementById('rq-new-fields');
+      targetSel?.addEventListener('change', () => {
+        newFields.style.display = targetSel.value === '__new__' ? 'block' : 'none';
+      });
+      document.getElementById('rq-extract-btn')?.addEventListener('click', async () => {
+        const targetId    = targetSel?.value;
+        const isNew       = !targetId || targetId === '__new__';
+        const subjectSel  = document.getElementById('rq-subject')?.value.trim();
+        const subjectText = document.getElementById('rq-subject-text')?.value.trim();
+        const subject      = subjectText || subjectSel;
+        const title         = document.getElementById('rq-title')?.value.trim();
+        const files        = document.getElementById('rq-file')?.files;
+        if (isNew && !subject) { Toast.error('Please enter a subject.'); return; }
+        if (!files || !files.length) { Toast.error('Please upload the worksheet (you can select several photos at once).'); return; }
+        if (!AIService.hasApiKey()) { Toast.error('Configure AI first in Settings.'); return; }
+        document.getElementById('rq-actions').style.display = 'none';
+        document.getElementById('rq-progress').style.display = 'block';
+        try {
+          const ocrText = await this._extractFilesText(files,
+            'These are pages of a revision question sheet. Extract all text exactly as it appears — every question, every multiple-choice option, and every answer/solution/memo, including answer keys.',
+            'Extract all text from this revision question sheet exactly as it appears. Include every question, every multiple-choice option, and every answer/solution.',
+            'the worksheet');
+          const newQs = await this._extractQuestionList(ocrText);
+
+          let node;
+          if (isNew) {
+            node = new KnowledgeNode({
+              subject, title: title || (subject + ' — Revision Questions'),
+              rawOCR: ocrText, userNotes: ocrText, questions: newQs, processingStatus: 'ready',
+            });
+          } else {
+            node = existingById[targetId] || nodeStore.get(targetId);
+            if (!node) throw new Error('That node no longer exists — pick another target.');
+            node.questions = (node.questions || []).concat(newQs);
+          }
+          nodeStore.save(node);
+          Modal.close();
+          StreakTracker.recordActivity();
+          Toast.success(newQs.length + ' revision question' + (newQs.length===1?'':'s') + ' added — exactly as written, ready to study.');
+          App.navigateTo('library');
+          setTimeout(() => NodeDetailView.open(node.id, 'questions'), 300);
+        } catch(err) {
+          document.getElementById('rq-actions').style.display = 'flex';
+          document.getElementById('rq-progress').style.display = 'none';
+          const msg = (err && err.message) ? err.message : (typeof err === 'string' ? err : 'Unknown error — check console');
+          Toast.error('Extraction failed: ' + msg);
+        }
+      });
+    }, 0);
+  },
+
+  /** Shared verbatim question-extraction: worksheet text in → gradeable
+   *  question objects out. Used by the Revision Questions dialog AND the
+   *  adaptive routing on the normal upload path. Throws when nothing usable
+   *  could be extracted. */
+  async _extractQuestionList(ocrText) {
+    const prompt = 'Extract EVERY question and its full answer/solution from this revision worksheet, EXACTLY as written.'
+      + ' Do not summarise, shorten, rewrite, or skip any — extract all of them, however many there are.'
+      + '\nRULES for specific formats:'
+      + '\n- Multiple-choice questions: include ALL the options (A, B, C, D…) inside the "question" text, each on its own line.'
+      + '\n- Answer keys: if the solutions are given as a separate key of letters (e.g. "1.1 A"), match each letter to its question and write the answer as the letter PLUS the full text of that option, e.g. "A — South African residents must pay tax on their worldwide income."'
+      + '\n- Long scenario/case questions with several required parts ((a), (b)…): output one entry per required part. Include the scenario facts and figures needed to answer it inside the "question" text — the student cannot see the original scenario while practicing. Keep the full worked solution as the "answer".'
+      + '\n- If a question has no answer given anywhere, leave "answer" empty rather than inventing one.'
+      + '\nOutput ONLY raw JSON, no fences: {"questions":[{"question":"","answer":""}]}'
+      + '\n\nWORKSHEET TEXT:\n' + ocrText;
+    const raw = await AIService._callWithFunction('noteProcessing', [{role:'user', content: prompt}], 8000);
+    const parsed = AIService._parseJSON(raw);
+    const extracted = (parsed.questions || []).filter(q => q && q.question && q.question.trim());
+    if (!extracted.length) { throw new Error('No questions could be extracted. Try a clearer scan or photo.'); }
+    return extracted.map(q => ({
+      id: KnowledgeNode._generateQuestionId(), type: 'recall',
+      question: q.question.trim(), answer: (q.answer || '').trim(),
+    }));
+  },
+
+  /** Cheap keyword heuristic — does this text look like a PRACTICE QUESTION
+   *  sheet (not notes, not a worked example)? Mirrors _looksLikeWorkedExample:
+   *  needs several independent signals before it fires. */
+  _looksLikeQuestionSheet(text) {
+    if (!text || text.length < 80) return false;
+    const t = text.toLowerCase();
+    let score = 0;
+    // Numbered question labels: "1.1", "question 3", "revision question 2"
+    const numbered = (t.match(/\b(\d+\.\d+|question\s+\d+)\b/g) || []).length;
+    if (numbered >= 3) score += 2; else if (numbered >= 1) score += 1;
+    // MCQ option rows: lines starting with a single letter A-F
+    const optionLines = (text.match(/^\s*[A-F][.)]?\s+\S/gm) || []).length;
+    if (optionLines >= 4) score += 2; else if (optionLines >= 2) score += 1;
+    // Exam-sheet vocabulary
+    if (/\b(marks?|mark allocation)\b/.test(t)) score += 1;
+    if (/\b(proposed solution|answer key|memo|memorandum|solutions?)\b/.test(t)) score += 1;
+    if (/\brevision question|multiple.choice|choose the correct\b/.test(t)) score += 1;
+    // Prose/notes signals push the other way — real notes explain, sheets ask
+    if (/\b(definition|is defined as|refers to|in summary|conclusion)\b/.test(t)) score -= 1;
+    return score >= 3;
+  },
+
+  /** Ask the user whether to import this as practice questions. Resolves true/false. */
+  _askQuestionRouting() {
+    return new Promise(resolve => {
+      Modal.open(
+        '<div style="text-align:center;">'
+        + '<div style="font-size:30px;margin-bottom:10px;">📚</div>'
+        + '<h2 style="font-family:var(--font-ui);font-size:18px;font-weight:800;margin-bottom:8px;">This looks like practice questions</h2>'
+        + '<p style="font-family:var(--font-body);font-size:13px;color:var(--text-secondary);line-height:1.6;margin-bottom:20px;">'
+        + 'It reads like a question sheet, not study notes. Import the questions <strong>exactly as written</strong> (nothing rewritten — ready to drill, with the coach able to tutor you through them), or process it as regular <strong>Notes</strong> where the AI structures the content and writes its own questions?</p>'
+        + '<div style="display:flex;gap:10px;justify-content:center;flex-wrap:wrap;">'
+        + '<button class="btn-primary" id="route-questions-btn" style="font-size:13px;padding:10px 18px;">📚 Import as Practice Questions</button>'
+        + '<button class="btn-secondary" id="route-material-btn" style="font-size:13px;padding:10px 18px;">📋 Process as Notes</button>'
+        + '</div></div>'
+      );
+      setTimeout(() => {
+        document.getElementById('route-questions-btn')?.addEventListener('click', () => { Modal.close(); resolve(true); });
+        document.getElementById('route-material-btn')?.addEventListener('click', () => { Modal.close(); resolve(false); });
+      }, 0);
+    });
+  },
+
+  /** Adaptive routing target: build a question-bank node straight from the
+   *  already-extracted upload text (no second OCR pass). */
+  async _saveAsQuestionBank(rawText, subject, chapter) {
+    const newQs = await this._extractQuestionList(rawText);
+    const node = new KnowledgeNode({
+      subject: subject || 'General', chapter: chapter || '',
+      title: [subject, chapter].filter(Boolean).join(' — ') || 'Revision Questions',
+      rawOCR: rawText, userNotes: rawText, questions: newQs, processingStatus: 'ready',
+    });
+    nodeStore.save(node);
+    this._reset();
+    this._status.classList.add('hidden');
+    StreakTracker.recordActivity();
+    Toast.success(newQs.length + ' practice question' + (newQs.length===1?'':'s') + ' imported exactly as written — ready to study.');
+    App.navigateTo('library');
+    setTimeout(() => NodeDetailView.open(node.id, 'questions'), 300);
+  },
+
+  /* ─── Create empty node ────────────────────────────── */
+  _createEmptyNode() {
+    Modal.open(
+      '<h2 style="font-family:var(--font-ui);font-size:19px;font-weight:800;margin-bottom:6px;">Create Empty Node</h2>'
+      + '<p style="font-family:var(--font-mono);font-size:12px;color:var(--text-muted);margin-bottom:20px;">Build structure now, add content later.</p>'
+      + '<div class="config-row" style="margin-bottom:14px;"><label class="config-label">Subject *</label><input type="text" id="en-subject" class="config-input" placeholder="e.g. Income Tax Returns"/></div>'
+      + '<div class="config-row" style="margin-bottom:14px;"><label class="config-label">Chapter / Module *</label><input type="text" id="en-chapter" class="config-input" placeholder="e.g. Module 1"/></div>'
+      + '<div class="config-row" style="margin-bottom:14px;"><label class="config-label">Node Title</label><input type="text" id="en-title" class="config-input" placeholder="e.g. M1.1 - Gross Income (auto-generated if blank)"/></div>'
+      + '<div style="background:var(--accent-soft);border:1px solid var(--accent-dim);border-radius:8px;padding:9px 12px;margin-bottom:14px;font-family:var(--font-body);font-size:12px;color:var(--text-secondary);line-height:1.5;">'
+      + '💡 <strong>Tip:</strong> One node per topic works best — e.g. "M1.1 - Gross Income" as its own node, not the whole module. Aim for 3–5 pages per node.'
+      + '</div>'
+      + '<div class="config-row" style="margin-bottom:20px;"><label class="config-label">Initial Notes (optional)</label><textarea id="en-notes" class="config-input" rows="3" style="resize:vertical;touch-action:pan-y;" placeholder="Paste any initial text…"></textarea></div>'
+      + '<div style="display:flex;gap:8px;"><button class="btn-primary" id="en-create-btn" style="flex:1;justify-content:center;">Create Node</button><button class="btn-secondary" onclick="Modal.close()">Cancel</button></div>'
+    );
+    setTimeout(() => {
+      document.getElementById('en-subject')?.focus();
+      document.getElementById('en-create-btn')?.addEventListener('click', () => {
+        const subject = document.getElementById('en-subject')?.value.trim();
+        const chapter = document.getElementById('en-chapter')?.value.trim();
+        const title   = document.getElementById('en-title')?.value.trim() || [subject,chapter].filter(Boolean).join(' — ');
+        const notes   = document.getElementById('en-notes')?.value.trim() || '';
+        if (!subject||!chapter) { Toast.error('Subject and Chapter are required.'); return; }
+        const node = new KnowledgeNode({ subject, chapter, title, userNotes:notes, processingStatus:'ready' });
+        nodeStore.save(node);
+        Modal.close();
+        Toast.success('"' + title + '" created.');
+        StreakTracker.recordActivity();
+        App.navigateTo('library');
+        setTimeout(() => NodeDetailView.open(node.id), 300);
+      });
+    }, 0);
+  },
+
+  /* ─── Append to existing node ──────────────────────── */
+  openForNode(nodeId) {
+    this._targetNodeId = nodeId;
+    const node = nodeStore.get(nodeId);
+    App.navigateTo('upload');
+    setTimeout(() => {
+      document.getElementById('upload-view-title').textContent    = 'Add More Content';
+      document.getElementById('upload-view-subtitle').textContent = 'Adding to: "' + (node?.title||'node') + '"';
+      const c = document.getElementById('append-badge-container');
+      if (c) {
+        c.innerHTML = '<div id="append-badge" style="display:inline-flex;align-items:center;gap:10px;padding:10px 18px;background:var(--accent-soft);border:1px solid var(--accent-dim);border-radius:var(--radius-md);font-family:var(--font-mono);font-size:12px;color:var(--accent);margin-bottom:20px;">⬡ Appending to: <strong>' + this._esc(node?.title||'') + '</strong><button id="cancel-append-btn" style="background:transparent;border:none;color:var(--text-muted);cursor:pointer;font-size:18px;">✕</button></div>';
+        document.getElementById('cancel-append-btn')?.addEventListener('click', () => this.cancelAppend());
+      }
+    }, 50);
+  },
+
+  cancelAppend() {
+    this._targetNodeId = null;
+    const c = document.getElementById('append-badge-container');
+    if (c) c.innerHTML = '';
+    document.getElementById('upload-view-title').textContent    = 'Upload Content';
+    document.getElementById('upload-view-subtitle').textContent = 'Drop images, PDFs, Word docs — AI processing or plain import.';
+    this._reset();
+  },
+
+  /* ─── File handling ────────────────────────────────── */
+  async _handleFiles(fileList) {
+    const allowed  = Array.from(fileList).filter(f => this._isSupported(f));
+    const rejected = fileList.length - allowed.length;
+    if (rejected > 0) Toast.info(rejected + ' file(s) skipped — unsupported format.');
+    if (!allowed.length) return;
+    this._files.push(...allowed);
+    await this._renderPreview();
+    this._config.classList.remove('hidden'); this._updateModuleHint();
+  },
+
+  _isSupported(f) {
+    return f.type.startsWith('image/')
+      || f.type.includes('pdf')
+      || f.type.includes('word') || f.name.endsWith('.docx') || f.name.endsWith('.doc')
+      || f.type.includes('excel') || f.name.endsWith('.xlsx')
+      || f.type.startsWith('text/') || f.name.endsWith('.txt') || f.name.endsWith('.md') || f.name.endsWith('.csv');
+  },
+
+  _fileIcon(f) {
+    if (f.type.startsWith('image/'))  return '🖼';
+    if (f.type.includes('pdf'))       return '📄';
+    if (f.name.endsWith('.docx'))     return '📝';
+    if (f.name.endsWith('.xlsx'))     return '📊';
+    return '📃';
+  },
+
+  async _renderPreview() {
+    this._preview.innerHTML = '';
+    this._preview.classList.toggle('hidden', !this._files.length);
+    if (!this._files.length) return;
+
+    // Header with count and reorder hint
+    const header = document.createElement('div');
+    header.style.cssText = 'font-family:var(--font-mono);font-size:12px;color:var(--text-muted);margin-bottom:10px;display:flex;align-items:center;gap:8px;';
+    header.innerHTML = '<span>' + this._files.length + ' file' + (this._files.length > 1 ? 's' : '') + ' selected</span>'
+      + (this._files.length > 1 ? '<span style="color:var(--text-muted);font-size:11px;">· Drag cards to reorder (AI reads left→right)</span>' : '');
+    this._preview.appendChild(header);
+
+    const grid = document.createElement('div');
+    grid.className = 'preview-grid';
+    this._preview.appendChild(grid);
+
+    for (let i = 0; i < this._files.length; i++) {
+      const f    = this._files[i];
+      const item = document.createElement('div');
+      item.className = 'preview-item';
+      item.draggable = true;
+      item.dataset.idx = i;
+
+      if (f.type.startsWith('image/')) {
+        const url = URL.createObjectURL(f);
+        item.innerHTML = '<div class="preview-order-badge">' + (i+1) + '</div><img src="' + url + '" loading="lazy" alt="Page ' + (i+1) + '" style="width:100%;height:110px;object-fit:cover;display:block;border-radius:var(--radius-sm) var(--radius-sm) 0 0;"/><div class="preview-filename">' + f.name.slice(0,22) + '</div><button class="preview-remove" data-idx="' + i + '">✕</button>';
+      } else {
+        item.innerHTML = '<div class="preview-order-badge">' + (i+1) + '</div><div style="height:80px;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:6px;"><span style="font-size:28px;">' + this._fileIcon(f) + '</span><span style="font-family:var(--font-mono);font-size:10px;color:var(--text-muted);">' + (f.size/1024).toFixed(0) + ' KB</span></div><div class="preview-filename">' + f.name.slice(0,22) + '</div><button class="preview-remove" data-idx="' + i + '">✕</button>';
+      }
+
+      // Drag-to-reorder
+      item.addEventListener('dragstart', e => { this._dragSrcIdx = i; item.style.opacity='0.4'; e.dataTransfer.effectAllowed='move'; });
+      item.addEventListener('dragend',   () => { item.style.opacity='1'; });
+      item.addEventListener('dragover',  e => { e.preventDefault(); e.dataTransfer.dropEffect='move'; item.style.outline='2px solid var(--accent)'; });
+      item.addEventListener('dragleave', () => { item.style.outline=''; });
+      item.addEventListener('drop',      e => {
+        e.preventDefault(); item.style.outline='';
+        if (this._dragSrcIdx !== null && this._dragSrcIdx !== i) {
+          const moved = this._files.splice(this._dragSrcIdx, 1)[0];
+          this._files.splice(i, 0, moved);
+          this._renderPreview();
+        }
+      });
+
+      grid.appendChild(item);
+    }
+
+    grid.querySelectorAll('.preview-remove').forEach(btn => {
+      btn.addEventListener('click', e => { e.stopPropagation(); this._removeFile(parseInt(btn.dataset.idx)); });
+    });
+  },
+
+  _removeFile(idx) {
+    this._files.splice(idx, 1);
+    this._renderPreview();
+    if (!this._files.length && !this._scannedText) this._config.classList.add('hidden');
+  },
+
+  /* ─── Camera capture ────────────────────────────────── */
+  _openCameraCapture() {
+    const isSecure = location.protocol === 'https:' || location.hostname === 'localhost' || location.hostname === '127.0.0.1';
+    const hasAPI   = !!(navigator.mediaDevices?.getUserMedia);
+
+    if (!hasAPI || !isSecure) {
+      const ua = navigator.userAgent;
+      let browserName = 'Your browser';
+      let tip = 'Camera access requires HTTPS.';
+      if (/SamsungBrowser/.test(ua)) { browserName='Samsung Browser'; tip='Samsung Browser requires HTTPS for camera. Use the native camera app instead.'; }
+      else if (/Chrome/.test(ua) && !/Edg/.test(ua)) { browserName='Chrome'; tip='Chrome requires HTTPS for camera access. This is a security policy.'; }
+      else if (/Firefox/.test(ua)) { browserName='Firefox'; tip='Firefox requires HTTPS for camera access.'; }
+      else if (/Edg/.test(ua)) { browserName='Edge'; tip='Edge requires HTTPS for camera access.'; }
+      else if (/Safari/.test(ua)) { browserName='Safari'; tip='Safari requires HTTPS for camera access.'; }
+
+      Modal.open(
+        '<h2 style="font-family:var(--font-ui);font-size:18px;font-weight:800;margin-bottom:12px;">Camera Unavailable</h2>'
+        + '<div style="background:var(--blue-dim);border:1px solid rgba(78,142,247,0.25);border-radius:var(--radius-md);padding:14px 18px;margin-bottom:16px;">'
+        + '<div style="font-family:var(--font-ui);font-size:12px;font-weight:700;color:var(--blue);margin-bottom:6px;">' + browserName + ' — HTTPS Required</div>'
+        + '<p style="font-family:var(--font-body);font-size:13px;color:var(--text-secondary);line-height:1.65;">' + tip + '</p>'
+        + '<p style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);margin-top:6px;">Current: ' + location.host + ' (HTTP)</p>'
+        + '</div>'
+        + '<div style="display:flex;gap:8px;"><button class="btn-primary" id="cam-gallery-fallback-btn" style="flex:1;justify-content:center;">📁 Open Gallery Instead</button><button class="btn-secondary" onclick="Modal.close()">Cancel</button></div>'
+      );
+      setTimeout(() => {
+        document.getElementById('cam-gallery-fallback-btn')?.addEventListener('click', () => {
+          Modal.close();
+          const inp = document.createElement('input'); inp.type='file'; inp.accept='image/*'; inp.multiple=true;
+          inp.addEventListener('change', () => { if(inp.files.length) { Array.from(inp.files).forEach(f=>this._processImageForOCR(f)); } inp.value=''; });
+          inp.click();
+        });
+      }, 0);
+      return;
+    }
+
+    const overlay = document.createElement('div');
+    overlay.style.cssText = 'position:fixed;inset:0;background:#000;z-index:99999;display:flex;flex-direction:column;';
+    overlay.innerHTML =
+      '<div style="display:flex;align-items:center;justify-content:space-between;padding:14px 16px;background:rgba(0,0,0,0.9);">'
+      + '<span style="font-family:var(--font-ui);font-size:14px;font-weight:700;color:#fff;">📷 Scan Document</span>'
+      + '<button id="cam-close-btn" style="background:transparent;border:none;color:#fff;font-size:22px;cursor:pointer;padding:4px 8px;">✕</button>'
+      + '</div>'
+      + '<div id="cam-status" style="position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);text-align:center;color:#fff;z-index:2;">'
+      + '<div style="font-size:32px;margin-bottom:12px;">📷</div>'
+      + '<div style="font-family:var(--font-ui);font-size:14px;">Starting camera…</div>'
+      + '<div style="font-family:var(--font-mono);font-size:11px;color:rgba(255,255,255,0.5);margin-top:6px;">Allow camera permission if prompted</div>'
+      + '</div>'
+      + '<video id="cam-video" autoplay playsinline muted style="flex:1;object-fit:cover;width:100%;display:block;background:#000;" webkit-playsinline></video>'
+      + '<div style="padding:20px 16px;background:rgba(0,0,0,0.88);display:flex;align-items:center;justify-content:center;gap:20px;position:relative;">'
+      + '<button id="cam-capture-btn" style="width:72px;height:72px;border-radius:50%;background:var(--accent);border:4px solid #fff;font-size:26px;cursor:pointer;display:flex;align-items:center;justify-content:center;box-shadow:0 4px 20px rgba(240,165,0,0.5);">📷</button>'
+      + '<button id="cam-gallery-btn" style="position:absolute;right:20px;padding:10px 16px;background:rgba(255,255,255,0.12);border:1px solid rgba(255,255,255,0.25);border-radius:var(--radius-md);color:#fff;font-family:var(--font-ui);font-size:12px;cursor:pointer;">Gallery</button>'
+      + '</div>'
+      + '<canvas id="cam-canvas" style="display:none;"></canvas>';
+    document.body.appendChild(overlay);
+
+    const video  = overlay.querySelector('#cam-video');
+    const canvas = overlay.querySelector('#cam-canvas');
+    const status = overlay.querySelector('#cam-status');
+    let stream   = null;
+
+    const cleanup = () => { stream?.getTracks().forEach(t=>t.stop()); overlay.remove(); };
+
+    const startCamera = async () => {
+      const constraints = [
+        { video:{ facingMode:{exact:'environment'} } },
+        { video:{ facingMode:'environment' } },
+        { video:true },
+      ];
+      for (const c of constraints) {
+        try { stream = await navigator.mediaDevices.getUserMedia(c); break; }
+        catch(e) { if (e.name==='NotAllowedError') { cleanup(); Toast.error('Camera permission denied.'); return; } }
+      }
+      if (!stream) { cleanup(); Toast.info('Camera unavailable — use Gallery.'); return; }
+      video.srcObject = stream;
+      video.onloadedmetadata = async () => { try { await video.play(); if(status) status.style.display='none'; } catch{} };
+      setTimeout(async () => { if (video.paused && stream) try { await video.play(); if(status) status.style.display='none'; } catch{} }, 800);
+    };
+
+    startCamera();
+
+    overlay.querySelector('#cam-close-btn').addEventListener('click', cleanup);
+    overlay.querySelector('#cam-capture-btn').addEventListener('click', () => {
+      if (!stream || video.videoWidth===0) { Toast.error('Camera not ready yet.'); return; }
+      canvas.width=video.videoWidth; canvas.height=video.videoHeight;
+      canvas.getContext('2d').drawImage(video,0,0);
+      const capBtn = overlay.querySelector('#cam-capture-btn');
+      if (capBtn) { capBtn.style.transform='scale(0.9)'; setTimeout(()=>capBtn.style.transform='',100); }
+      cleanup();
+      canvas.toBlob(blob => { if(blob) this._processImageForOCR(new File([blob],'scan.jpg',{type:'image/jpeg'})); }, 'image/jpeg', 0.95);
+    });
+    overlay.querySelector('#cam-gallery-btn').addEventListener('click', () => {
+      cleanup();
+      const inp=document.createElement('input'); inp.type='file'; inp.accept='image/*'; inp.multiple=true;
+      inp.addEventListener('change', () => { Array.from(inp.files).forEach(f=>this._handleFiles([f])); inp.value=''; });
+      inp.click();
+    });
+  },
+
+  async _processImageForOCR(file) {
+    const modal = document.createElement('div');
+    modal.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,0.88);z-index:99999;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:16px;';
+    modal.innerHTML = KNLoader.hex(56) + '<p style="font-family:var(--font-mono);font-size:14px;color:var(--accent);" id="ocr-status">Reading text…</p><div class="mastery-bar-track" style="width:240px;height:6px;"><div class="mastery-bar-fill" id="ocr-progress" style="width:0%;height:6px;"></div></div>';
+    document.body.appendChild(modal);
+    try {
+      this._files.push(file);
+      await this._renderPreview();
+      this._config.classList.remove('hidden'); this._updateModuleHint();
+      if (window.Tesseract) {
+        const imgUrl = URL.createObjectURL(file);
+        const result = await Tesseract.recognize(imgUrl, 'eng', {
+          logger: m => {
+            if (m.status==='recognizing text') {
+              const pct = Math.round(m.progress*100);
+              const el = document.getElementById('ocr-status'); if(el) el.textContent='Recognising: '+pct+'%';
+              const pr = document.getElementById('ocr-progress'); if(pr) pr.style.width=pct+'%';
+            }
+          }
+        });
+        URL.revokeObjectURL(imgUrl);
+        const text = result.data.text?.trim();
+        if (text) {
+          document.body.removeChild(modal);
+          OCRReview.show(file, text, result.data?.words||[], (confirmed) => {
+            this._scannedText = (this._scannedText ? this._scannedText + '\n\n---\n\n' : '') + confirmed;
+            Toast.success('✓ Text confirmed. Fill Subject/Chapter and choose import method.');
+          }, () => {
+            this._scannedText = (this._scannedText ? this._scannedText + '\n\n---\n\n' : '') + text;
+            Toast.info('Text imported as-is.');
+          });
+        } else {
+          document.body.removeChild(modal);
+          Toast.info('No text detected. Image saved — use AI Processing.');
+        }
+      } else {
+        document.body.removeChild(modal);
+        Toast.info('Image added. Use AI Processing for text extraction.');
+      }
+    } catch(e) {
+      if (modal.parentNode) document.body.removeChild(modal);
+      Toast.error('Scan error: ' + e.message);
+    }
+  },
+
+  /* ─── AI Processing ────────────────────────────────── */
+  async _processWithAI() {
+    if (!this._files.length && !this._scannedText) { Toast.error('Add a file, scan an image, or type notes first.'); return; }
+    const subject = document.getElementById('node-subject').value.trim();
+    const chapter = document.getElementById('node-chapter').value.trim();
+    const detail  = document.getElementById('node-detail').value;
+    const meta    = { subject, chapter, detail };
+
+    this._config.classList.add('hidden');
+    this._status.classList.remove('hidden');
+
+    const onProgress = (step, label) => {
+      this._label.textContent = label;
+      ['pstep-1','pstep-2','pstep-3','pstep-4'].forEach((id, i) => {
+        const el = document.getElementById(id);
+        if (!el) return;
+        el.className = i+1 < step ? 'proc-step done' : i+1===step ? 'proc-step active' : 'proc-step';
+      });
+    };
+
+    try {
+      const imageFiles   = this._files.filter(f => f.type.startsWith('image/'));
+      const textFiles    = this._files.filter(f => !f.type.startsWith('image/'));
+      const imageData = await Promise.all(imageFiles.map(f => this._toBase64WithType(f)));
+      const base64Images = imageData.map(d => d.base64);
+      const mediaTypes   = imageData.map(d => d.mediaType);
+
+      let rawText = this._scannedText || '';
+      if (!rawText && textFiles.length > 0) {
+        onProgress(1, 'Extracting text from ' + textFiles.length + ' file(s)…');
+        const parts = await Promise.all(textFiles.map(f => this._extractFileText(f)));
+        rawText = parts.join('\n\n---\n\n');
+      }
+      // For photo uploads, OCR up front so we can detect worked examples too.
+      // The extracted text is then reused by processContent (no double OCR).
+      if (!rawText && base64Images.length > 0 && AIService.hasApiKey()) {
+        onProgress(1, 'Reading ' + base64Images.length + ' image' + (base64Images.length>1?'s':'') + '…');
+        try {
+          rawText = base64Images.length > 1
+            ? await AIService._extractMultiPageText(base64Images, mediaTypes)
+            : await AIService._extractSingleImageText(base64Images[0], mediaTypes[0] || 'image/jpeg');
+        } catch(e) { /* fall through; processContent will OCR if needed */ }
+      }
+
+      // Detect if this looks like a worked example, and offer to file it there.
+      if (this._looksLikeWorkedExample(rawText)) {
+        const goExamples = await this._askExampleRouting();
+        if (goExamples) {
+          const filed = await this._saveAsWorkedExample(rawText, subject, chapter, base64Images);
+          if (filed) { return; }
+          // Extraction errored — fall through and process as notes instead
+          this._status.classList.remove('hidden');
+        }
+      }
+      // Adaptive routing: a question sheet is PRACTICE QUESTIONS, not source
+      // material — offer to import the questions verbatim instead of having
+      // the AI restructure them into notes and write its own questions.
+      else if (AIService.hasApiKey() && this._looksLikeQuestionSheet(rawText)) {
+        const goQuestions = await this._askQuestionRouting();
+        if (goQuestions) {
+          try {
+            this._status.classList.remove('hidden');
+            await this._saveAsQuestionBank(rawText, subject, chapter);
+            return;
+          } catch (e) {
+            Toast.error('Question import failed: ' + (e.message || 'unknown') + ' — processing as notes instead.');
+            this._status.classList.remove('hidden');
+          }
+        }
+      }
+
+      let nodeData;
+      if (AIService.hasApiKey()) {
+        nodeData = await AIService.processContent(base64Images, rawText, meta, onProgress, mediaTypes);
+      } else {
+        Toast.info('No AI key configured — using demo data. Go to Settings → Configure AI.');
+        nodeData = await AIService.mockProcess(meta, onProgress);
+      }
+
+      await this._saveNode(nodeData, subject, chapter, detail, base64Images);
+    } catch(err) {
+      console.error('[UploadView]', err);
+      Toast.error('AI processing failed: ' + err.message);
+      this._status.classList.add('hidden');
+      this._config.classList.remove('hidden'); this._updateModuleHint();
+    }
+  },
+
+  /** Cheap keyword heuristic — does this text look like a worked example?
+   *  Worked examples have a question + a full solution, often labelled. */
+  _looksLikeWorkedExample(text) {
+    if (!text || text.length < 60) return false;
+    const t = text.toLowerCase();
+    let score = 0;
+    // Explicit labels (your textbook uses "Learning example")
+    if (/\b(learning example|worked example|example \d|exercise \d|activity \d)\b/.test(t)) score += 3;
+    // Question/solution structure
+    if (/\b(required|solution|answer|prepare the|calculate|draw up|show the)\b/.test(t)) score += 1;
+    if (/\b(solution|answer|workings?)\b/.test(t)) score += 1;
+    // Accounting working cues
+    if (/\b(trial balance|trading account|profit and loss|general ledger|journal|debit|credit)\b/.test(t)) score += 1;
+    return score >= 3;
+  },
+
+  /** Ask the user whether to file this as a worked example. Resolves true/false. */
+  _askExampleRouting() {
+    return new Promise(resolve => {
+      Modal.open(
+        '<div style="text-align:center;">'
+        + '<div style="font-size:30px;margin-bottom:10px;">💡</div>'
+        + '<h2 style="font-family:var(--font-ui);font-size:18px;font-weight:800;margin-bottom:8px;">This looks like a worked example</h2>'
+        + '<p style="font-family:var(--font-body);font-size:13px;color:var(--text-secondary);line-height:1.6;margin-bottom:20px;">'
+        + 'It has a question and a full solution. Would you like to file it under <strong>Examples</strong> (where the AI tutors you through it step by step), or keep it as regular <strong>Notes</strong>?</p>'
+        + '<div style="display:flex;gap:10px;justify-content:center;flex-wrap:wrap;">'
+        + '<button class="btn-primary" id="route-example-btn" style="font-size:13px;padding:10px 18px;">💡 Add to Examples</button>'
+        + '<button class="btn-secondary" id="route-notes-btn" style="font-size:13px;padding:10px 18px;">📋 Keep as Notes</button>'
+        + '</div></div>'
+      );
+      setTimeout(() => {
+        document.getElementById('route-example-btn')?.addEventListener('click', () => { Modal.close(); resolve(true); });
+        document.getElementById('route-notes-btn')?.addEventListener('click', () => { Modal.close(); resolve(false); });
+      }, 0);
+    });
+  },
+
+  /** Process the text as a worked example and attach it to the chosen node. */
+  async _saveAsWorkedExample(rawText, subject, chapter, base64Images = []) {
+    // Pick or create a node to attach the example to:
+    //   1. If we're appending to a specific node, use that one.
+    //   2. Else an existing node in the same subject+chapter.
+    //   3. Else the newest node in the subject.
+    //   4. Else create a new node so the example always has a home.
+    const all = nodeStore.getAll();
+    const subjKey = (subject || '').toLowerCase().trim();
+    let target = this._targetNodeId ? nodeStore.get(this._targetNodeId) : null;
+    if (!target && subjKey) {
+      target = all.find(n => (n.subject||'').toLowerCase().trim() === subjKey
+                           && (n.chapter||'').toLowerCase().trim() === (chapter||'').toLowerCase().trim());
+    }
+    if (!target && subjKey) {
+      target = all.filter(n => (n.subject||'').toLowerCase().trim() === subjKey)
+                  .sort((a,b)=>(b.updatedAt||0)-(a.updatedAt||0))[0];
+    }
+
+    try {
+      Toast.info('Extracting worked example…');
+      let data = null;
+      if (AIService.hasApiKey()) {
+        const prompt = 'Extract this worked accounting example. Capture any ledger accounts, journals, or financial tables as structured tables — preserve columns and rows, including totals.\n'
+          + 'Output ONLY valid, complete JSON (no markdown, no trailing commas, close every bracket):\n'
+          + '{"title":"brief title","question":"the question/scenario","solution":"narrative explanation only","steps":["step"],"tables":[{"caption":"","columns":["col"],"rows":[["cell"]]}]}\n'
+          + 'Keep numbers exactly as written. If unsure, use fewer tables rather than malformed ones.\n\nTEXT:\n' + rawText.slice(0, 16000);
+        try {
+          const raw = await AIService._callWithFunction('noteProcessing', [{role:'user',content:prompt}], 6000);
+          data = AIService._parseJSON(raw);
+        } catch(parseErr) {
+          // First attempt failed — retry once asking for narrative only (no tables),
+          // which produces much simpler, more reliable JSON.
+          console.warn('[UploadView] example JSON failed, retrying without tables:', parseErr);
+          try {
+            const simplePrompt = 'Summarise this worked example. Output ONLY valid JSON:\n'
+              + '{"title":"brief title","question":"the question","solution":"full solution as readable text including the figures"}\n\nTEXT:\n' + rawText.slice(0, 16000);
+            const raw2 = await AIService._callWithFunction('noteProcessing', [{role:'user',content:simplePrompt}], 4000);
+            data = AIService._parseJSON(raw2);
+            if (data && !data.tables) data.tables = [];
+          } catch(parseErr2) {
+            data = null; // both failed — fall back to raw text below
+          }
+        }
+      }
+
+      // Fallback: if AI extraction failed or no key, save the raw text so the
+      // example is never lost — the user can tidy it in the Examples tab.
+      if (!data || typeof data !== 'object') {
+        const lines = rawText.split('\n').map(l=>l.trim()).filter(Boolean);
+        data = {
+          title:    'Scanned Example',
+          question: lines.slice(0, 2).join(' ') || 'Worked example',
+          solution: rawText.slice(0, 4000),
+          steps:    [],
+          tables:   [],
+        };
+        Toast.info('Saved the example as text — couldn\'t structure the tables this time.');
+      }
+
+      const example = {
+        id: 'ex_' + Math.random().toString(36).slice(2,9),
+        title:    data.title    || 'Scanned Example',
+        question: data.question || '',
+        solution: data.solution || rawText.slice(0,2000),
+        steps:    Array.isArray(data.steps) ? data.steps : [],
+        tables:   Array.isArray(data.tables) ? data.tables : [],
+        pageCount: base64Images.length || 1,
+        addedAt:  Date.now(),
+      };
+
+      // No existing node to attach to → create one so the example has a home,
+      // honoring the user's choice instead of silently dumping it into notes.
+      if (!target) {
+        target = new KnowledgeNode({
+          subject: subject || 'Examples',
+          chapter: chapter || '',
+          title:   example.title || 'Worked Examples',
+          summary: 'Worked examples for this topic.',
+          processingStatus: 'ready',
+          workedExamples: [example],
+        });
+        nodeStore.save(target);
+        if (typeof Onboarding !== 'undefined') Onboarding.markUploaded();
+        Toast.success('Created "' + target.title + '" with your worked example ✓');
+        this._reset();
+        App.navigateTo('library');
+        return true;
+      }
+
+      if (!target.workedExamples) target.workedExamples = [];
+      target.workedExamples.push(example);
+      nodeStore.save(target);
+      if (typeof Onboarding !== 'undefined') Onboarding.markUploaded();
+      Toast.success('Worked example added to "' + target.title + '" → Examples tab ✓');
+      this._reset();
+      App.navigateTo('library');
+      return true;
+    } catch(e) {
+      Toast.error('Could not extract example: ' + (e.message||'try again'));
+      this._config.classList.remove('hidden'); this._updateModuleHint();
+      return false;
+    }
+  },
+
+  /* ─── Plain import ─────────────────────────────────── */
+  async _saveAsPlain() {
+    if (!this._files.length && !this._scannedText) { Toast.error('Add a file or type notes first.'); return; }
+    const subject = document.getElementById('node-subject').value.trim();
+    const chapter = document.getElementById('node-chapter').value.trim();
+    this._config.classList.add('hidden');
+    this._status.classList.remove('hidden');
+    this._label.textContent = 'Importing…';
+    document.getElementById('pstep-1').className = 'proc-step active';
+    try {
+      const imageFiles   = this._files.filter(f => f.type.startsWith('image/'));
+      const textFiles    = this._files.filter(f => !f.type.startsWith('image/'));
+      const imageData = await Promise.all(imageFiles.map(f => this._toBase64WithType(f)));
+      const base64Images = imageData.map(d => d.base64);
+      let rawText = this._scannedText || '';
+      if (!rawText && textFiles.length > 0) {
+        const parts = await Promise.all(textFiles.map(f => this._extractFileText(f)));
+        rawText = parts.join('\n\n---\n\n');
+      }
+      document.getElementById('pstep-1').className = 'proc-step done';
+      document.getElementById('pstep-4').className = 'proc-step active';
+      this._label.textContent = 'Building node…';
+      await this._delay(200);
+      const title = chapter||subject ? [subject,chapter].filter(Boolean).join(' — ') : (this._files[0]?.name.replace(/\.[^.]+$/,'') || 'Imported Notes');
+      await this._saveNode({ rawOCR:rawText, title, definitions:[], tables:[], formulas:[], procedures:[], commonMistakes:[], summary:'', userNotes:rawText, questions:[], processingStatus:'ready' }, subject, chapter, 'plain', base64Images);
+    } catch(err) {
+      Toast.error('Import failed: ' + err.message);
+      this._status.classList.add('hidden');
+      this._config.classList.remove('hidden'); this._updateModuleHint();
+    }
+  },
+
+  /* ─── Save node ─────────────────────────────────────── */
+  async _saveNode(nodeData, subject, chapter, detail, base64Images) {
+    if (this._targetNodeId) {
+      const existing = nodeStore.get(this._targetNodeId);
+      if (existing) {
+        existing.definitions    = [...existing.definitions,    ...(nodeData.definitions    ||[])];
+        existing.tables         = [...(existing.tables||[]),   ...(nodeData.tables         ||[])];
+        existing.formulas       = [...existing.formulas,       ...(nodeData.formulas       ||[])];
+        existing.procedures     = [...(existing.procedures||[]),...(nodeData.procedures    ||[])];
+        existing.commonMistakes = [...existing.commonMistakes, ...(nodeData.commonMistakes ||[])];
+        existing.summary        = [existing.summary, nodeData.summary].filter(Boolean).join('\n\n');
+        existing.userNotes      = [existing.userNotes, nodeData.userNotes].filter(Boolean).join('\n\n---\n\n');
+        existing.questions      = [...existing.questions,      ...(nodeData.questions      ||[])];
+        existing.sourceImages   = [...existing.sourceImages,   ...base64Images];
+        existing.rawOCR         = [existing.rawOCR, nodeData.rawOCR].filter(Boolean).join('\n\n---\n\n');
+        nodeStore.save(existing);
+        Toast.success('Content added to "' + existing.title + '"!');
+        this._targetNodeId = null;
+        this._reset();
+        App.navigateTo('library');
+        return;
+      }
+    }
+    const node = new KnowledgeNode({...nodeData, subject, chapter, sourceImages:base64Images, processingDetail:detail});
+    nodeStore.save(node);
+    StreakTracker.recordActivity();
+    Onboarding.markUploaded();
+    Toast.success('Node created: "' + node.title + '"');
+    this._reset();
+    App.navigateTo('library');
+  },
+
+  /* ─── Text extraction ───────────────────────────────── */
+  async _extractFileText(file) {
+    if (file.type.startsWith('text/')||file.name.endsWith('.txt')||file.name.endsWith('.md')||file.name.endsWith('.csv')) return await file.text();
+    if (file.type.includes('pdf'))  return await this._extractPDFText(file);
+    if (file.type.includes('word')||file.name.endsWith('.docx')) return await this._extractDocxText(file);
+    return '[' + file.name + ']';
+  },
+
+  async _extractPDFText(file) {
+    try {
+      if (window.pdfjsLib) {
+        const pdf = await pdfjsLib.getDocument({ data: await file.arrayBuffer() }).promise;
+        const pageCount = Math.min(pdf.numPages, 20); // cap at 20 pages
+        let text = '';
+        for (let i = 1; i <= pageCount; i++) {
+          const page    = await pdf.getPage(i);
+          const content = await page.getTextContent();
+          text += content.items.map(item => item.str).join(' ') + '\n\n';
+        }
+        const cleaned = text.replace(/\s{3,}/g, '\n').trim();
+        if (cleaned.length > 30) return cleaned;
+        // PDF had no extractable text — likely a scanned document
+        Toast.info('This PDF appears to be scanned. Use "Scan Example" to photograph pages directly.');
+        return '[PDF: ' + file.name + ' — scanned PDF, no text layer found. Upload images of the pages instead.]';
+      }
+      return '[PDF: ' + file.name + ' — PDF viewer not loaded yet, try again in a moment.]';
+    } catch(e) {
+      console.warn('[UploadView] PDF extraction failed:', e);
+      return '[PDF: ' + file.name + ' — ' + e.message + '. Try uploading a photo of the page instead.]';
+    }
+  },
+
+  /** Render the first N pages of a PDF to JPEG base64 strings (for scanned PDFs). */
+  async _pdfPagesToImages(file, maxPages = 5) {
+    const images = [];
+    try {
+      if (!window.pdfjsLib) return images;
+      const pdf = await pdfjsLib.getDocument({ data: await file.arrayBuffer() }).promise;
+      const pageCount = Math.min(pdf.numPages, maxPages);
+      for (let i = 1; i <= pageCount; i++) {
+        const page     = await pdf.getPage(i);
+        const viewport = page.getViewport({ scale: 1.6 });
+        const canvas   = document.createElement('canvas');
+        canvas.width   = viewport.width;
+        canvas.height  = viewport.height;
+        const ctx      = canvas.getContext('2d');
+        await page.render({ canvasContext: ctx, viewport }).promise;
+        const jpeg = canvas.toDataURL('image/jpeg', 0.85);
+        images.push(jpeg.split(',')[1]);
+      }
+    } catch(e) {
+      console.warn('[UploadView] PDF rasterize failed:', e);
+    }
+    return images;
+  },
+
+  async _extractDocxText(file) {
+    try {
+      if (window.mammoth) {
+        const result = await mammoth.extractRawText({ arrayBuffer:await file.arrayBuffer() });
+        if (result.value?.trim()) return result.value;
+      }
+      return '[Word: ' + file.name + ' — mammoth.js loading, try again.]';
+    } catch(e) { return '[Word: ' + file.name + ' — ' + e.message + ']'; }
+  },
+
+  _toBase64(file) {
+    return new Promise((res,rej) => { const r=new FileReader(); r.onload=()=>res(r.result.split(',')[1]); r.onerror=rej; r.readAsDataURL(file); });
+  },
+
+  // Returns {base64, mediaType} — normalises to Claude-supported types
+  _toBase64WithType(file) {
+    return new Promise((res, rej) => {
+      const r = new FileReader();
+      r.onload = () => {
+        const dataUrl = r.result;
+        const parts = dataUrl.split(',');
+        let mt = parts[0].match(/data:([^;]+);/)?.[1] || file.type || 'image/jpeg';
+        const supported = ['image/jpeg','image/png','image/gif','image/webp'];
+        if (!supported.includes(mt)) {
+          // Convert unsupported format (HEIC, BMP, TIFF, etc.) to JPEG via canvas
+          const img = new Image();
+          img.onload = () => {
+            const c = document.createElement('canvas');
+            c.width = img.width; c.height = img.height;
+            c.getContext('2d').drawImage(img, 0, 0);
+            const jpeg = c.toDataURL('image/jpeg', 0.92);
+            res({ base64: jpeg.split(',')[1], mediaType: 'image/jpeg' });
+          };
+          img.onerror = rej;
+          img.src = dataUrl;
+        } else {
+          res({ base64: parts[1], mediaType: mt });
+        }
+      };
+      r.onerror = rej;
+      r.readAsDataURL(file);
+    });
+  },
+
+  _reset() {
+    this._files=[]; this._scannedText='';
+    this._preview.innerHTML=''; this._preview.classList.add('hidden');
+    this._config.classList.add('hidden');
+    this._status.classList.add('hidden');
+    this._input.value='';
+    document.getElementById('node-subject').value='';
+    document.getElementById('node-chapter').value='';
+    document.getElementById('manual-text-panel')?.classList.add('hidden');
+    const mt = document.getElementById('manual-text-input'); if(mt) mt.value='';
+    const bc = document.getElementById('append-badge-container'); if(bc) bc.innerHTML='';
+    this._targetNodeId = null;
+    const hint = document.getElementById('existing-modules-hint'); if(hint){ hint.classList.add('hidden'); hint.innerHTML=''; }
+  },
+
+  _esc: s => String(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'),
+
+  _delay: ms => new Promise(r=>setTimeout(r,ms)),
+};

--- a/knowledgenode/www/manifest.json
+++ b/knowledgenode/www/manifest.json
@@ -1,0 +1,23 @@
+{
+  "name": "KnowledgeNode Study System",
+  "short_name": "KnowledgeNode",
+  "description": "AI-powered study notes, spaced repetition, and exam prep \u2014 offline ready.",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#080a0d",
+  "theme_color": "#f0a500",
+  "orientation": "any",
+  "icons": [
+    {
+      "src": "icons/icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ],
+  "categories": [
+    "education",
+    "productivity"
+  ],
+  "screenshots": []
+}

--- a/knowledgenode/www/sw.js
+++ b/knowledgenode/www/sw.js
@@ -1,0 +1,34 @@
+/**
+ * sw.js — NEUTERED / SELF-UNREGISTERING
+ *
+ * Earlier builds shipped a service worker whose precache list referenced files
+ * that were later deleted, causing the SW install to fail and, in some browsers,
+ * leaving a broken SW stuck in control of the page — which made the whole app
+ * appear dead (no buttons worked) because every asset was served from a corrupt
+ * cache.
+ *
+ * This stub does the opposite of caching: on install it immediately takes over,
+ * deletes every cache, and unregisters itself. After one load the app runs with
+ * NO service worker at all — every file loads fresh from the server. Offline
+ * support is intentionally sacrificed to guarantee the app always loads.
+ */
+self.addEventListener('install', e => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', e => {
+  e.waitUntil((async () => {
+    try {
+      const keys = await caches.keys();
+      await Promise.all(keys.map(k => caches.delete(k)));
+    } catch (_) {}
+    try {
+      await self.clients.claim();
+      await self.registration.unregister();
+      const clients = await self.clients.matchAll();
+      clients.forEach(c => c.navigate(c.url));
+    } catch (_) {}
+  })());
+});
+
+// Never intercept fetches — always go to network.


### PR DESCRIPTION
## Why

The app had been living only in an ephemeral container working directory, where it was lost once already. This commits it as a single source of truth, together with the checks that verify it.

## Layout

| Path | What it is |
|---|---|
| `knowledgenode/www/` | The app. All three shipped builds derive from this. |
| `knowledgenode/android-native/` | Java helpers for the Capacitor Android wrapper |
| `knowledgenode/qa/` | 9 automated suites, 184 checks, run with `npm test` |
| `knowledgenode/README.md` | Build steps, cache-busting, design notes |

### One copy instead of three

The Android, plain-webpage and static-host builds were previously three hand-synced copies, which is how they drifted. They are byte-identical, so only `www/` is kept and `README.md` documents the commands that regenerate the other two. Those commands were verified to reproduce the shipped zips file-for-file.

### Tests now run from the repo

The suites previously hardcoded absolute `/tmp` paths and would not have run for anyone else. They now default to `../www`, overridable with `WWW=`:

```sh
cd knowledgenode/qa && npm install && npm test
```

Test dependencies (~27 MB) are gitignored rather than committed.

## Functional work included

**Interactive matching questions.** Lettered multiple-choice options are parsed out of question text into tappable choices, and a full match-and-pair set is reassembled from its individual imported items into one interactive two-column table (Column A items against a Column B answer bank). Every pair is graded on-device, so drilling these costs no AI credits.

**Study coach memory.** The coach was re-asking for information it had already been given. Three causes, all fixed:

- only the last four messages reached the model — the window is now bounded by characters rather than a fixed four turns
- no durable record was kept of what the student stated — stated facts are now stored keyed on-device and replayed into every turn, so they cannot roll off, and corrections replace values rather than accumulating
- the conversation was never persisted — it now survives a restart

Failed API calls are also no longer fed back as conversation context.

## Verification

All 9 suites pass from the committed location, on both the Android and webpage builds:

```
PASS  boot-smoke-check.js               ALL 28 checks passed
PASS  coach-memory-check.js             ALL 28 checks passed
PASS  exam-selection-check.js           ALL 14 checks passed
PASS  grader-numbers-check.js           ALL 19 checks passed
PASS  leech-intervention-check.js       ALL 23 checks passed
PASS  match-group-check.js              ALL 16 checks passed
PASS  match-group-integration-check.js  ALL 18 checks passed
PASS  match-integration-check.js        ALL 11 checks passed
PASS  match-options-check.js            ALL 27 checks passed

All 9 suites passed (184 checks)
```

`boot-smoke-check` loads every script tag in a headless DOM exactly as a browser does, so any parse or start-up breakage in any file surfaces there.

Behaviour verified in a headless DOM rather than on a physical device: the matching table renders, pairs on tap, preserves answers across navigation, and marks with zero network calls. Visual appearance on a real phone has not been confirmed.

## Note on scope

This is the `github-slideshow` Jekyll tutorial repo. The app sits in a `knowledgenode/` subfolder so it does not collide with the Jekyll site at the repo root. A dedicated repository would be a better long-term home for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJKcLGisb1yVDAHy6Lgy2T

---
_Generated by [Claude Code](https://claude.ai/code/session_01YJKcLGisb1yVDAHy6Lgy2T)_